### PR TITLE
Expose method to get a single slave device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,20 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- [#84] `GroupSlave::iter` will now panic instead of completing early if a slave device is already
+  borrowed.
+
 ### Added
 
-- [#83] Add `SlaveRef::identity` method to get the vendor ID, etc of a slave device.
+- [#83] Add `SlaveRef::identity` method to get the vendor ID, hardware revision, etc of a slave
+  device.
+
+### Changed
+
+- [#84] The `SlaveGroupState` trait is now not-doc-hidden so the `GroupSlave::slave` method is more
+  easily accessible.
 
 ## [0.2.0] - 2023-07-31
 
@@ -147,5 +158,6 @@ An EtherCAT master written in Rust.
 [#59]: https://github.com/ethercrab-rs/ethercrab/pull/59
 [#75]: https://github.com/ethercrab-rs/ethercrab/pull/75
 [#83]: https://github.com/ethercrab-rs/ethercrab/pull/83
+[#84]: https://github.com/ethercrab-rs/ethercrab/pull/84
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -171,6 +171,33 @@ macro_rules! error_ {
     };
 }
 
+#[cfg(feature = "defmt")]
+macro_rules! unwrap_ {
+    ($($x:tt)*) => {
+        ::defmt::unwrap!($($x)*)
+    };
+}
+
+#[cfg(not(feature = "defmt"))]
+macro_rules! unwrap_ {
+    ($arg:expr) => {
+        match $arg {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(e) => {
+                ::core::panic!("unwrap of `{}` failed: {:?}", ::core::stringify!($arg), e);
+            }
+        }
+    };
+    ($arg:expr, $($msg:expr),+ $(,)? ) => {
+        match $arg {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(e) => {
+                ::core::panic!("unwrap of `{}` failed: {}: {:?}", ::core::stringify!($arg), ::core::format_args!($($msg,)*), e);
+            }
+        }
+    }
+}
+
 pub(crate) use assert_ as assert;
 pub(crate) use assert_eq_ as assert_eq;
 pub(crate) use assert_ne_ as assert_ne;
@@ -184,4 +211,5 @@ pub(crate) use panic_ as panic;
 pub(crate) use todo_ as todo;
 pub(crate) use trace_ as trace;
 pub(crate) use unreachable_ as unreachable;
+pub(crate) use unwrap_ as unwrap;
 pub(crate) use warn_ as warn;

--- a/src/slave_group/iterator.rs
+++ b/src/slave_group/iterator.rs
@@ -34,10 +34,11 @@ where
             return None;
         }
 
-        // Squelch errors. If we're failing at this point, something is _very_ wrong.
-        let slave = self.group.slave(self.client, self.idx).map_err(|e| {
+        let slave = fmt::unwrap!( self.group.slave(self.client, self.idx).map_err(|e| {
             fmt::error!("Failed to get slave at index {} from group with {} slaves: {}. This is very wrong. Please open an issue.", self.idx, self.group.len(), e);
-        }).ok()?;
+
+            e
+        }));
 
         self.idx += 1;
 


### PR DESCRIPTION
This trait was `#[doc(hidden)]` before.

This PR also changes `SlaveGroup::iter` behaviour to panic on reborrow instead of silently completing early.