### PR TITLE
Fix slave storage issues

### DIFF
--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -678,7 +678,7 @@ bitflags::bitflags! {
     /// Supported mailbox category.
     ///
     /// Defined in ETG1000.6 Table 18 or ETG2010 Table 4.
-    #[derive(Copy, Clone, Default, Debug)]
+    #[derive(Copy, Clone, Default, Debug, PartialEq)]
     pub struct MailboxProtocols: u16 {
         /// ADS over EtherCAT (routing and parallel services).
         const AOE = 0x0001;

--- a/src/register.rs
+++ b/src/register.rs
@@ -213,7 +213,7 @@ pub enum PortType {
     Mii = 0x03,
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, PartialEq)]
 pub struct SupportFlags {
     pub fmmu_supports_bit_ops: bool,
     pub reserved_register_support: bool,

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -32,7 +32,7 @@ use core::{
 use nom::{bytes::complete::take, number::complete::le_u32, IResult};
 use packed_struct::{PackedStruct, PackedStructInfo, PackedStructSlice};
 
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, PartialEq)]
 pub struct SlaveIdentity {
     pub vendor_id: u32,
     pub product_id: u32,
@@ -74,27 +74,27 @@ impl FromEeprom for SlaveIdentity {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct SlaveConfig {
     pub io: IoRanges,
     pub mailbox: MailboxConfig,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct MailboxConfig {
     read: Option<Mailbox>,
     write: Option<Mailbox>,
     supported_protocols: MailboxProtocols,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Mailbox {
     address: u16,
     len: u16,
     sync_manager: u8,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct IoRanges {
     pub input: PdiSegment,
     pub output: PdiSegment,
@@ -114,7 +114,10 @@ impl IoRanges {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+// Gated by test feature so we can easily create test cases, but not expose a `Default`-ed `Slave`
+// to the user as this is an invalid state.
+#[cfg_attr(test, derive(Default))]
 pub struct Slave {
     /// Configured station address.
     pub(crate) configured_address: u16,

--- a/src/slave/ports.rs
+++ b/src/slave/ports.rs
@@ -34,7 +34,7 @@ pub enum Topology {
     Fork,
 }
 
-#[derive(Default, Copy, Clone, Debug)]
+#[derive(Default, Copy, Clone, Debug, PartialEq)]
 pub struct Ports(pub [Port; 4]);
 
 impl Ports {

--- a/src/slave_group/configurator.rs
+++ b/src/slave_group/configurator.rs
@@ -38,7 +38,8 @@ impl<'a> SlaveGroupRef<'a> {
         client: &'sto Client<'sto>,
     ) -> Result<PdiOffset, Error> {
         log::debug!(
-            "Going to configure group, starting PDI offset {:#08x}",
+            "Going to configure group with {} slave(s), starting PDI offset {:#08x}",
+            self.slaves.len(),
             global_offset.start_address
         );
 

--- a/src/slave_group/mod.rs
+++ b/src/slave_group/mod.rs
@@ -76,12 +76,7 @@ impl<const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroup<MAX_SLAVES, MAX_P
     pub fn new(preop_safeop_hook: HookFn) -> Self {
         Self {
             preop_safeop_hook: Some(preop_safeop_hook),
-            slaves: SlaveStorage::new(),
-            pdi: UnsafeCell::new([0u8; MAX_PDI]),
-            read_pdi_len: Default::default(),
-            pdi_len: Default::default(),
-            start_address: 0,
-            group_working_counter: 0,
+            ..Default::default()
         }
     }
 

--- a/src/slave_group/slave_storage.rs
+++ b/src/slave_group/slave_storage.rs
@@ -5,26 +5,30 @@ use crate::{error::Error, slave::Slave};
 use core::{
     mem::MaybeUninit,
     ops::{Deref, DerefMut},
+    slice,
 };
 
 pub struct SlaveStorage<const N: usize> {
-    num_slaves: usize,
-    slaves: MaybeUninit<[Slave; N]>,
+    len: usize,
+    slaves: [MaybeUninit<Slave>; N],
 }
 
 impl<const N: usize> SlaveStorage<N> {
+    const ELEM: MaybeUninit<Slave> = MaybeUninit::uninit();
+    const INIT: [MaybeUninit<Slave>; N] = [Self::ELEM; N]; // important for optimization of `new`
+
     pub const fn new() -> Self {
         Self {
-            slaves: MaybeUninit::uninit(),
-            num_slaves: 0,
+            slaves: Self::INIT,
+            len: 0,
         }
     }
 
     pub fn as_ref(&mut self) -> SlaveStorageRef {
         SlaveStorageRef {
             max_slaves: N,
-            num_slaves: &mut self.num_slaves,
-            slaves: unsafe { self.slaves.assume_init_mut() },
+            len: &mut self.len,
+            slaves: &mut self.slaves,
         }
     }
 }
@@ -39,35 +43,31 @@ impl<const N: usize> Deref for SlaveStorage<N> {
     type Target = [Slave];
 
     fn deref(&self) -> &Self::Target {
-        let slaves = unsafe { self.slaves.assume_init_ref() };
-
-        &slaves[0..self.num_slaves]
+        unsafe { slice::from_raw_parts(self.slaves.as_ptr() as *const Slave, self.len) }
     }
 }
 
 impl<const N: usize> DerefMut for SlaveStorage<N> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        let slaves = unsafe { self.slaves.assume_init_mut() };
-
-        &mut slaves[0..self.num_slaves]
+        unsafe { slice::from_raw_parts_mut(self.slaves.as_ptr() as *mut Slave, self.len) }
     }
 }
 
 pub struct SlaveStorageRef<'a> {
     max_slaves: usize,
-    num_slaves: &'a mut usize,
-    slaves: &'a mut [Slave],
+    len: &'a mut usize,
+    slaves: &'a mut [MaybeUninit<Slave>],
 }
 
 impl<'a> SlaveStorageRef<'a> {
     pub fn push(&mut self, slave: Slave) -> Result<(), Error> {
-        if *self.num_slaves >= self.max_slaves {
+        if *self.len >= self.max_slaves {
             return Err(Error::Capacity(crate::error::Item::Slave));
         }
 
-        *self.num_slaves += 1;
+        unsafe { *self.slaves.get_unchecked_mut(*self.len) = MaybeUninit::new(slave) };
 
-        self.slaves[*self.num_slaves] = slave;
+        *self.len += 1;
 
         Ok(())
     }
@@ -77,12 +77,12 @@ impl<'a> Deref for SlaveStorageRef<'a> {
     type Target = [Slave];
 
     fn deref(&self) -> &Self::Target {
-        &self.slaves[0..*self.num_slaves]
+        unsafe { slice::from_raw_parts(self.slaves.as_ptr() as *const Slave, *self.len) }
     }
 }
 
 impl<'a> DerefMut for SlaveStorageRef<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.slaves[0..*self.num_slaves]
+        unsafe { slice::from_raw_parts_mut(self.slaves.as_ptr() as *mut Slave, *self.len) }
     }
 }

--- a/src/slave_group/slave_storage.rs
+++ b/src/slave_group/slave_storage.rs
@@ -86,3 +86,100 @@ impl<'a> DerefMut for SlaveStorageRef<'a> {
         unsafe { slice::from_raw_parts_mut(self.slaves.as_ptr() as *mut Slave, *self.len) }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_slave() {
+        let slave = Slave {
+            configured_address: 0x1001,
+            ..Slave::default()
+        };
+
+        let mut storage = SlaveStorage::<16>::new();
+
+        let mut s = storage.as_ref();
+
+        s.push(slave).expect("capacity");
+
+        assert_eq!(
+            s.deref(),
+            &[Slave {
+                configured_address: 0x1001,
+                ..Slave::default()
+            }]
+        );
+    }
+
+    #[test]
+    fn many() {
+        let mut storage = SlaveStorage::<16>::new();
+
+        let mut s = storage.as_ref();
+
+        s.push(Slave {
+            configured_address: 0x1001,
+            ..Slave::default()
+        })
+        .unwrap();
+
+        s.push(Slave {
+            configured_address: 0x1002,
+            ..Slave::default()
+        })
+        .unwrap();
+
+        s.push(Slave {
+            configured_address: 0x1003,
+            ..Slave::default()
+        })
+        .unwrap();
+
+        assert_eq!(
+            s.deref(),
+            &[
+                Slave {
+                    configured_address: 0x1001,
+                    ..Slave::default()
+                },
+                Slave {
+                    configured_address: 0x1002,
+                    ..Slave::default()
+                },
+                Slave {
+                    configured_address: 0x1003,
+                    ..Slave::default()
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn full() {
+        let mut storage = SlaveStorage::<2>::new();
+
+        let mut s = storage.as_ref();
+
+        s.push(Slave {
+            configured_address: 0x1001,
+            ..Slave::default()
+        })
+        .unwrap();
+
+        s.push(Slave {
+            configured_address: 0x1002,
+            ..Slave::default()
+        })
+        .unwrap();
+
+        assert_eq!(
+            s.push(Slave {
+                configured_address: 0x1003,
+                ..Slave::default()
+            }),
+            Err(Error::Capacity(crate::error::Item::Slave))
+        );
+    }
+}


### PR DESCRIPTION
Closes #41 

This was a regression caused by the introduction of the internal `SlaveStorage` container - it was writing the slave device into the wrong piece of memory, meaning the retrieval of that slave's info would return a struct with all zeroes. This caused the error seen in #41 as it was sending an address of `0x0000` instead of `0x1000` (which the slave device is configured to.