### PR TITLE
Add `Display` impls to print out more slave details

### DIFF
--- a/src/register.rs
+++ b/src/register.rs
@@ -1,4 +1,5 @@
 use crate::pdu_data::{PduData, PduRead};
+use core::fmt;
 use packed_struct::{prelude::*, PackingError};
 
 /// Register address abstraction.
@@ -227,6 +228,31 @@ pub struct SupportFlags {
     pub lrw_supported: bool,
     pub brw_aprw_fprw_supported: bool,
     pub special_fmmu: bool,
+}
+
+impl fmt::Display for SupportFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Just print DC for now
+        f.write_str("DC: ")?;
+
+        if self.dc_supported {
+            f.write_str("yes")?;
+
+            if self.has_64bit_dc {
+                f.write_str(" (64 bit)")?;
+            } else {
+                f.write_str(" (32 bit)")?;
+            }
+        } else {
+            f.write_str("no")?;
+        }
+
+        if self.enhanced_dc_sync {
+            f.write_str(", enhanced sync")?;
+        }
+
+        Ok(())
+    }
 }
 
 impl PackedStruct for SupportFlags {

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -149,7 +149,14 @@ impl Slave {
                 ])
             })?;
 
-        log::debug!("Slave {:#06x} name {}", configured_address, name);
+        log::debug!(
+            "Slave {:#06x} name {} {}, {}, {}",
+            configured_address,
+            name,
+            identity,
+            flags,
+            ports
+        );
 
         Ok(Self {
             configured_address,

--- a/src/slave/ports.rs
+++ b/src/slave/ports.rs
@@ -1,4 +1,4 @@
-use core::fmt::Debug;
+use core::fmt::{self, Debug};
 
 /// Flags showing which ports are active or not on the slave.
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone)]
@@ -36,6 +36,24 @@ pub enum Topology {
 
 #[derive(Default, Copy, Clone, Debug, PartialEq)]
 pub struct Ports(pub [Port; 4]);
+
+impl fmt::Display for Ports {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ports [ ")?;
+
+        for p in self.0 {
+            if p.active {
+                f.write_str("open ")?;
+            } else {
+                f.write_str("closed ")?;
+            }
+        }
+
+        f.write_str("]")?;
+
+        Ok(())
+    }
+}
 
 impl Ports {
     fn open_ports(&self) -> u8 {

--- a/src/slave/types.rs
+++ b/src/slave/types.rs
@@ -14,6 +14,15 @@ pub struct SlaveIdentity {
     pub serial: u32,
 }
 
+impl fmt::Display for SlaveIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "vendor: {:#010x}, product {:#010x}, rev {}, serial {}",
+            self.vendor_id, self.product_id, self.revision, self.serial
+        ))
+    }
+}
+
 impl Debug for SlaveIdentity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SlaveIdentity")


### PR DESCRIPTION
The slave info debug line now prints more info than just address and name:

```
Slave 0x1000 name EK1100 vendor: 0x00000002, product 0x044c2c52, rev 1179648, serial 0, DC: yes (64 bit), ports [ open open closed closed ]
```

this adds a bit more data before any other potential failures.