### PR TITLE
Refactor group initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ An EtherCAT master written in Rust.
 
 ### Changed
 
+- **(breaking)** [#39] Change group init closure to return `Result<SlaveGroupRef, Error>`
 - **(breaking)** [#32] To mitigate some internal issues, `PduStorage` now requires `N` (the number
   of storage elements) to be a power of two.
 - **(breaking)** [#33] `send_frames_blocking` is removed. It is replaced with
@@ -98,5 +99,6 @@ An EtherCAT master written in Rust.
 [#31]: https://github.com/ethercrab-rs/ethercrab/pull/31
 [#32]: https://github.com/ethercrab-rs/ethercrab/pull/32
 [#33]: https://github.com/ethercrab-rs/ethercrab/pull/33
+[#39]: https://github.com/ethercrab-rs/ethercrab/pull/39
 [unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Error> {
 
     let group = client
         // Initialise up to 16 slave devices
-        .init::<MAX_SLAVES, _>(group, |groups, slave| groups.push(slave))
+        .init::<16, _>(group, |groups, _slave| Ok(groups.as_mut()))
         .await
         .expect("Init");
 

--- a/examples/akd.rs
+++ b/examples/akd.rs
@@ -125,7 +125,7 @@ async fn main() -> Result<(), Error> {
     });
 
     let group = client
-        .init::<16, _>(groups, |groups, slave| groups.push(slave))
+        .init::<16, _>(groups, |groups, _slave| Ok(groups.as_mut()))
         .await
         .expect("Init");
 

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Error> {
     });
 
     let group = client
-        .init::<16, _>(group, |groups, slave| groups.push(slave))
+        .init::<16, _>(group, |groups, _slave| Ok(groups.as_mut()))
         .await
         .expect("Init");
 

--- a/examples/ec400.rs
+++ b/examples/ec400.rs
@@ -113,7 +113,7 @@ async fn main() -> Result<(), Error> {
     });
 
     let group = client
-        .init::<16, _>(groups, |groups, slave| groups.push(slave))
+        .init::<16, _>(groups, |groups, _slave| Ok(groups.as_mut()))
         .await
         .expect("Init");
 

--- a/examples/ek1100.rs
+++ b/examples/ek1100.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<(), Error> {
 
     let group = client
         // Initialise up to 16 slave devices
-        .init::<MAX_SLAVES, _>(group, |groups, slave| groups.push(slave))
+        .init::<MAX_SLAVES, _>(group, |groups, _slave| Ok(groups.as_mut()))
         .await
         .expect("Init");
 

--- a/examples/multiple-groups.rs
+++ b/examples/multiple-groups.rs
@@ -83,13 +83,9 @@ async fn main() -> Result<(), Error> {
 
     let client = Arc::new(client);
 
-    let mut ass = 0;
-
     // Read configurations from slave EEPROMs and configure devices.
     let groups = client
         .init::<MAX_SLAVES, _>(Groups::default(), |groups, slave| {
-            ass += 1;
-
             match slave.name.as_str() {
                 "EL2889" | "EK1100" => Ok(groups.slow_outputs.as_mut()),
                 "EL2828" => Ok(groups.fast_outputs.as_mut()),

--- a/examples/multiple-groups.rs
+++ b/examples/multiple-groups.rs
@@ -43,8 +43,8 @@ impl SlaveGroupContainer for Groups {
 
     fn group(&mut self, index: usize) -> Option<SlaveGroupRef> {
         match index {
-            0 => Some(self.slow_outputs.as_mut_ref()),
-            1 => Some(self.fast_outputs.as_mut_ref()),
+            0 => Some(self.slow_outputs.as_mut()),
+            1 => Some(self.fast_outputs.as_mut()),
             _ => None,
         }
     }
@@ -83,12 +83,16 @@ async fn main() -> Result<(), Error> {
 
     let client = Arc::new(client);
 
+    let mut ass = 0;
+
     // Read configurations from slave EEPROMs and configure devices.
     let groups = client
         .init::<MAX_SLAVES, _>(Groups::default(), |groups, slave| {
+            ass += 1;
+
             match slave.name.as_str() {
-                "EL2889" | "EK1100" => groups.slow_outputs.push(slave),
-                "EL2828" => groups.fast_outputs.push(slave),
+                "EL2889" | "EK1100" => Ok(groups.slow_outputs.as_mut()),
+                "EL2828" => Ok(groups.fast_outputs.as_mut()),
                 _ => Err(Error::UnknownSlave),
             }
         })

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -53,8 +53,8 @@ async fn main() -> Result<(), ethercrab::error::Error> {
 
         fn group(&mut self, index: usize) -> Option<SlaveGroupRef> {
             match index {
-                0 => Some(self.slow_outputs.as_mut_ref()),
-                1 => Some(self.fast_outputs.as_mut_ref()),
+                0 => Some(self.slow_outputs.as_mut()),
+                1 => Some(self.fast_outputs.as_mut()),
                 _ => None,
             }
         }

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -117,8 +117,8 @@ async fn main() -> Result<(), ethercrab::error::Error> {
     let groups = client
         .init::<MAX_SLAVES, _>(Groups::default(), |groups, slave| {
             match slave.name.as_str() {
-                "EL2889" | "EK1100" => groups.slow_outputs.push(slave),
-                "EL2828" => groups.fast_outputs.push(slave),
+                "EL2889" | "EK1100" => Ok(groups.slow_outputs.as_mut()),
+                "EL2828" => Ok(groups.fast_outputs.as_mut()),
                 _ => Err(Error::UnknownSlave),
             }
         })

--- a/src/client.rs
+++ b/src/client.rs
@@ -188,7 +188,6 @@ impl<'sto> Client<'sto> {
 
         // If there are slave devices that support distributed clocks, run static drift compensation
         if let Some(dc_master) = dc_master {
-            // TODO: Configurable number of iterations. 10k takes forever on Windows.
             dc::run_dc_static_sync(self, dc_master, self.config.dc_static_sync_iterations).await?;
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,7 @@ use crate::{
     slave_group::SlaveGroupContainer,
     slave_state::SlaveState,
     timer_factory::timeout,
-    ClientConfig, Timeouts, BASE_SLAVE_ADDR,
+    ClientConfig, SlaveGroupRef, Timeouts, BASE_SLAVE_ADDR,
 };
 use core::{
     any::type_name,
@@ -135,10 +135,17 @@ impl<'sto> Client<'sto> {
 
     /// Detect slaves, set their configured station addresses, assign to groups, configure slave
     /// devices from EEPROM.
+    ///
+    /// The `group_filter` closure should return a [`SlaveGroupRef`] to add the slave to. All slaves
+    /// must be assigned to a group even if they are unused.
+    ///
+    /// If a slave device cannot or should not be added to a group for some reason (e.g. an
+    /// unrecognised slave was detected on the network), an
+    /// [`Err(Error::UnknownSlave)`](Error::UnknownSlave) should be returned.
     pub async fn init<const MAX_SLAVES: usize, G>(
         &self,
         mut groups: G,
-        mut group_filter: impl FnMut(&mut G, Slave) -> Result<(), Error>,
+        mut group_filter: impl for<'g> FnMut(&'g mut G, &Slave) -> Result<SlaveGroupRef<'g>, Error>,
     ) -> Result<G, Error>
     where
         G: SlaveGroupContainer,
@@ -186,20 +193,9 @@ impl<'sto> Client<'sto> {
         }
 
         while let Some(slave) = slaves.pop_front() {
-            let configured_address = slave.configured_address;
-            let slave_name = slave.name.clone();
+            let mut group = group_filter(&mut groups, &slave)?;
 
-            let before_count = groups.total_slaves();
-
-            group_filter(&mut groups, slave)?;
-
-            if groups.total_slaves() != before_count + 1 {
-                log::error!(
-                    "Slave {:#06x} ({}) was not assigned to a group. All slaves must be assigned.",
-                    configured_address,
-                    slave_name
-                );
-            }
+            group.push(slave)?;
         }
 
         let mut offset = PdiOffset::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@
 //!
 //!     let group = client
 //!         // Initialise up to 16 slave devices
-//!         .init::<MAX_SLAVES, _>(group, |groups, slave| groups.push(slave))
+//!         .init::<16, _>(group, |groups, _slave| Ok(groups.as_mut()))
 //!         .await
 //!         .expect("Init");
 //!

--- a/src/slave_group/configurator.rs
+++ b/src/slave_group/configurator.rs
@@ -1,4 +1,4 @@
-use super::HookFn;
+use super::{slave_storage::SlaveStorageRef, HookFn};
 use crate::{
     error::Error,
     pdi::PdiOffset,
@@ -12,18 +12,24 @@ use crate::{
 };
 use core::time::Duration;
 
-/// TODO: Doc
+/// A reference to a [`SlaveGroup`](crate::SlaveGroup) returned by the closure passed to
+/// [`Client::init`](crate::Client::init).
 pub struct SlaveGroupRef<'a> {
     pub(crate) pdi_len: &'a mut usize,
     pub(crate) read_pdi_len: &'a mut usize,
     pub(crate) max_pdi_len: usize,
     pub(crate) start_address: &'a mut u32,
     pub(crate) group_working_counter: &'a mut u16,
-    pub(crate) slaves: &'a mut [Slave],
+    pub(crate) slaves: SlaveStorageRef<'a>,
     pub(crate) preop_safeop_hook: Option<&'a HookFn>,
 }
 
 impl<'a> SlaveGroupRef<'a> {
+    /// Add a slave to this group.
+    pub(crate) fn push(&mut self, slave: Slave) -> Result<(), Error> {
+        self.slaves.push(slave)
+    }
+
     pub(crate) async fn configure_from_eeprom<'sto>(
         &mut self,
         // We need to start this group's PDI after that of the previous group. That offset is passed

--- a/src/slave_group/container.rs
+++ b/src/slave_group/container.rs
@@ -33,7 +33,7 @@ impl<const N: usize, const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroupCo
     }
 
     fn group(&mut self, index: usize) -> Option<SlaveGroupRef> {
-        self.get_mut(index).map(|group| group.as_mut_ref())
+        self.get_mut(index).map(|group| group.as_mut())
     }
 }
 
@@ -45,6 +45,6 @@ impl<const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroupContainer
     }
 
     fn group(&mut self, _index: usize) -> Option<SlaveGroupRef> {
-        Some(self.as_mut_ref())
+        Some(self.as_mut())
     }
 }

--- a/src/slave_group/slave_storage.rs
+++ b/src/slave_group/slave_storage.rs
@@ -1,0 +1,88 @@
+//! A `heapless::Vec`-like storage container but with a smaller API, and the ability to create a
+//! reference to it with erased const generics.
+
+use crate::{error::Error, slave::Slave};
+use core::{
+    mem::MaybeUninit,
+    ops::{Deref, DerefMut},
+};
+
+pub struct SlaveStorage<const N: usize> {
+    num_slaves: usize,
+    slaves: MaybeUninit<[Slave; N]>,
+}
+
+impl<const N: usize> SlaveStorage<N> {
+    pub const fn new() -> Self {
+        Self {
+            slaves: MaybeUninit::uninit(),
+            num_slaves: 0,
+        }
+    }
+
+    pub fn as_ref(&mut self) -> SlaveStorageRef {
+        SlaveStorageRef {
+            max_slaves: N,
+            num_slaves: &mut self.num_slaves,
+            slaves: unsafe { self.slaves.assume_init_mut() },
+        }
+    }
+}
+
+impl<const N: usize> Default for SlaveStorage<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize> Deref for SlaveStorage<N> {
+    type Target = [Slave];
+
+    fn deref(&self) -> &Self::Target {
+        let slaves = unsafe { self.slaves.assume_init_ref() };
+
+        &slaves[0..self.num_slaves]
+    }
+}
+
+impl<const N: usize> DerefMut for SlaveStorage<N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let slaves = unsafe { self.slaves.assume_init_mut() };
+
+        &mut slaves[0..self.num_slaves]
+    }
+}
+
+pub struct SlaveStorageRef<'a> {
+    max_slaves: usize,
+    num_slaves: &'a mut usize,
+    slaves: &'a mut [Slave],
+}
+
+impl<'a> SlaveStorageRef<'a> {
+    pub fn push(&mut self, slave: Slave) -> Result<(), Error> {
+        if *self.num_slaves >= self.max_slaves {
+            return Err(Error::Capacity(crate::error::Item::Slave));
+        }
+
+        *self.num_slaves += 1;
+
+        self.slaves[*self.num_slaves] = slave;
+
+        Ok(())
+    }
+}
+
+impl<'a> Deref for SlaveStorageRef<'a> {
+    type Target = [Slave];
+
+    fn deref(&self) -> &Self::Target {
+        &self.slaves[0..*self.num_slaves]
+    }
+}
+
+impl<'a> DerefMut for SlaveStorageRef<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.slaves[0..*self.num_slaves]
+    }
+}


### PR DESCRIPTION
Instead of requiring the programmer to remember to `push` the slave device onto the current group, instead a reference to the desired group is returned from the closure, letting EtherCrab handle putting the slave in the right place.

E.g. `groups.slow_outputs.push(slave)` becomes `Ok(groups.slow_outputs.as_mut())`

Old API:

```rust
let groups = client
    .init::<MAX_SLAVES, _>(Groups::default(), |groups, slave| {
        match slave.name.as_str() {
            "EL2889" | "EK1100" => groups.slow_outputs.push(slave),
            "EL2828" => groups.fast_outputs.push(slave),
            _ => Err(Error::UnknownSlave),
        }
    })
    .await
    .expect("Init");
```

New API:

```rust
let groups = client
    .init::<MAX_SLAVES, _>(Groups::default(), |groups, slave| {
        match slave.name.as_str() {
            "EL2889" | "EK1100" => Ok(groups.slow_outputs.as_mut()),
            "EL2828" => Ok(groups.fast_outputs.as_mut()),
            _ => Err(Error::UnknownSlave),
        }
    })
    .await
    .expect("Init");
```