### PR TITLE
Fix smoltcp feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ miri_steps: &miri_steps
           - ./target
           - /home/circleci/.cargo/registry
 
-target_steps_no_test: &target_steps_no_test
+target_steps_no_std: &target_steps_no_std
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
     - image: cimg/rust:1.69.0
@@ -149,12 +149,11 @@ jobs:
       - TARGET: "aarch64-apple-darwin"
     <<: *macos_steps
 
-  # TODO: Re-enable when we can remove `Box` from the slave group preop hook fn
-  # target-thumbv7m-none-eabi:
-  #   resource_class: large
-  #   environment:
-  #     - TARGET: "thumbv7m-none-eabi"
-  #   <<: *target_steps_no_test
+  target-thumbv7m-none-eabi:
+    resource_class: large
+    environment:
+      - TARGET: "thumbv7m-none-eabi"
+    <<: *target_steps_no_std
 
 build_jobs: &build_jobs
   jobs:
@@ -163,7 +162,7 @@ build_jobs: &build_jobs
     - windows-cross
     - macos-cross
     - macos-arm-cross
-    # - target-thumbv7m-none-eabi
+    - target-thumbv7m-none-eabi
 
 workflows:
   version: 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ packed_struct = { version = "0.10.1", default-features = false }
 safe-transmute = { version = "0.11.2", default-features = false }
 sealed = "0.5.0"
 smlang = "0.6.0"
-smoltcp = { version = "0.9.1", default-features = false, features = [ "proto-ipv4", "socket-raw", "medium-ethernet", "phy-raw_socket" ] }
+smoltcp = { version = "0.9.1", default-features = false, features = [ "proto-ipv4", "socket-raw", "medium-ethernet" ] }
 spin = { version = "0.9.8", default-features = false, features = ["rwlock"] }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
@@ -54,7 +54,7 @@ tokio = { version = "1.28.2", features = ["rt-multi-thread", "macros", "sync", "
 
 [features]
 default = ["std"]
-std = ["pnet_datalink", "async-io"]
+std = ["pnet_datalink", "async-io", "smoltcp/phy-raw_socket"]
 # Development only - DO NOT USE
 bench-hacks = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,8 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
 
+extern crate alloc;
+
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod log;
 

--- a/src/pdu_loop/pdu_tx.rs
+++ b/src/pdu_loop/pdu_tx.rs
@@ -40,7 +40,10 @@ impl<'sto> PduTx<'sto> {
         None
     }
 
-    #[cfg_attr(any(target_os = "windows", target_os = "macos"), allow(unused))]
+    #[cfg_attr(
+        any(target_os = "windows", target_os = "macos", not(feature = "std")),
+        allow(unused)
+    )]
     pub(crate) fn lock_waker<'lock>(&self) -> RwLockWriteGuard<'lock, Option<Waker>>
     where
         'sto: 'lock,

--- a/src/slave_group/mod.rs
+++ b/src/slave_group/mod.rs
@@ -7,6 +7,9 @@ use crate::{
 };
 use core::{cell::UnsafeCell, future::Future, pin::Pin, sync::atomic::AtomicUsize};
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 pub use configurator::SlaveGroupRef;
 
 // TODO: When the right async-trait stuff is stabilised, it should be possible to remove the


### PR DESCRIPTION
Also fixes usage of `Box` in no_std so this crate should now compile for no_std targets. Note though that it still requires `alloc` to be present.

I'm hoping to redesign the API a bit to remove the requirement on `Box<dyn ...>` which would mean no dynamic alloc is required by EtherCrab at all.

Closes #56 