### PR TITLE
Mention that the DS402 module is experimental

### DIFF
--- a/examples/ec400.rs
+++ b/examples/ec400.rs
@@ -1,6 +1,11 @@
 //! Configure a Leadshine EtherCat EL7 series drive and turn the motor.
 //!
 //! This demonstrates using the DS402 state machine to operate a DS402 compliant servo drive.
+//!
+//! # Experimental
+//!
+//! Please note the `ds402` module is experimental and may change drastically at any time. It is
+//! also not well tested so use at your own risk.
 
 use env_logger::Env;
 use ethercrab::{

--- a/src/ds402.rs
+++ b/src/ds402.rs
@@ -1,4 +1,12 @@
 //! DS402 state machine.
+//!
+//! # Experimental
+//!
+//! Please note the `ds402` module is rough, experimental and may change drastically at any time as
+//! the API evolves. It has basic functionality at the moment and can be used to make motors spin,
+//! but there is a lot missing.
+//!
+//! Use at your own risk.
 
 use crate::{
     error::Error as EthercrabError,


### PR DESCRIPTION
This is IMO the last blocker to a new release. I toyed with the idea of removing it or feature flagging it, but I think leaving it in with a mention that it's experimental is ok.