### PR TITLE
Support configuring DC sync iterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ An EtherCAT master written in Rust.
 
 - **(breaking)** [#25] Changed `pdu_rx` to `receive_frame` to mirror `send_frames_blocking`.
 - **(breaking)** [#30] Removed `PduError::Encode` variant.
+- **(breaking)** [#31] Added a `ClientConfig` argument to `Client::new` to allow configuration of
+  various EtherCrab behaviours.
 
 ### Added
 
@@ -88,5 +90,6 @@ An EtherCAT master written in Rust.
 [#28]: https://github.com/ethercrab-rs/ethercrab/pull/28
 [#29]: https://github.com/ethercrab-rs/ethercrab/pull/29
 [#30]: https://github.com/ethercrab-rs/ethercrab/pull/30
+[#31]: https://github.com/ethercrab-rs/ethercrab/pull/31
 [unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,19 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#30] Added `Copy`, `Clone`, `PartialEq` and `Eq` implementations to `Error` and `PduError`.
+- [#1] Added `SlaveGroup::len` and `SlaveGroup::is_empty` methods.
+- [#29] Implement `Display` for `Error`, `PduError`, `MailboxError`, `EepromError`,
+  `VisibleStringError` and `PduValidationError`
+- **(breaking)** [#31] Added a `ClientConfig` argument to `Client::new` to allow configuration of
+  various EtherCrab behaviours.
+
 ### Changed
 
-- **(breaking)** [#1] `SlaveGroup::slaves` now returns an iterator over each slave with IO in the
-  group, instead of a plain slave.
-- **(breaking)** [#2] Rename `slave_group::Configurator` to `SlaveGroupRef`.
-- **(breaking)** [#9] Rename the fields of some variants in `ethercrab::error::Error` to make them
-  less confusing.
-- **(breaking)** [#16] Remove `TIMER`/`TIMEOUT` generic parameter. `std` environments will now use
-  the timer provided by `smol` (`async-io`). `no_std` environments will use `embassy-time`.
+- **(breaking)** [#30] Removed `PduError::Encode` variant.
+- **(breaking)** [#25] Changed `pdu_rx` to `receive_frame` to mirror `send_frames_blocking`.
 - **(breaking)** [#20] Changed the way the client, tx and rx instances are initialised to only allow
   one TX and RX to exist.
 
@@ -45,17 +49,13 @@ An EtherCAT master written in Rust.
   }
   ```
 
-- **(breaking)** [#25] Changed `pdu_rx` to `receive_frame` to mirror `send_frames_blocking`.
-- **(breaking)** [#30] Removed `PduError::Encode` variant.
-- **(breaking)** [#31] Added a `ClientConfig` argument to `Client::new` to allow configuration of
-  various EtherCrab behaviours.
-
-### Added
-
-- [#30] Added `Copy`, `Clone`, `PartialEq` and `Eq` implementations to `Error` and `PduError`.
-- [#1] Added `SlaveGroup::len` and `SlaveGroup::is_empty` methods.
-- [#29] Implement `Display` for `Error`, `PduError`, `MailboxError`, `EepromError`,
-  `VisibleStringError` and `PduValidationError`
+- **(breaking)** [#16] Remove `TIMER`/`TIMEOUT` generic parameter. `std` environments will now use
+  the timer provided by `smol` (`async-io`). `no_std` environments will use `embassy-time`.
+- **(breaking)** [#9] Rename the fields of some variants in `ethercrab::error::Error` to make them
+  less confusing.
+- **(breaking)** [#2] Rename `slave_group::Configurator` to `SlaveGroupRef`.
+- **(breaking)** [#1] `SlaveGroup::slaves` now returns an iterator over each slave with IO in the
+  group, instead of a plain slave.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ use async_ctrlc::CtrlC;
 use async_io::Timer;
 use ethercrab::{
     error::Error, std::tx_rx_task, Client, PduLoop, PduStorage, SlaveGroup, SubIndex, Timeouts,
+    ClientConfig
 };
 use futures_lite::{FutureExt, StreamExt};
 use smol::LocalExecutor;
@@ -65,7 +66,7 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
 
     let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
 
-    let client = Arc::new(Client::new(pdu_loop, Timeouts::default()));
+    let client = Arc::new(Client::new(pdu_loop, Timeouts::default(), ClientConfig::default()));
 
     ex.spawn(tx_rx_task(&interface, tx, rx).unwrap()).detach();
 

--- a/examples/akd.rs
+++ b/examples/akd.rs
@@ -5,7 +5,7 @@ use async_io::Timer;
 use ethercrab::{
     error::{Error, MailboxError},
     std::tx_rx_task,
-    Client, PduStorage, SlaveGroup, SlaveState, SubIndex, Timeouts,
+    Client, ClientConfig, PduStorage, SlaveGroup, SlaveState, SubIndex, Timeouts,
 };
 use futures_lite::{FutureExt, StreamExt};
 use smol::LocalExecutor;
@@ -35,7 +35,11 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
 
     let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
 
-    let client = Arc::new(Client::new(pdu_loop, Timeouts::default()));
+    let client = Arc::new(Client::new(
+        pdu_loop,
+        Timeouts::default(),
+        ClientConfig::default(),
+    ));
 
     ex.spawn(tx_rx_task(INTERFACE, tx, rx).unwrap()).detach();
 

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -3,8 +3,8 @@
 use async_ctrlc::CtrlC;
 use async_io::Timer;
 use ethercrab::{
-    error::Error, std::tx_rx_task, Client, PduStorage, RegisterAddress, SlaveGroup, SubIndex,
-    Timeouts,
+    error::Error, std::tx_rx_task, Client, ClientConfig, PduStorage, RegisterAddress, SlaveGroup,
+    SubIndex, Timeouts,
 };
 use futures_lite::{FutureExt, StreamExt};
 use smol::LocalExecutor;
@@ -41,6 +41,7 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
             mailbox_response: Duration::from_millis(1000),
             ..Default::default()
         },
+        ClientConfig::default(),
     ));
 
     ex.spawn(tx_rx_task(INTERFACE, tx, rx).unwrap()).detach();

--- a/examples/ec400.rs
+++ b/examples/ec400.rs
@@ -5,7 +5,7 @@ use ethercrab::{
     ds402::{Ds402, Ds402Sm},
     error::Error,
     std::tx_rx_task,
-    Client, PduStorage, SlaveGroup, SlaveState, SubIndex, Timeouts,
+    Client, ClientConfig, PduStorage, SlaveGroup, SlaveState, SubIndex, Timeouts,
 };
 use futures_lite::StreamExt;
 use smol::LocalExecutor;
@@ -41,7 +41,11 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
 
     let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
 
-    let client = Arc::new(Client::new(pdu_loop, Timeouts::default()));
+    let client = Arc::new(Client::new(
+        pdu_loop,
+        Timeouts::default(),
+        ClientConfig::default(),
+    ));
 
     ex.spawn(tx_rx_task(INTERFACE, tx, rx).unwrap()).detach();
 

--- a/examples/ek1100.rs
+++ b/examples/ek1100.rs
@@ -17,7 +17,7 @@
 use async_ctrlc::CtrlC;
 use async_io::Timer;
 use ethercrab::{
-    error::Error, std::tx_rx_task, Client, PduStorage, SlaveGroup, SubIndex, Timeouts,
+    error::Error, std::tx_rx_task, Client, ClientConfig, PduStorage, SlaveGroup, SubIndex, Timeouts,
 };
 use futures_lite::{FutureExt, StreamExt};
 use smol::LocalExecutor;
@@ -51,6 +51,7 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
             mailbox_response: Duration::from_millis(1000),
             ..Default::default()
         },
+        ClientConfig::default(),
     ));
 
     ex.spawn(tx_rx_task(&interface, tx, rx).unwrap()).detach();

--- a/examples/multiple-groups.rs
+++ b/examples/multiple-groups.rs
@@ -9,8 +9,8 @@
 use async_ctrlc::CtrlC;
 use async_io::Timer;
 use ethercrab::{
-    error::Error, std::tx_rx_task, Client, PduStorage, SlaveGroup, SlaveGroupContainer,
-    SlaveGroupRef, Timeouts,
+    error::Error, std::tx_rx_task, Client, ClientConfig, PduStorage, SlaveGroup,
+    SlaveGroupContainer, SlaveGroupRef, Timeouts,
 };
 use futures_lite::{FutureExt, StreamExt};
 use smol::LocalExecutor;
@@ -68,6 +68,7 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
             mailbox_response: Duration::from_millis(1000),
             ..Default::default()
         },
+        ClientConfig::default(),
     ));
 
     ex.spawn(tx_rx_task(&interface, tx, rx).unwrap()).detach();

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -1,0 +1,21 @@
+//! Configuration passed to [`Client`].
+
+/// Configuration passed to [`Client`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ClientConfig {
+    /// The number of `FRMW` packets to send during the static phase of Distributed Clocks (DC)
+    /// synchronisation.
+    ///
+    /// Defaults to 10000.
+    ///
+    /// If this is set to zero, no static sync will be performed.
+    pub(crate) dc_static_sync_iterations: u32,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            dc_static_sync_iterations: 10_000,
+        }
+    }
+}

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -1,6 +1,6 @@
-//! Configuration passed to [`Client`].
+//! Configuration passed to [`Client`](crate::Client).
 
-/// Configuration passed to [`Client`].
+/// Configuration passed to [`Client`](crate::Client).
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ClientConfig {
     /// The number of `FRMW` packets to send during the static phase of Distributed Clocks (DC)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@
 //! use async_ctrlc::CtrlC;
 //! use async_io::Timer;
 //! use ethercrab::{
-//!     error::Error, std::tx_rx_task, Client, PduLoop, PduStorage, SlaveGroup, SubIndex, Timeouts
+//!     error::Error, std::tx_rx_task, Client, PduLoop, PduStorage, SlaveGroup, SubIndex, Timeouts,
+//!     ClientConfig
 //! };
 //! use futures_lite::{FutureExt, StreamExt};
 //! use smol::LocalExecutor;
@@ -62,7 +63,7 @@
 //!
 //!     let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
 //!
-//!     let client = Arc::new(Client::new(pdu_loop, Timeouts::default()));
+//!     let client = Arc::new(Client::new(pdu_loop, Timeouts::default(), ClientConfig::default()));
 //!
 //!     ex.spawn(tx_rx_task(&interface, tx, rx).unwrap()).detach();
 //!
@@ -166,6 +167,7 @@ mod al_control;
 mod al_status_code;
 mod base_data_types;
 mod client;
+mod client_config;
 mod coe;
 mod command;
 mod dc;
@@ -197,6 +199,7 @@ use nom::IResult;
 use smoltcp::wire::{EthernetAddress, EthernetProtocol};
 
 pub use client::Client;
+pub use client_config::ClientConfig;
 pub use coe::SubIndex;
 pub use pdu_loop::{PduLoop, PduRx, PduStorage, PduTx, SendableFrame};
 pub use register::RegisterAddress;


### PR DESCRIPTION
Adds a `ClientConfig` field to `Client::new()` to allow configuration of various behaviours. Currently only supports DC static sync iteration count.

Closes #15