### PR TITLE
Replace smol with its constituent parts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ thread-priority = "0.13.1"
 criterion = { version = "0.4.0", features = ["html_reports", "async_tokio"] }
 ctrlc = "3.2.3"
 env_logger = "0.10.0"
+smol = "1.3.0"
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "sync", "time"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ futures-lite = { version = "1.12.0", default-features = false }
 heapless = "0.7.16"
 log = "0.4.17"
 nom = { version = "7.1.1", default-features = false }
-num_enum = { version = "0.5.7", default-features = false }
+num_enum = { version = "0.6.0", default-features = false }
 packed_struct = { version = "0.10.0", default-features = false }
 safe-transmute = { version = "0.11.2", default-features = false }
 smlang = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/ethercrab"
 description = "An EtherCAT master in pure-Rust that is no_std compatible"
 keywords = ["no-std", "beckhoff", "ethercat", "igh", "soem"]
 exclude = [ "dumps", "NOTES.md", "SPECNOTES.md" ]
+resolver = "2"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -17,11 +18,13 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = [ "x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu" ]
 
 [dependencies]
+async-io = { version = "1.13.0", optional = true }
 atomic_enum = "0.2.0"
 bitflags = "2.0.2"
 defmt = "0.3.2"
 embassy-futures = "0.1.0"
 embassy-time = "0.1.0"
+futures-lite = { version = "1.12.0", default-features = false }
 heapless = "0.7.16"
 log = "0.4.17"
 nom = { version = "7.1.1", default-features = false }
@@ -29,12 +32,12 @@ num_enum = { version = "0.5.7", default-features = false }
 packed_struct = { version = "0.10.0", default-features = false }
 safe-transmute = { version = "0.11.2", default-features = false }
 smlang = "0.6.0"
-smol = { version = "1.2.5", optional = true }
 smoltcp = { version = "0.9.1", default-features = false, features = [ "proto-ipv4", "socket-raw", "medium-ethernet", "phy-raw_socket" ] }
 spin = { version = "0.9.4", default-features = false, features = ["rwlock"] }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 pnet_datalink = { version = "0.33.0", features = ["std"], optional = true }
+blocking = "1.3.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.134"
@@ -45,12 +48,11 @@ thread-priority = "0.13.1"
 criterion = { version = "0.4.0", features = ["html_reports", "async_tokio"] }
 ctrlc = "3.2.3"
 env_logger = "0.10.0"
-futures-lite = { version = "1.12.0", default-features = false }
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros", "sync", "time"] }
 
 [features]
 default = ["std"]
-std = ["pnet_datalink", "smol"]
+std = ["pnet_datalink", "async-io"]
 # Development only - DO NOT USE
 bench-hacks = []
 

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -259,7 +259,7 @@ mod tests {
             &data,
         ));
 
-        let _ = smol::block_on(frame_fut);
+        let _ = async_io::block_on(frame_fut);
 
         let send_fut = poll_once(async {
             let mut packet_buf = [0u8; 1536];
@@ -276,7 +276,7 @@ mod tests {
                 .unwrap();
         });
 
-        let _ = smol::block_on(send_fut);
+        let _ = async_io::block_on(send_fut);
 
         assert_eq!(written_packet.len(), FRAME_OVERHEAD + data.len());
 
@@ -395,7 +395,7 @@ mod tests {
                             .unwrap();
                     }
 
-                    smol::future::yield_now().await;
+                    futures_lite::future::yield_now().await;
                 }
             };
 

--- a/src/std/linux/mod.rs
+++ b/src/std/linux/mod.rs
@@ -8,8 +8,7 @@ use crate::{
     pdu_loop::{PduRx, PduTx},
 };
 use core::{future::Future, pin::Pin, task::Poll};
-use smol::io::{AsyncRead, AsyncWrite};
-use smol::Async;
+use futures_lite::io::{Async, AsyncRead, AsyncWrite};
 
 struct TxRxFut<'a> {
     socket: Async<RawSocketDesc>,
@@ -105,7 +104,7 @@ pub fn tx_rx_task(
 ) -> Result<impl Future<Output = Result<(), Error>>, std::io::Error> {
     let socket = RawSocketDesc::new(interface)?;
 
-    let async_socket = smol::Async::new(socket)?;
+    let async_socket = async_io::Async::new(socket)?;
 
     let task = TxRxFut {
         socket: async_socket,

--- a/src/std/linux/mod.rs
+++ b/src/std/linux/mod.rs
@@ -7,8 +7,9 @@ use crate::{
     error::Error,
     pdu_loop::{PduRx, PduTx},
 };
+use async_io::Async;
 use core::{future::Future, pin::Pin, task::Poll};
-use futures_lite::io::{Async, AsyncRead, AsyncWrite};
+use futures_lite::io::{AsyncRead, AsyncWrite};
 
 struct TxRxFut<'a> {
     socket: Async<RawSocketDesc>,

--- a/src/std/not_linux.rs
+++ b/src/std/not_linux.rs
@@ -76,12 +76,12 @@ pub fn tx_rx_task(
                         .expect("TX");
                 }
 
-                smol::future::yield_now().await;
+                futures_lite::future::yield_now().await;
             }
         };
 
         // TODO: Unwraps
-        let rx_task = smol::unblock(move || {
+        let rx_task = blocking::unblock(move || {
             let mut frame_buf: Vec<u8> = Vec::new();
 
             loop {

--- a/src/timer_factory.rs
+++ b/src/timer_factory.rs
@@ -12,7 +12,7 @@ pub async fn timer(duration: Duration) {
 
 #[cfg(feature = "std")]
 pub async fn timer(duration: Duration) {
-    smol::Timer::after(duration).await;
+    async_io::Timer::after(duration).await;
 }
 
 pub async fn timeout<O, F>(timeout: Duration, future: F) -> Result<O, Error>


### PR DESCRIPTION
`cargo tree | wc -l` goes from 300 to 265. A lot of dependencies in that list are dev-deps so it's not too scary for end users.