### PR TITLE
Benchmark PDU loop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ target_steps: &target_steps
 
     - run: rustup target add $TARGET || true
     - run: cargo test --target $TARGET
+    - run: cargo bench --no-run --target $TARGET
     - run: cargo build --target $TARGET --examples --release
     - run:
         MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation" cargo miri test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ An EtherCAT master written in Rust.
   }
   ```
 
+- **(breaking)** [#TODO] Changed `pdu_rx` to `receive_frame` to mirror `send_frames_blocking`.
+
 ### Added
 
 - [#1] Added `SlaveGroup::len` and `SlaveGroup::is_empty` methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ An EtherCAT master written in Rust.
   }
   ```
 
-- **(breaking)** [#TODO] Changed `pdu_rx` to `receive_frame` to mirror `send_frames_blocking`.
+- **(breaking)** [#25] Changed `pdu_rx` to `receive_frame` to mirror `send_frames_blocking`.
 
 ### Added
 
@@ -77,5 +77,6 @@ An EtherCAT master written in Rust.
 [#16]: https://github.com/ethercrab-rs/ethercrab/pull/16
 [#23]: https://github.com/ethercrab-rs/ethercrab/pull/23
 [#20]: https://github.com/ethercrab-rs/ethercrab/pull/20
+[#25]: https://github.com/ethercrab-rs/ethercrab/pull/25
 [unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ spin = { version = "0.9.4", default-features = false, features = ["rwlock"] }
 async-ctrlc = "1.2.0"
 async-io = "1.9.0"
 chrono = "0.4.22"
+criterion = { version = "0.4.0", features = ["html_reports"] }
 ctrlc = "3.2.3"
 env_logger = "0.9.1"
 futures-lite = { version = "1.12.0", default-features = false }
@@ -68,3 +69,7 @@ required-features = ["std"]
 [[example]]
 name = "multiple-groups"
 required-features = ["std"]
+
+[[bench]]
+name = "pdu_loop"
+harness = false

--- a/benches/pdu_loop.rs
+++ b/benches/pdu_loop.rs
@@ -1,0 +1,74 @@
+use core::task::Poll;
+use criterion::{criterion_group, criterion_main, Bencher, Criterion, Throughput};
+use ethercrab::{internals::Command, PduStorage};
+
+const DATA: [u8; 8] = [0x11u8, 0x22, 0x33, 0x44, 0xaa, 0xbb, 0xcc, 0xdd];
+
+fn do_bench(b: &mut Bencher) {
+    const FRAME_OVERHEAD: usize = 28;
+
+    // 1 frame, up to 128 bytes payload
+    let storage = PduStorage::<1, 128>::new();
+
+    let (tx, rx, pdu_loop) = storage.try_split().unwrap();
+
+    let mut packet_buf = [0u8; 1536];
+    let mut written_packet = Vec::new();
+    written_packet.resize(FRAME_OVERHEAD + DATA.len(), 0);
+
+    b.iter(|| {
+        //  --- Prepare frame
+
+        let frame_fut = futures_lite::future::poll_once(pdu_loop.pdu_tx_readwrite(
+            Command::Fpwr {
+                address: 0x5678,
+                register: 0x1234,
+            },
+            &DATA,
+        ));
+
+        let _ = smol::block_on(frame_fut);
+
+        // --- Send frame
+
+        let send_fut = futures_lite::future::poll_once(core::future::poll_fn::<(), _>(|ctx| {
+            tx.send_frames_blocking(ctx.waker(), |frame| {
+                let packet = frame
+                    .write_ethernet_packet(&mut packet_buf)
+                    .expect("Write Ethernet frame");
+
+                written_packet.copy_from_slice(packet);
+
+                Ok(())
+            })
+            .unwrap();
+
+            Poll::Ready(())
+        }));
+
+        let _ = smol::block_on(send_fut);
+
+        assert_eq!(written_packet.len(), FRAME_OVERHEAD + DATA.len());
+
+        // --- Receive frame
+
+        let _ = rx.receive_frame(&written_packet);
+    })
+}
+
+pub fn tx_rx(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pdu-loop");
+
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("elements", do_bench);
+
+    group.throughput(Throughput::Bytes(DATA.len() as u64));
+
+    group.bench_function("payload bytes", do_bench);
+
+    group.finish();
+}
+
+criterion_group!(pdu_loop, tx_rx);
+criterion_main!(pdu_loop);

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,11 +1,14 @@
 use cookie_factory::{gen_simple, GenError};
 use nom::{combinator::map, error::ParseError, sequence::pair, IResult};
 
+/// PDU command.
 #[derive(Default, PartialEq, Eq, Debug, Copy, Clone)]
 pub enum Command {
+    /// No operation.
     #[default]
     Nop,
 
+    /// APRD.
     Aprd {
         /// Auto increment counter.
         address: u16,
@@ -13,6 +16,7 @@ pub enum Command {
         /// Memory location to read from.
         register: u16,
     },
+    /// FPRD.
     Fprd {
         /// Configured station address.
         address: u16,
@@ -20,6 +24,7 @@ pub enum Command {
         /// Memory location to read from.
         register: u16,
     },
+    /// BRD.
     Brd {
         /// Autoincremented by each slave visited.
         address: u16,
@@ -27,11 +32,13 @@ pub enum Command {
         /// Memory location to read from.
         register: u16,
     },
+    /// LRD.
     Lrd {
         /// Logical address.
         address: u32,
     },
 
+    /// BWR.
     Bwr {
         /// Autoincremented by each slave visited.
         address: u16,
@@ -39,6 +46,7 @@ pub enum Command {
         /// Memory location to write to.
         register: u16,
     },
+    /// APWR.
     Apwr {
         /// Auto increment counter.
         address: u16,
@@ -46,6 +54,7 @@ pub enum Command {
         /// Memory location to write to.
         register: u16,
     },
+    /// FPWR.
     Fpwr {
         /// Configured station address.
         address: u16,
@@ -53,6 +62,7 @@ pub enum Command {
         /// Memory location to read from.
         register: u16,
     },
+    /// FRMW.
     Frmw {
         /// Configured station address.
         address: u16,
@@ -60,11 +70,13 @@ pub enum Command {
         /// Memory location to read from.
         register: u16,
     },
+    /// LWR.
     Lwr {
         /// Logical address.
         address: u32,
     },
 
+    /// LRW.
     Lrw {
         /// Logical address.
         address: u32,
@@ -72,6 +84,7 @@ pub enum Command {
 }
 
 impl Command {
+    /// Get just the command code for a command.
     pub const fn code(&self) -> CommandCode {
         match self {
             Self::Nop => CommandCode::Nop,
@@ -94,6 +107,7 @@ impl Command {
         }
     }
 
+    /// Get the address value for the command.
     pub fn address(&self) -> Result<[u8; 4], GenError> {
         let mut arr = [0x00u8; 4];
 

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -1,0 +1,5 @@
+//! For integration testing or internal benchmarking use only.
+//!
+//! DO NOT USE.
+
+pub use crate::command::Command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,9 @@ mod sync_manager_channel;
 mod timer_factory;
 mod vendors;
 
+#[doc(hidden)]
+pub mod internals;
+
 #[cfg(feature = "std")]
 pub mod std;
 

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -240,6 +240,8 @@ mod tests {
     }
 
     #[test]
+    // MIRI fails this test with `unsupported operation: can't execute syscall with ID 291`.
+    #[cfg_attr(miri, ignore)]
     fn single_frame_round_trip() {
         const FRAME_OVERHEAD: usize = 28;
 

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -377,7 +377,7 @@ mod tests {
                     frame.into_inner()
                 };
 
-                rx.pdu_rx(&ethernet_frame).expect("RX");
+                rx.receive_frame(&ethernet_frame).expect("RX");
             }
         });
 

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -28,7 +28,7 @@ impl<'sto> PduRx<'sto> {
     }
 
     /// Parse a PDU from a complete Ethernet II frame.
-    pub fn pdu_rx(&self, ethernet_frame: &[u8]) -> Result<(), Error> {
+    pub fn receive_frame(&self, ethernet_frame: &[u8]) -> Result<(), Error> {
         let raw_packet = EthernetFrame::new_checked(ethernet_frame)?;
 
         // Look for EtherCAT packets whilst ignoring broadcast packets sent from self. As per

--- a/src/std.rs
+++ b/src/std.rs
@@ -102,7 +102,7 @@ pub fn tx_rx_task(
                     };
 
                     pdu_rx
-                        .pdu_rx(&frame_buf)
+                        .receive_frame(&frame_buf)
                         .map_err(|e| {
                             dbg!(frame_buf.len());
 


### PR DESCRIPTION
This is the most pure/basic possible benchmark of the PDU loop. It:

1. Prepares a `FPWR` frame with 8 bytes of payload data (32 bytes total) and marks it as sendable
2. Writes an Ethernet II packet containing the EtherCAT frame into a buffer
3. Passes the buffer to `receive_frame` which parses the data back out of the buffer

This test doesn't include any networking (not even loopback) because I'm on Windows so it's more a theoretical benchmark to check for regressions in the code than a real-world representation. On my Windows 11 (🤮) Ryzen 9 5950X system I get:

```
pdu-loop/elements       time:   [256.58 ns 257.65 ns 259.05 ns]
                        thrpt:  [3.8603 Melem/s 3.8812 Melem/s 3.8974 Melem/s]

pdu-loop/payload bytes  time:   [259.66 ns 261.35 ns 263.59 ns]
                        thrpt:  [28.944 MiB/s 29.193 MiB/s 29.382 MiB/s]
```

3.8m full frames/sec or 29MiB/sec EtherCAT payload of 8 bytes. I'm sure we can do better but this is a decent starting baseline.

I'll add a Linux benchmark when my test rig arrives which can involve sending traffic over the loopback interface for a more representative sample of the performance.