### PR TITLE
Ignore non-DC slaves when configuring DC

### DIFF
--- a/src/dc.rs
+++ b/src/dc.rs
@@ -10,14 +10,16 @@ use crate::{
 
 /// Send a broadcast to all slaves to latch in DC receive time, then store it on the slave structs.
 async fn latch_dc_times(client: &Client<'_>, slaves: &mut [Slave]) -> Result<(), Error> {
-    let num_slaves = slaves.len();
+    let num_slaves_with_dc: usize = slaves
+        .iter()
+        .filter(|slave| slave.flags.dc_supported)
+        .count();
 
     // Latch receive times into all ports of all slaves.
     client
         .bwr(RegisterAddress::DcTimePort0, 0u32)
-        .await
-        .expect("Broadcast time")
-        .wkc(num_slaves as u16, "Broadcast time")?;
+        .await?
+        .wkc(num_slaves_with_dc as u16, "Broadcast time")?;
 
     // Read receive times for all slaves and store on slave structs
     for slave in slaves {

--- a/src/dc.rs
+++ b/src/dc.rs
@@ -55,17 +55,15 @@ async fn write_dc_parameters(
 ) -> Result<(), Error> {
     let sl = SlaveRef::new(client, slave.configured_address, ());
 
-    sl.write::<i64>(
+    sl.write_ignore_wkc::<i64>(
         RegisterAddress::DcSystemTimeOffset,
         -dc_receive_time + now_nanos,
-        "DC system time offset",
     )
     .await?;
 
-    sl.write::<u32>(
+    sl.write_ignore_wkc::<u32>(
         RegisterAddress::DcSystemTimeTransmissionDelay,
         slave.propagation_delay,
-        "DC transmission delay",
     )
     .await?;
 

--- a/src/dc.rs
+++ b/src/dc.rs
@@ -154,17 +154,6 @@ fn configure_slave_offsets(
 ) -> Result<i64, Error> {
     slave.parent_index = find_slave_parent(parents, slave)?;
 
-    log::debug!(
-        "Slave {:#06x} {} {}",
-        slave.configured_address,
-        slave.name,
-        if slave.flags.dc_supported {
-            "has DC"
-        } else {
-            "no DC"
-        }
-    );
-
     // Convenient variable names
     let dc_receive_time = slave.dc_receive_time;
 
@@ -273,6 +262,17 @@ pub(crate) async fn configure_dc<'slaves>(
         let (parents, rest) = slaves.split_at_mut(i);
         let slave = rest.first_mut().ok_or(Error::Internal)?;
 
+        log::debug!(
+            "Slave {:#06x} {} {}",
+            slave.configured_address,
+            slave.name,
+            if slave.flags.dc_supported {
+                "has DC"
+            } else {
+                "no DC"
+            }
+        );
+
         // If this slave has a parent, find it, then assign the parent's next open port to this
         // slave, estabilishing the relationship between them by index.
         if let Some(parent_idx) = slave.parent_index {
@@ -293,7 +293,7 @@ pub(crate) async fn configure_dc<'slaves>(
             write_dc_parameters(client, slave, dc_receive_time, now_nanos).await?;
         } else {
             log::trace!(
-                "Skipping DC config for slave {:#06x}: DC not supported",
+                "--> Skipping DC config for slave {:#06x}: DC not supported",
                 slave.configured_address
             );
         }

--- a/src/dc.rs
+++ b/src/dc.rs
@@ -49,21 +49,23 @@ async fn latch_dc_times(client: &Client<'_>, slaves: &mut [Slave]) -> Result<(),
 /// Write DC system time offset and propagation delay to the slave memory.
 async fn write_dc_parameters(
     client: &Client<'_>,
-    slave: &mut Slave,
+    slave: &Slave,
     dc_receive_time: i64,
     now_nanos: i64,
 ) -> Result<(), Error> {
     let sl = SlaveRef::new(client, slave.configured_address, ());
 
-    sl.write_ignore_wkc::<i64>(
+    sl.write::<i64>(
         RegisterAddress::DcSystemTimeOffset,
         -dc_receive_time + now_nanos,
+        "DC system time offset",
     )
     .await?;
 
-    sl.write_ignore_wkc::<u32>(
+    sl.write::<u32>(
         RegisterAddress::DcSystemTimeTransmissionDelay,
         slave.propagation_delay,
+        "DC transmission delay",
     )
     .await?;
 
@@ -149,7 +151,7 @@ fn find_slave_parent(parents: &[Slave], slave: &Slave) -> Result<Option<usize>, 
 /// reach it when sent from the master.
 fn configure_slave_offsets(
     slave: &mut Slave,
-    parents: &mut [Slave],
+    parents: &[Slave],
     delay_accum: &mut u32,
 ) -> Result<i64, Error> {
     slave.parent_index = find_slave_parent(parents, slave)?;
@@ -167,34 +169,39 @@ fn configure_slave_offsets(
 
     // Convenient variable names
     let dc_receive_time = slave.dc_receive_time;
-    let time_p0 = slave.ports.0[0].dc_receive_time;
-    let time_p1 = slave.ports.0[1].dc_receive_time;
-    let time_p2 = slave.ports.0[2].dc_receive_time;
-    let time_p3 = slave.ports.0[3].dc_receive_time;
 
-    // Time deltas between port receive times
-    let d01 = time_p1.saturating_sub(time_p0);
-    let d12 = time_p2.saturating_sub(time_p1);
-    let d32 = time_p3.saturating_sub(time_p2);
+    // Just for debug
+    {
+        let time_p0 = slave.ports.0[0].dc_receive_time;
+        let time_p1 = slave.ports.0[1].dc_receive_time;
+        let time_p2 = slave.ports.0[2].dc_receive_time;
+        let time_p3 = slave.ports.0[3].dc_receive_time;
 
-    let loop_propagation_time = slave.ports.propagation_time();
-    let child_delay = slave.ports.child_delay().unwrap_or(0);
+        // Time deltas between port receive times
+        let d01 = time_p1.saturating_sub(time_p0);
+        let d12 = time_p2.saturating_sub(time_p1);
+        let d32 = time_p3.saturating_sub(time_p2);
 
-    log::debug!("--> Times {time_p0} ({d01}) {time_p1} ({d12}) {time_p2} ({d32}) {time_p3}");
-    log::debug!("--> Propagation time {loop_propagation_time:?} ns, child delay {child_delay} ns");
+        let loop_propagation_time = slave.ports.propagation_time();
+        let child_delay = slave.ports.child_delay().unwrap_or(0);
+
+        log::debug!("--> Times {time_p0} ({d01}) {time_p1} ({d12}) {time_p2} ({d32}) {time_p3}");
+        log::debug!(
+            "--> Loop propagation time {loop_propagation_time:?} ns, child delay {child_delay} ns"
+        );
+    }
 
     if let Some(parent_idx) = slave.parent_index {
         let parent = parents
-            .iter_mut()
+            .iter()
             .find(|parent| parent.index == parent_idx)
             .expect("Parent");
 
-        let assigned_port_idx = parent
+        let parent_port = parent
             .ports
-            .assign_next_downstream_port(slave.index)
-            .expect("No free ports. Logic error.");
+            .last_port()
+            .expect("No open ports on parent. Logic error.");
 
-        let parent_port = parent.ports.0[assigned_port_idx];
         let prev_parent_port = parent
             .ports
             .prev_open_port(&parent_port)
@@ -213,8 +220,8 @@ fn configure_slave_offsets(
 
         *delay_accum += delay;
 
-        // If parent has children but we're not one of them, add the children's delay to
-        // this slave's offset.
+        // If parent has children but we're not one of them, add the children's delay to this
+        // slave's offset.
         if let Some(child_delay) = parent
             .ports
             .child_delay()
@@ -268,9 +275,30 @@ pub(crate) async fn configure_dc<'slaves>(
         let (parents, rest) = slaves.split_at_mut(i);
         let slave = rest.first_mut().ok_or(Error::Internal)?;
 
-        let dc_receive_time = configure_slave_offsets(slave, parents, &mut delay_accum)?;
+        // If this slave has a parent, find it, then assign the parent's next open port to this
+        // slave, estabilishing the relationship between them by index.
+        if let Some(parent_idx) = slave.parent_index {
+            let parent = parents
+                .iter_mut()
+                .find(|parent| parent.index == parent_idx)
+                .expect("Parent");
 
-        write_dc_parameters(client, slave, dc_receive_time, now_nanos).await?;
+            parent
+                .ports
+                .assign_next_downstream_port(slave.index)
+                .expect("No free ports on parent. Logic error.");
+        }
+
+        if slave.flags.dc_supported {
+            let dc_receive_time = configure_slave_offsets(slave, parents, &mut delay_accum)?;
+
+            write_dc_parameters(client, slave, dc_receive_time, now_nanos).await?;
+        } else {
+            log::trace!(
+                "Skipping DC config for slave {:#06x}: DC not supported",
+                slave.configured_address
+            );
+        }
     }
 
     let first_dc_slave = slaves.iter().find(|slave| slave.flags.dc_supported);

--- a/src/slave/ports.rs
+++ b/src/slave/ports.rs
@@ -68,7 +68,8 @@ impl Ports {
             .min_by_key(|port| port.dc_receive_time)
     }
 
-    fn last_port(&self) -> Option<Port> {
+    /// Get the last open port.
+    pub fn last_port(&self) -> Option<Port> {
         self.0
             .into_iter()
             .filter(|port| port.active)

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,3 +30,11 @@ Then run the test using real interface e.g.:
 ```bash
 INTERFACE=enp2s0 just linux-test replay
 ```
+
+### Filtering captured replays
+
+Use `tshark` to filter out only EtherCAT packets from provided dumps:
+
+```bash
+tshark -r EL1014.pcapng -Y 'ecat' -w issue-63-el1014.pcapng
+```


### PR DESCRIPTION
I could reproduce the error in #63 using the provided Wireshark captures, however for some mysterious reason every single module I plug into my EK1100 shows up as `DC: yes` so I'm unable to test this fix. 

Closes #63 
