### PR TITLE
Add workarounds so EtherCrab works on stable Rust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 target_steps: &target_steps
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.67.0
+    - image: cimg/rust:1.68.0
   steps:
     - checkout
     - run: sudo apt update && sudo apt install -y libpcap-dev
@@ -19,9 +19,6 @@ target_steps: &target_steps
     - run: cargo test --target $TARGET
     - run: cargo bench --no-run --target $TARGET
     - run: cargo build --target $TARGET --examples --release
-    - run:
-        MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation" cargo miri test
-        --target $TARGET --release
     - run: cargo deadlinks --ignore-fragments
 
     - save_cache:
@@ -31,10 +28,33 @@ target_steps: &target_steps
           - /home/circleci/.cargo/registry
           - /home/circleci/.cargo/bin
 
+miri_steps: &miri_steps
+  docker:
+    # NOTE: Exact version is overridden in `rust-toolchain.toml`
+    - image: cimg/rust:1.68.0
+  steps:
+    - checkout
+    - run: sudo apt update && sudo apt install -y libpcap-dev
+    - restore_cache:
+        key: v4-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+
+    # Arbitrary nightly version - just the latest at time of writing. This can be changed freely.
+    - run: rustup toolchain add nightly-2023-03-16 --target $TARGET --component miri
+    - run: |
+        export MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation"
+
+        cargo +nightly-2023-03-16 miri test --target $TARGET --release
+
+    - save_cache:
+        key: v4-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+        paths:
+          - ./target
+          - /home/circleci/.cargo/registry
+
 target_steps_no_test: &target_steps_no_test
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.67.0
+    - image: cimg/rust:1.68.0
   steps:
     - checkout
     - run: sudo apt update && sudo apt install -y libpcap-dev
@@ -50,7 +70,6 @@ target_steps_no_test: &target_steps_no_test
         paths:
           - ./target
           - /home/circleci/.cargo/registry
-          - /home/circleci/.cargo/bin
 
 version: 2
 jobs:
@@ -59,6 +78,12 @@ jobs:
     environment:
       - TARGET: "x86_64-unknown-linux-gnu"
     <<: *target_steps
+
+  miri-x86_64-unknown-linux-gnu:
+    resource_class: large
+    environment:
+      - TARGET: "x86_64-unknown-linux-gnu"
+    <<: *miri_steps
   # TODO: Re-enable when we can remove `Box` from the slave group preop hook fn
   # target-thumbv7m-none-eabi:
   #   resource_class: large
@@ -69,6 +94,7 @@ jobs:
 build_jobs: &build_jobs
   jobs:
     - target-x86_64-unknown-linux-gnu
+    - miri-x86_64-unknown-linux-gnu
     # - target-thumbv7m-none-eabi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ target_steps: &target_steps
     - checkout
     - run: sudo apt update && sudo apt install -y libpcap-dev
     - restore_cache:
-        key: v4-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+        key: v5-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
 
     # For docs gen
     - run: rustup target add x86_64-unknown-linux-gnu || true
@@ -22,7 +22,7 @@ target_steps: &target_steps
     - run: cargo deadlinks --ignore-fragments
 
     - save_cache:
-        key: v4-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+        key: v5-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
         paths:
           - ./target
           - /home/circleci/.cargo/registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ An EtherCAT master written in Rust.
 
 ### Fixed
 
+- [#26] :tada: EtherCrab now works on stable Rust. The MSRV is 1.68.
 - [#23] Strip trailing null bytes (`\0`) in strings read from SII
 - [#14] Fixed various overflow/arithmetic bugs in distributed clock time calculations and PDI
   configuration
@@ -78,5 +79,6 @@ An EtherCAT master written in Rust.
 [#23]: https://github.com/ethercrab-rs/ethercrab/pull/23
 [#20]: https://github.com/ethercrab-rs/ethercrab/pull/20
 [#25]: https://github.com/ethercrab-rs/ethercrab/pull/25
+[#26]: https://github.com/ethercrab-rs/ethercrab/pull/26
 [unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ An EtherCAT master written in pure Rust.
 
 ## MSRV
 
-Unfortunately, nightly Rust is currently required.
-
-The MSRV for EtherCrab can be found in `rust-toolchain.toml`.
+The current MSRV for EtherCrab is 1.68.
 
 ## Example
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "nightly-2022-12-20"
+channel = "1.68"
 profile = "default"
-components = [ "miri" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,6 @@
 //! ```
 
 #![feature(const_maybe_uninit_zeroed)]
-#![feature(pin_macro)]
 #![feature(pointer_byte_offsets)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,6 @@
 //! }
 //! ```
 
-#![feature(pointer_byte_offsets)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![deny(missing_copy_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@
 //!
 //! Breaking changes may be made at any time.
 //!
+//! # MSRV
+//!
+//! The current MSRV for EtherCrab is 1.68.
+//!
 //! # Examples
 //!
 //! This example increments the output bytes of all detected slaves every tick. It is tested on an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,6 @@
 //! }
 //! ```
 
-#![feature(const_maybe_uninit_zeroed)]
 #![feature(pointer_byte_offsets)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]

--- a/src/pdu_loop/storage.rs
+++ b/src/pdu_loop/storage.rs
@@ -187,8 +187,10 @@ impl<'sto> PduStorageRef<'sto> {
             .pad_to_align()
             .size();
 
-        // NIGHTLY: pointer_byte_offsets
-        self.frames.as_ptr().byte_add(idx * stride)
+        // MSRV: When `pointer_byte_offsets` is stabilised, use `self.frames.as_ptr().byte_add(idx *
+        // stride)`. This code is a rip from the core lib function so should do pretty much the same
+        // thing.
+        self.frames.as_ptr().cast::<u8>().add(idx * stride).cast()
     }
 }
 


### PR DESCRIPTION
We're nightly free!

MSRV is 1.68 to use `core::pin::pin!`