### PR TITLE
Clean up examples and migrate them to `tokio`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,8 @@ pnet = { version = "0.31.0", features = ["std"], optional = true }
 
 [target."cfg(unix)".dependencies]
 libc = "0.2.134"
-nix = { version = "0.26.2", default-features = false, features = ["sched", "process"] }
 
 [dev-dependencies]
-async-ctrlc = "1.2.0"
 criterion = { version = "0.4.0", features = ["html_reports"] }
 ctrlc = "3.2.3"
 env_logger = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ pnet = { version = "0.31.0", features = ["std"], optional = true }
 
 [target."cfg(unix)".dependencies]
 libc = "0.2.134"
+nix = { version = "0.26.2", default-features = false, features = ["sched", "process"] }
 
 [dev-dependencies]
 async-ctrlc = "1.2.0"
@@ -42,7 +43,7 @@ criterion = { version = "0.4.0", features = ["html_reports"] }
 ctrlc = "3.2.3"
 env_logger = "0.10.0"
 futures-lite = { version = "1.12.0", default-features = false }
-tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "sync"] }
+tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "sync", "time"] }
 
 [features]
 default = ["std"]

--- a/examples/ek1100.rs
+++ b/examples/ek1100.rs
@@ -110,14 +110,11 @@ async fn main() -> Result<(), Error> {
     let mut tick_interval = tokio::time::interval(Duration::from_millis(5));
     tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-    let group = Arc::new(group);
-    let group2 = group.clone();
-
     loop {
         group.tx_rx(&client).await.expect("TX/RX");
 
         // Increment every output byte for every slave device by one
-        for slave in group2.slaves() {
+        for slave in group.slaves() {
             let (_i, o) = slave.io();
 
             for byte in o.iter_mut() {

--- a/examples/ek1100.rs
+++ b/examples/ek1100.rs
@@ -14,14 +14,12 @@
 //! $env:RUST_LOG="debug" ; cargo run --example ek1100 --release -- '\Device\NPF_{FF0ACEE6-E8CD-48D5-A399-619CD2340465}'
 //! ```
 
-use async_ctrlc::CtrlC;
+use env_logger::Env;
 use ethercrab::{
     error::Error, std::tx_rx_task, Client, ClientConfig, PduStorage, SlaveGroup, SubIndex, Timeouts,
 };
-use futures_lite::{FutureExt, StreamExt};
-use smol::LocalExecutor;
-use smol::Timer;
 use std::{sync::Arc, time::Duration};
+use tokio::time::MissedTickBehavior;
 
 /// Maximum number of slaves that can be stored.
 const MAX_SLAVES: usize = 16;
@@ -34,13 +32,17 @@ const PDI_LEN: usize = 64;
 
 static PDU_STORAGE: PduStorage<MAX_FRAMES, MAX_PDU_DATA> = PduStorage::new();
 
-async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
     let interface = std::env::args()
         .nth(1)
-        .expect("Provide interface as first argument");
+        .expect("Provide interface as first argument. Pass an unrecognised name to list available interfaces.");
 
     log::info!("Starting EK1100 demo...");
     log::info!("Ensure an EK1100 is the first slave, with any number of modules connected after");
+    log::info!("Run with RUST_LOG=ethercrab=debug or =trace for debug information");
 
     let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
 
@@ -54,12 +56,12 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
         ClientConfig::default(),
     ));
 
-    ex.spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task"))
-        .detach();
+    tokio::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task"));
 
     let group = SlaveGroup::<MAX_SLAVES, PDI_LEN>::new(|slave| {
         Box::pin(async {
-            // EL3004 needs some specific config during init to function properly
+            // Special case: if an EL3004 module is discovered, it needs some specific config during
+            // init to function properly
             if slave.name() == "EL3004" {
                 log::info!("Found EL3004. Configuring...");
 
@@ -91,7 +93,7 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
         .await
         .expect("Init");
 
-    log::info!("Group has {} slaves", group.len());
+    log::info!("Discovered {} slaves", group.len());
 
     for slave in group.slaves() {
         let (i, o) = slave.io();
@@ -105,12 +107,13 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
         );
     }
 
-    let mut tick_interval = Timer::interval(Duration::from_millis(5));
+    let mut tick_interval = tokio::time::interval(Duration::from_millis(5));
+    tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     let group = Arc::new(group);
     let group2 = group.clone();
 
-    while let Some(_) = tick_interval.next().await {
+    loop {
         group.tx_rx(&client).await.expect("TX/RX");
 
         // Increment every output byte for every slave device by one
@@ -121,20 +124,7 @@ async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
                 *byte = byte.wrapping_add(1);
             }
         }
+
+        tick_interval.tick().await;
     }
-
-    Ok(())
-}
-
-fn main() -> Result<(), Error> {
-    env_logger::init();
-    let local_ex = LocalExecutor::new();
-
-    let ctrlc = CtrlC::new().expect("cannot create Ctrl+C handler?");
-
-    futures_lite::future::block_on(
-        local_ex.run(ctrlc.race(async { main_inner(&local_ex).await.unwrap() })),
-    );
-
-    Ok(())
 }

--- a/src/ds402.rs
+++ b/src/ds402.rs
@@ -207,6 +207,8 @@ impl<'a> Ds402Sm<'a> {
     }
 
     /// Put the slave into "switch on disabled" state. Returns true when finished.
+    // TODO: Some sort of typestate API to transition between higher level states so we can't do
+    // this during normal op
     pub fn tick_shutdown(&mut self) -> bool {
         let status = self.sm.context().status_word();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,15 +32,12 @@
 //! ```
 //!
 //! ```rust,no_run
-//! use async_ctrlc::CtrlC;
+//! use env_logger::Env;
 //! use ethercrab::{
-//!     error::Error, std::tx_rx_task, Client, PduLoop, PduStorage, SlaveGroup, SubIndex, Timeouts,
-//!     ClientConfig
+//!     error::Error, std::tx_rx_task, Client, ClientConfig, PduStorage, SlaveGroup, SubIndex, Timeouts,
 //! };
-//! use futures_lite::{FutureExt, StreamExt};
-//! use smol::Timer;
-//! use smol::LocalExecutor;
 //! use std::{sync::Arc, time::Duration};
+//! use tokio::time::MissedTickBehavior;
 //!
 //! /// Maximum number of slaves that can be stored.
 //! const MAX_SLAVES: usize = 16;
@@ -53,23 +50,36 @@
 //!
 //! static PDU_STORAGE: PduStorage<MAX_FRAMES, MAX_PDU_DATA> = PduStorage::new();
 //!
-//! async fn main_inner(ex: &LocalExecutor<'static>) -> Result<(), Error> {
+//! #[tokio::main]
+//! async fn main() -> Result<(), Error> {
+//!     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+//!
 //!     let interface = std::env::args()
 //!         .nth(1)
-//!         .expect("Provide interface as first argument");
+//!         .expect("Provide interface as first argument. Pass an unrecognised name to list available interfaces.");
 //!
 //!     log::info!("Starting EK1100 demo...");
 //!     log::info!("Ensure an EK1100 is the first slave, with any number of modules connected after");
+//!     log::info!("Run with RUST_LOG=ethercrab=debug or =trace for debug information");
 //!
 //!     let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
 //!
-//!     let client = Arc::new(Client::new(pdu_loop, Timeouts::default(), ClientConfig::default()));
+//!     let client = Arc::new(Client::new(
+//!         pdu_loop,
+//!         Timeouts {
+//!             wait_loop_delay: Duration::from_millis(2),
+//!             mailbox_response: Duration::from_millis(1000),
+//!             ..Default::default()
+//!         },
+//!         ClientConfig::default(),
+//!     ));
 //!
-//!     ex.spawn(tx_rx_task(&interface, tx, rx).unwrap()).detach();
+//!     tokio::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task"));
 //!
 //!     let group = SlaveGroup::<MAX_SLAVES, PDI_LEN>::new(|slave| {
 //!         Box::pin(async {
-//!             // EL3004 needs some specific config during init to function properly
+//!             // Special case: if an EL3004 module is discovered, it needs some specific config during
+//!             // init to function properly
 //!             if slave.name() == "EL3004" {
 //!                 log::info!("Found EL3004. Configuring...");
 //!
@@ -101,7 +111,7 @@
 //!         .await
 //!         .expect("Init");
 //!
-//!     log::info!("Group has {} slaves", group.len());
+//!     log::info!("Discovered {} slaves", group.len());
 //!
 //!     for slave in group.slaves() {
 //!         let (i, o) = slave.io();
@@ -115,38 +125,23 @@
 //!         );
 //!     }
 //!
-//!     let mut tick_interval = Timer::interval(Duration::from_millis(5));
+//!     let mut tick_interval = tokio::time::interval(Duration::from_millis(5));
+//!     tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 //!
-//!     let group = Arc::new(group);
-//!     let group2 = group.clone();
-//!
-//!     while let Some(_) = tick_interval.next().await {
+//!     loop {
 //!         group.tx_rx(&client).await.expect("TX/RX");
 //!
 //!         // Increment every output byte for every slave device by one
-//!         for slave in group2.slaves() {
+//!         for slave in group.slaves() {
 //!             let (_i, o) = slave.io();
 //!
 //!             for byte in o.iter_mut() {
 //!                 *byte = byte.wrapping_add(1);
 //!             }
 //!         }
+//!
+//!         tick_interval.tick().await;
 //!     }
-//!
-//!     Ok(())
-//! }
-//!
-//! fn main() -> Result<(), Error> {
-//!     env_logger::init();
-//!     let local_ex = LocalExecutor::new();
-//!
-//!     let ctrlc = CtrlC::new().expect("cannot create Ctrl+C handler?");
-//!
-//!     futures_lite::future::block_on(
-//!         local_ex.run(ctrlc.race(async { main_inner(&local_ex).await.unwrap() })),
-//!     );
-//!
-//!     Ok(())
 //! }
 //! ```
 


### PR DESCRIPTION
- Migrate to `tokio` so we can cleanly spawn the TX/RX task in (potentially) another thread
- Clean up a lot of the code and comments to hopefully make it easier to follow along

This makes the examples more reliable too. In my testing, I'm no longer seeing `TX/RX: Timeout` errors spring up due to moving the TX/RX task into a multi-threaded executor.