### PR TITLE
Make init future `Send`-able

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ libc = "0.2.146"
 rustix = { version = "0.37.19", default-features = false, features = ["process"] }
 thread-priority = "0.13.1"
 
+[target.'cfg(miri)'.dependencies]
+tokio = { version = "1.28.2", features = ["rt", "macros", "time"] }
+
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 ctrlc = "3.4.0"

--- a/src/timer_factory.rs
+++ b/src/timer_factory.rs
@@ -10,9 +10,14 @@ pub async fn timer(duration: Duration) {
     .await;
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(miri)))]
 pub async fn timer(duration: Duration) {
     async_io::Timer::after(duration).await;
+}
+
+#[cfg(all(feature = "std", miri))]
+pub async fn timer(duration: Duration) {
+    tokio::time::sleep(duration).await;
 }
 
 pub async fn timeout<O, F>(timeout: Duration, future: F) -> Result<O, Error>


### PR DESCRIPTION
I haven't included it in this PR because it times out but I ran a MIRI pass over a replay test and it didn't throw up any errors so I _think_ this is safe?