### PR TITLE
Fix abort code parsing

### DIFF
--- a/examples/ec400.rs
+++ b/examples/ec400.rs
@@ -81,7 +81,7 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
                 // Control word, u16
                 // NOTE: The lower word specifies the field length
                 slave
-                    .write_sdo(0x1600, SubIndex::Index(1), 0x6040u16)
+                    .write_sdo(0x1600, SubIndex::Index(1), 0x6040_0010u32)
                     .await?;
                 // Target velocity, i32
                 slave

--- a/examples/ec400.rs
+++ b/examples/ec400.rs
@@ -81,7 +81,7 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
                 // Control word, u16
                 // NOTE: The lower word specifies the field length
                 slave
-                    .write_sdo(0x1600, SubIndex::Index(1), 0x6040_0010u32)
+                    .write_sdo(0x1600, SubIndex::Index(1), 0x6040u16)
                     .await?;
                 // Target velocity, i32
                 slave

--- a/src/coe/abort_code.rs
+++ b/src/coe/abort_code.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 /// Defined in ETG1000.6 Table 41 – SDO Abort Codes
-#[derive(Debug, Copy, Clone, PartialEq, Eq, num_enum::TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, num_enum::FromPrimitive)]
 #[repr(u32)]
 pub enum AbortCode {
     /// Toggle bit not changed
@@ -77,6 +77,10 @@ pub enum AbortCode {
 
     /// Object dictionary dynamic generation fails or no object dictionary is present
     NoObjectDictionary = 0x08000023,
+
+    /// Unknown abort code.
+    #[num_enum(catch_all)]
+    Unknown(u32),
 }
 
 impl fmt::Display for AbortCode {
@@ -112,6 +116,23 @@ impl fmt::Display for AbortCode {
             Self::TransferFailedLocal => f.write_str("0x08000021: Data cannot be transferred or stored to the application because of local control"),
             Self::InvalidState => f.write_str("0x08000022:  Data cannot be transferred or stored to the application because of the present device state"),
             Self::NoObjectDictionary => f.write_str("0x08000023: Object dictionary dynamic generation fails or no object dictionary is present"),
+            Self::Unknown(code) => write!(f, "{:#010x}: Unknown code", code),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_code() {
+        let code = 0x1234_5678u32;
+
+        let decoded = AbortCode::from(code);
+
+        assert_eq!(decoded, AbortCode::Unknown(0x1234_5678u32));
+
+        assert_eq!(decoded.to_string(), "0x12345678: Unknown code");
     }
 }

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -506,11 +506,12 @@ impl<'a> SlaveRef<'a> {
         if headers.is_aborted() {
             let code = data[0..4]
                 .try_into()
-                .map_err(|_| ())
-                .and_then(|arr| {
-                    AbortCode::try_from_primitive(u32::from_le_bytes(arr)).map_err(|_| ())
-                })
-                .unwrap_or(AbortCode::General);
+                .map(|arr| AbortCode::from(u32::from_le_bytes(arr)))
+                .map_err(|_| {
+                    log::error!("Not enough data to decode abort code u32");
+
+                    Error::Internal
+                })?;
 
             Err(Error::Mailbox(MailboxError::Aborted {
                 code,


### PR DESCRIPTION
Abort codes would fail to parse when an expedited download was aborted. The return type would steal the abort code bytes as its payload, leaving the `AbortCode` parsing with zeroes. This is fixed now.

Abort codes can now never fail to parse. Instead, an unknown abort code will be parsed as `AbortCode::Unknown(u32)` and displayed like `0x12345678: Unknown code`

Closes #27 