### PR TITLE
Add `SlaveRef::identity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#TODO] Add `SlaveRef::identity` method to get the vendor ID, etc of a slave device.
+
 ## [0.2.0] - 2023-07-31
 
 ### Added
@@ -119,8 +123,8 @@ An EtherCAT master written in Rust.
 - Initial release
 
 <!-- next-url -->
-[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.2.0...HEAD
 
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.2.0...HEAD
 [#2]: https://github.com/ethercrab-rs/ethercrab/pull/2
 [#1]: https://github.com/ethercrab-rs/ethercrab/pull/1
 [#6]: https://github.com/ethercrab-rs/ethercrab/pull/6
@@ -142,5 +146,6 @@ An EtherCAT master written in Rust.
 [#55]: https://github.com/ethercrab-rs/ethercrab/pull/55
 [#59]: https://github.com/ethercrab-rs/ethercrab/pull/59
 [#75]: https://github.com/ethercrab-rs/ethercrab/pull/75
+[#TODO]: https://github.com/ethercrab-rs/ethercrab/pull/TODO
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ An EtherCAT master written in Rust.
 
 ### Added
 
-- [#TODO] Add `SlaveRef::identity` method to get the vendor ID, etc of a slave device.
+- [#83] Add `SlaveRef::identity` method to get the vendor ID, etc of a slave device.
 
 ## [0.2.0] - 2023-07-31
 
@@ -146,6 +146,6 @@ An EtherCAT master written in Rust.
 [#55]: https://github.com/ethercrab-rs/ethercrab/pull/55
 [#59]: https://github.com/ethercrab-rs/ethercrab/pull/59
 [#75]: https://github.com/ethercrab-rs/ethercrab/pull/75
-[#TODO]: https://github.com/ethercrab-rs/ethercrab/pull/TODO
+[#83]: https://github.com/ethercrab-rs/ethercrab/pull/83
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -233,6 +233,11 @@ where
         self.state.name.as_str()
     }
 
+    /// Get additional identifying details for the slave device.
+    pub fn identity(&self) -> SlaveIdentity {
+        self.state.identity
+    }
+
     /// Get the configured station address of the slave device.
     pub fn configured_address(&self) -> u16 {
         self.state.configured_address


### PR DESCRIPTION
This was already present on `Slave` but needs to be usable with `SlaveRef` too.