### PR TITLE
Support "cross" topologies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#91] Add support for "cross" topologies, e.g. with EK1122.
+
 ## [0.2.1] - 2023-07-31
 
 ### Fixed
@@ -164,5 +168,6 @@ An EtherCAT master written in Rust.
 [#83]: https://github.com/ethercrab-rs/ethercrab/pull/83
 [#84]: https://github.com/ethercrab-rs/ethercrab/pull/84
 [#86]: https://github.com/ethercrab-rs/ethercrab/pull/86
+[#91]: https://github.com/ethercrab-rs/ethercrab/pull/91
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/examples/discover.rs
+++ b/examples/discover.rs
@@ -28,12 +28,11 @@ fn main() {
 
     let client = Arc::new(Client::new(
         pdu_loop,
-        Timeouts {
-            wait_loop_delay: Duration::from_millis(2),
-            mailbox_response: Duration::from_millis(1000),
-            ..Default::default()
+        Timeouts::default(),
+        ClientConfig {
+            dc_static_sync_iterations: 0,
+            ..ClientConfig::default()
         },
-        ClientConfig::default(),
     ));
 
     smol::block_on(async {

--- a/src/dc.rs
+++ b/src/dc.rs
@@ -207,7 +207,7 @@ fn configure_slave_offsets(
         // The port the master is connected to on this slave. Must always be entry port.
         let this_port = slave.ports.entry_port().expect("No entry port lmao");
 
-        log::debug!(
+        fmt::debug!(
             "--> Parent ({:?}) {} port {} assigned to {} port {} (slave is child of parent: {:?})",
             parent.ports.topology(),
             parent.name(),
@@ -220,7 +220,7 @@ fn configure_slave_offsets(
         let parent_prop_time = parent.ports.total_propagation_time().unwrap_or(0);
         let this_prop_time = slave.ports.total_propagation_time().unwrap_or(0);
 
-        log::debug!(
+        fmt::debug!(
             "--> Parent propagation time {}, my prop. time {} delta {}",
             parent_prop_time,
             this_prop_time,
@@ -256,7 +256,7 @@ fn configure_slave_offsets(
 
         *delay_accum += propagation_delay;
 
-        log::debug!(
+        fmt::debug!(
             "--> Propagation delay {} (delta {}) ns",
             delay_accum,
             propagation_delay,
@@ -315,6 +315,7 @@ fn assign_parent_relationships(slaves: &mut [Slave]) -> Result<(), Error> {
     }
 
     // Extremely crude output to generate test cases with. `rustfmt` makes it look nice in the test.
+    #[cfg(feature = "std")]
     if option_env!("PRINT_TEST_CASE").is_some() {
         for slave in slaves.iter() {
             let p = slave.ports.0;

--- a/src/dc.rs
+++ b/src/dc.rs
@@ -129,7 +129,10 @@ fn find_slave_parent(parents: &[Slave], slave: &Slave) -> Result<Option<usize>, 
         // that as the parent.
         if parent.ports.topology() == Topology::LineEnd {
             let split_point = parents_it
-                .find(|slave| slave.ports.topology() == Topology::Fork)
+                .find(|slave| {
+                    slave.ports.topology() == Topology::Fork
+                        || slave.ports.topology() == Topology::Cross
+                })
                 .ok_or_else(|| {
                     fmt::error!(
                         "Did not find fork parent for slave {:#06x}",

--- a/src/dc.rs
+++ b/src/dc.rs
@@ -251,7 +251,7 @@ fn configure_slave_offsets(
 
                     (children_loop_time - this_prop_time) / 2
                 } else {
-                    (parent_prop_time - this_prop_time) / 2
+                    parent_prop_time - *delay_accum
                 }
             }
             // A parent of any device cannot have a `LineEnd` topology as it will always have at

--- a/src/dc.rs
+++ b/src/dc.rs
@@ -165,14 +165,14 @@ fn configure_slave_offsets(
     // Just for debug
     {
         let time_p0 = slave.ports.0[0].dc_receive_time;
-        let time_p1 = slave.ports.0[1].dc_receive_time;
-        let time_p2 = slave.ports.0[2].dc_receive_time;
-        let time_p3 = slave.ports.0[3].dc_receive_time;
+        let time_p3 = slave.ports.0[1].dc_receive_time;
+        let time_p1 = slave.ports.0[2].dc_receive_time;
+        let time_p2 = slave.ports.0[3].dc_receive_time;
 
         // Deltas between port receive times
-        let d01 = time_p1.saturating_sub(time_p0);
-        let d21 = time_p2.saturating_sub(time_p1);
-        let d32 = time_p3.saturating_sub(time_p2);
+        let d03 = time_p3.saturating_sub(time_p0);
+        let d31 = time_p1.saturating_sub(time_p3);
+        let p12 = time_p2.saturating_sub(time_p1);
 
         let loop_propagation_time = slave.ports.total_propagation_time();
         let child_delay = slave.ports.fork_child_delay();
@@ -181,12 +181,12 @@ fn configure_slave_offsets(
         fmt::debug!(
             "--> Receive times {} ns (Δ {} ns) {} (Δ {} ns) {} (Δ {} ns) {}",
             time_p0,
-            d01,
+            d03,
+            time_p3,
+            d31,
             time_p1,
-            d21,
-            time_p2,
-            d32,
-            time_p3
+            p12,
+            time_p2
         );
         fmt::debug!(
             "--> Loop propagation time {:?} ns, child delay {:?} ns",

--- a/src/dc.rs
+++ b/src/dc.rs
@@ -224,17 +224,28 @@ fn configure_slave_offsets(
         match parent.ports.topology() {
             Topology::Fork if !slave.is_child_of(parent) => {
                 // Delays between intermediate ports on parent
-                let parent_intermediate_delays = parent.ports.intermediate_propagation_time();
+                let parent_intermediate_delays =
+                    parent.ports.intermediate_propagation_time_to(&parent_port);
+
+                dbg!(parent_intermediate_delays);
 
                 let parent_prop_time = parent.ports.total_propagation_time().unwrap_or(0);
 
                 let my_prop_time = slave.ports.total_propagation_time().unwrap_or(0);
 
-                let propagation_delay =
-                    parent_prop_time - (parent_intermediate_delays / 2) - (my_prop_time / 2);
+                let propagation_delay = (parent_prop_time - my_prop_time) / 2;
 
-                // TODO: Why is this just an assignment?
-                *delay_accum = propagation_delay;
+                // dbg!(
+                //     *delay_accum,
+                //     parent_intermediate_delays,
+                //     parent_prop_time,
+                //     my_prop_time,
+                //     (parent_prop_time - parent_intermediate_delays - my_prop_time) / 2,
+                //     (parent_prop_time - my_prop_time) / 2,
+                //     propagation_delay,
+                // );
+
+                *delay_accum += propagation_delay;
 
                 log::debug!(
                     "--> (a) Propagation delay {} ns (accum {})",
@@ -244,7 +255,10 @@ fn configure_slave_offsets(
             }
             Topology::Fork if slave.is_child_of(parent) => {
                 // Delays between intermediate ports on parent
-                let parent_intermediate_delays = parent.ports.intermediate_propagation_time();
+                let parent_intermediate_delays =
+                    parent.ports.intermediate_propagation_time_to(&parent_port);
+
+                dbg!(parent_intermediate_delays);
 
                 let parent_prop_time = parent.ports.total_propagation_time().unwrap_or(0);
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -198,6 +198,13 @@ macro_rules! unwrap_ {
     }
 }
 
+#[cfg(feature = "defmt")]
+macro_rules! unwrap_opt_ {
+    ($($x:tt)*) => {
+        ::defmt::unwrap!($($x)*)
+    };
+}
+
 #[cfg(not(feature = "defmt"))]
 macro_rules! unwrap_opt_ {
     ($arg:expr) => {

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -198,6 +198,26 @@ macro_rules! unwrap_ {
     }
 }
 
+#[cfg(not(feature = "defmt"))]
+macro_rules! unwrap_opt_ {
+    ($arg:expr) => {
+        match $arg {
+            ::core::option::Option::Some(t) => t,
+            ::core::option::Option::None => {
+                ::core::panic!("unwrap of `{}` failed: {:?}", ::core::stringify!($arg), e);
+            }
+        }
+    };
+    ($arg:expr, $($msg:expr),+ $(,)? ) => {
+        match $arg {
+            ::core::option::Option::Some(t) => t,
+            ::core::option::Option::None => {
+                ::core::panic!("unwrap of `{}` failed: {}", ::core::stringify!($arg), ::core::format_args!($($msg,)*));
+            }
+        }
+    }
+}
+
 pub(crate) use assert_ as assert;
 pub(crate) use assert_eq_ as assert_eq;
 pub(crate) use assert_ne_ as assert_ne;
@@ -212,4 +232,5 @@ pub(crate) use todo_ as todo;
 pub(crate) use trace_ as trace;
 pub(crate) use unreachable_ as unreachable;
 pub(crate) use unwrap_ as unwrap;
+pub(crate) use unwrap_opt_ as unwrap_opt;
 pub(crate) use warn_ as warn;

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -759,6 +759,8 @@ impl<'a, S> SlaveRef<'a, S> {
     }
 
     pub(crate) async fn set_eeprom_mode(&self, mode: SiiOwner) -> Result<(), Error> {
+        // ETG1000.4 Table 48 – Slave information interface access
+        // A value of 2 sets owner to Master (not PDI) and cancels access
         self.write::<u16>(RegisterAddress::SiiConfig, 2, "Write SII config literal")
             .await?;
         self.write::<u16>(

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -174,6 +174,12 @@ impl Slave {
 
     /// Check if the current slave device is a child of `parent`.
     ///
+    /// A slave device is a child of a parent if it is connected to an intermediate port of the
+    /// parent device, i.e. is not connected to the last open port. In the latter case, this is a
+    /// "downstream" device.
+    ///
+    /// # Examples
+    ///
     /// An EK1100 (parent) with an EL2004 module connected (child) as well as another EK1914 coupler
     /// (downstream) connected has one child: the EL2004.
     pub(crate) fn is_child_of(&self, parent: &Slave) -> bool {

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -181,10 +181,10 @@ impl Slave {
         // downstream devices.
         let parent_is_fork = parent.ports.topology().is_junction();
 
-        let child_port = parent.ports.port_assigned_to(self);
+        let parent_port = parent.ports.port_assigned_to(self);
 
         // Children in a fork must be connected to intermediate ports
-        let child_attached_to_last_parent_port = child_port
+        let child_attached_to_last_parent_port = parent_port
             .map(|child_port| parent.ports.is_last_port(child_port))
             .unwrap_or(false);
 

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -4,7 +4,6 @@ pub mod pdi;
 pub mod ports;
 mod types;
 
-use self::{ports::Topology, types::SlaveConfig};
 use crate::{
     al_control::AlControl,
     al_status_code::AlStatusCode,
@@ -24,7 +23,7 @@ use crate::{
     pdu_loop::{CheckWorkingCounter, PduResponse, RxFrameDataBuf},
     register::RegisterAddress,
     register::SupportFlags,
-    slave::ports::{Port, Ports},
+    slave::{ports::Ports, types::SlaveConfig},
     slave_state::SlaveState,
     sync_manager_channel::SyncManagerChannel,
     Timeouts,

--- a/src/slave/ports.rs
+++ b/src/slave/ports.rs
@@ -134,6 +134,8 @@ impl Ports {
     }
 
     /// The port of the slave that first sees EtherCAT traffic.
+    // TODO: This shouldn't return an option. A slave HAS to have a entry port if it's even
+    // discovered on the network.
     pub fn entry_port(&self) -> Option<Port> {
         self.active_ports()
             .min_by_key(|port| port.dc_receive_time)
@@ -302,6 +304,21 @@ impl Ports {
             .filter(|t| *t > 0);
 
         between_ports
+    }
+
+    /// The previous active port to the one given.
+    pub fn prev_active_port(&self, port: &Port) -> Option<&Port> {
+        let mut sub_by = 1;
+
+        while let Some(idx) = port.index().checked_sub(sub_by) {
+            if self.0[idx].active {
+                return Some(&self.0[idx]);
+            }
+
+            sub_by += 1;
+        }
+
+        None
     }
 }
 

--- a/src/slave/ports.rs
+++ b/src/slave/ports.rs
@@ -35,6 +35,8 @@ pub enum Topology {
     LineEnd,
     /// The slave device forms a fork in the topology, with 3 open ports.
     Fork,
+    /// The slave device forms a cross in the topology, with 4 open ports.
+    Cross,
 }
 
 #[derive(Default, Copy, Clone, Debug, PartialEq)]
@@ -136,8 +138,7 @@ impl Ports {
             1 => Topology::LineEnd,
             2 => Topology::Passthrough,
             3 => Topology::Fork,
-            // TODO: I need test devices!
-            4 => todo!("Cross topology not yet supported"),
+            4 => Topology::Cross,
             n => unreachable!("Invalid topology {}", n),
         }
     }

--- a/src/slave/ports.rs
+++ b/src/slave/ports.rs
@@ -1,5 +1,6 @@
+use crate::fmt;
 use crate::Slave;
-use core::fmt::{self, Debug};
+use core::fmt::Debug;
 
 /// Flags showing which ports are active or not on the slave.
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone)]
@@ -14,7 +15,8 @@ pub struct Port {
 }
 
 impl Port {
-    fn index(&self) -> usize {
+    // TODO: Un-pub
+    pub(crate) fn index(&self) -> usize {
         match self.number {
             0 => 0,
             3 => 1,
@@ -39,12 +41,18 @@ pub enum Topology {
     Cross,
 }
 
+impl Topology {
+    pub fn is_junction(&self) -> bool {
+        matches!(self, Self::Fork | Self::Cross)
+    }
+}
+
 #[derive(Default, Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Ports(pub [Port; 4]);
 
-impl fmt::Display for Ports {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Display for Ports {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("ports [ ")?;
 
         for p in self.0 {
@@ -62,11 +70,66 @@ impl fmt::Display for Ports {
 }
 
 impl Ports {
+    pub(crate) fn new(active0: bool, active3: bool, active1: bool, active2: bool) -> Self {
+        Self([
+            Port {
+                active: active0,
+                number: 0,
+                ..Port::default()
+            },
+            Port {
+                active: active3,
+                number: 3,
+                ..Port::default()
+            },
+            Port {
+                active: active1,
+                number: 1,
+                ..Port::default()
+            },
+            Port {
+                active: active2,
+                number: 2,
+                ..Port::default()
+            },
+        ])
+    }
+
+    /// Set port DC receive times, given in EtherCAT port order 0 -> 3 -> 1 -> 2
+    pub(crate) fn set_receive_times(
+        &mut self,
+        time_p0: u32,
+        time_p3: u32,
+        time_p1: u32,
+        time_p2: u32,
+    ) {
+        // NOTE: indexes vs EtherCAT port order
+        self.0[0].dc_receive_time = time_p0;
+        self.0[1].dc_receive_time = time_p3;
+        self.0[2].dc_receive_time = time_p1;
+        self.0[3].dc_receive_time = time_p2;
+    }
+
+    /// TEST ONLY: Set downstream ports.
+    #[cfg(test)]
+    pub(crate) fn set_downstreams(
+        &mut self,
+        d0: Option<usize>,
+        d3: Option<usize>,
+        d1: Option<usize>,
+        d2: Option<usize>,
+    ) {
+        self.0[0].downstream_to = d0;
+        self.0[1].downstream_to = d3;
+        self.0[2].downstream_to = d1;
+        self.0[3].downstream_to = d2;
+    }
+
     fn open_ports(&self) -> u8 {
         self.active_ports().count() as u8
     }
 
-    fn active_ports(&self) -> impl Iterator<Item = &Port> {
+    fn active_ports(&self) -> impl Iterator<Item = &Port> + Clone {
         self.0.iter().filter(|port| port.active)
     }
 
@@ -83,37 +146,26 @@ impl Ports {
     }
 
     /// Find the next port that hasn't already been assigned as the upstream port of another slave.
-    fn next_assignable_port(&mut self, port: &Port) -> Option<&mut Port> {
-        let mut index = port.index();
+    fn next_assignable_port(&mut self, this_port: &Port) -> Option<&mut Port> {
+        let this_port_index = this_port.index();
 
-        for _ in 0..4 {
-            index = (index + 1) % 4;
+        let next_port_index = self
+            .active_ports()
+            .cycle()
+            // Start at the next port
+            .skip(this_port_index + 1)
+            .take(4)
+            .find(|next_port| next_port.downstream_to.is_none())?
+            .index();
 
-            let next_port = self.0[index];
-
-            if next_port.active && next_port.downstream_to.is_none() {
-                break;
-            }
-        }
-
-        self.0.get_mut(index)
+        self.0.get_mut(next_port_index)
     }
 
     /// Find the next open port after the given port.
     fn next_open_port(&self, port: &Port) -> Option<&Port> {
-        let mut index = port.index();
+        let index = port.index();
 
-        for _ in 0..4 {
-            index = (index + 1) % 4;
-
-            let next_port = &self.0[index];
-
-            if next_port.active {
-                return Some(next_port);
-            }
-        }
-
-        None
+        self.active_ports().cycle().skip(index + 1).next()
     }
 
     /// Link a downstream device to the current device using the next open port from the entry port.
@@ -151,7 +203,7 @@ impl Ports {
     /// children.
     ///
     /// Returns `None` if the current node is not a fork.
-    pub fn child_delay(&self) -> Option<u32> {
+    pub fn fork_child_delay(&self) -> Option<u32> {
         if self.topology() == Topology::Fork {
             let input_port = self.entry_port()?;
 
@@ -159,7 +211,9 @@ impl Ports {
             // port after the input.
             let children_port = self.next_open_port(&input_port)?;
 
-            Some(children_port.dc_receive_time - input_port.dc_receive_time)
+            // Some(children_port.dc_receive_time - input_port.dc_receive_time)
+
+            self.propagation_time_to(children_port)
         } else {
             None
         }
@@ -167,7 +221,7 @@ impl Ports {
 
     /// The time in nanoseconds for a packet to completely traverse all active ports of a slave
     /// device.
-    pub fn propagation_time(&self) -> Option<u32> {
+    pub fn total_propagation_time(&self) -> Option<u32> {
         let times = self
             .0
             .iter()
@@ -179,6 +233,28 @@ impl Ports {
             .and_then(|max| times.min().map(|min| max - min))
             .filter(|t| *t > 0)
     }
+
+    /// Get the propagation time taken from entry to this slave device up to the given port.
+    pub fn propagation_time_to(&self, this_port: &Port) -> Option<u32> {
+        // If we don't have an entry port we can't be connected to the network so this is probably a
+        // logic bug and should panic.
+        let entry_port =
+            crate::fmt::unwrap_opt!(self.entry_port(), "no entry port. Likely a logic bug");
+
+        // Find active ports between entry and this one
+        let times = self
+            .active_ports()
+            .filter(|port| port.index() >= entry_port.index() && port.index() <= this_port.index())
+            .map(|port| port.dc_receive_time);
+
+        let between_ports = times
+            .clone()
+            .max()
+            .and_then(|max| times.min().map(|min| max - min))
+            .filter(|t| *t > 0);
+
+        between_ports
+    }
 }
 
 #[cfg(test)]
@@ -188,32 +264,14 @@ pub mod tests {
     const ENTRY_RECEIVE: u32 = 1234;
 
     pub(crate) fn make_ports(active0: bool, active3: bool, active1: bool, active2: bool) -> Ports {
-        Ports([
-            Port {
-                active: active0,
-                number: 0,
-                dc_receive_time: ENTRY_RECEIVE,
-                ..Port::default()
-            },
-            Port {
-                active: active3,
-                number: 3,
-                dc_receive_time: ENTRY_RECEIVE + 100,
-                ..Port::default()
-            },
-            Port {
-                active: active1,
-                number: 1,
-                dc_receive_time: ENTRY_RECEIVE + 200,
-                ..Port::default()
-            },
-            Port {
-                active: active2,
-                number: 2,
-                dc_receive_time: ENTRY_RECEIVE + 300,
-                ..Port::default()
-            },
-        ])
+        let mut ports = Ports::new(active0, active3, active1, active2);
+
+        ports.0[0].dc_receive_time = ENTRY_RECEIVE;
+        ports.0[1].dc_receive_time = ENTRY_RECEIVE + 100;
+        ports.0[2].dc_receive_time = ENTRY_RECEIVE + 200;
+        ports.0[3].dc_receive_time = ENTRY_RECEIVE + 300;
+
+        ports
     }
 
     #[test]
@@ -261,7 +319,7 @@ pub mod tests {
         // Passthrough slave
         let ports = make_ports(true, true, false, false);
 
-        assert_eq!(ports.propagation_time(), Some(100));
+        assert_eq!(ports.total_propagation_time(), Some(100));
     }
 
     #[test]
@@ -269,7 +327,16 @@ pub mod tests {
         // Fork, e.g. EK1100 with modules AND downstream devices
         let ports = make_ports(true, true, true, false);
 
-        assert_eq!(ports.propagation_time(), Some(200));
+        assert_eq!(ports.total_propagation_time(), Some(200));
+    }
+
+    #[test]
+    fn propagation_time_cross() {
+        // Cross, e.g. EK1122 in a module chain with both ports connected
+        let ports = make_ports(true, true, true, true);
+
+        assert_eq!(ports.topology(), Topology::Cross);
+        assert_eq!(ports.total_propagation_time(), Some(300));
     }
 
     #[test]
@@ -279,13 +346,23 @@ pub mod tests {
         // Normal slave has no children, so no child delay
         let passthrough = make_ports(true, true, false, false);
 
-        assert_eq!(ports.child_delay(), Some(100));
-        assert_eq!(passthrough.child_delay(), None);
+        assert_eq!(ports.fork_child_delay(), Some(100));
+        assert_eq!(passthrough.fork_child_delay(), None);
     }
 
     #[test]
     fn assign_downstream_port() {
         let mut ports = make_ports(true, true, true, false);
+
+        assert_eq!(
+            ports.entry_port(),
+            Some(Port {
+                active: true,
+                dc_receive_time: ENTRY_RECEIVE,
+                number: 0,
+                downstream_to: None
+            })
+        );
 
         let port_number = ports.assign_next_downstream_port(1);
 
@@ -294,5 +371,36 @@ pub mod tests {
         let port_number = ports.assign_next_downstream_port(2);
 
         assert_eq!(port_number, Some(1), "assign slave idx 2");
+
+        pretty_assertions::assert_eq!(
+            ports,
+            Ports([
+                // Entry port
+                Port {
+                    active: true,
+                    dc_receive_time: ENTRY_RECEIVE,
+                    number: 0,
+                    downstream_to: None,
+                },
+                Port {
+                    active: true,
+                    dc_receive_time: ENTRY_RECEIVE + 100,
+                    number: 3,
+                    downstream_to: Some(1),
+                },
+                Port {
+                    active: true,
+                    dc_receive_time: ENTRY_RECEIVE + 200,
+                    number: 1,
+                    downstream_to: Some(2),
+                },
+                Port {
+                    active: false,
+                    dc_receive_time: ENTRY_RECEIVE + 300,
+                    number: 2,
+                    downstream_to: None,
+                }
+            ])
+        )
     }
 }

--- a/src/slave/ports.rs
+++ b/src/slave/ports.rs
@@ -234,6 +234,42 @@ impl Ports {
             .filter(|t| *t > 0)
     }
 
+    /// Propagation time between active ports in this slave.
+    pub fn intermediate_propagation_time(&self) -> u32 {
+        // let time_p0 = self.0[0].dc_receive_time;
+        // let time_p3 = self.0[1].dc_receive_time;
+        // let time_p1 = self.0[2].dc_receive_time;
+        // let time_p2 = self.0[3].dc_receive_time;
+
+        // // Deltas between port receive times
+        // let d03 = time_p3.saturating_sub(time_p0);
+        // let d31 = time_p1.saturating_sub(time_p3);
+        // let d12 = time_p2.saturating_sub(time_p1);
+
+        // let d03 = if self.0[1].active { d03 } else { 0 };
+        // let d31 = if self.0[2].active { d31 } else { 0 };
+        // let d12 = if self.0[3].active { d12 } else { 0 };
+
+        // d03 + d31 + d12
+
+        // If a pair of ports is open, they have a propagation delta between them, and we can sum these deltas up to get the child delays of this slave (fork or cross have children)
+        self.0
+            .windows(2)
+            .map(|window| {
+                let [a, b] = window else {
+            return 0
+        };
+
+                // Both ports must be active to have a delta
+                if a.active && b.active {
+                    b.dc_receive_time.saturating_sub(a.dc_receive_time)
+                } else {
+                    0
+                }
+            })
+            .sum::<u32>()
+    }
+
     /// Get the propagation time taken from entry to this slave device up to the given port.
     pub fn propagation_time_to(&self, this_port: &Port) -> Option<u32> {
         // If we don't have an entry port we can't be connected to the network so this is probably a

--- a/src/slave/ports.rs
+++ b/src/slave/ports.rs
@@ -234,31 +234,43 @@ impl Ports {
             .filter(|t| *t > 0)
     }
 
+    // /// Propagation time between active ports in this slave.
+    // pub fn intermediate_propagation_time(&self) -> u32 {
+    //     // If a pair of ports is open, they have a propagation delta between them, and we can sum
+    //     // these deltas up to get the child delays of this slave (fork or cross have children)
+    //     self.0
+    //         .windows(2)
+    //         .map(|window| {
+    //             let [a, b] = window else {
+    //                 return 0
+    //             };
+
+    //             // Both ports must be active to have a delta
+    //             if a.active && b.active {
+    //                 b.dc_receive_time.saturating_sub(a.dc_receive_time)
+    //             } else {
+    //                 0
+    //             }
+    //         })
+    //         .sum::<u32>()
+    // }
+
     /// Propagation time between active ports in this slave.
-    pub fn intermediate_propagation_time(&self) -> u32 {
-        // let time_p0 = self.0[0].dc_receive_time;
-        // let time_p3 = self.0[1].dc_receive_time;
-        // let time_p1 = self.0[2].dc_receive_time;
-        // let time_p2 = self.0[3].dc_receive_time;
-
-        // // Deltas between port receive times
-        // let d03 = time_p3.saturating_sub(time_p0);
-        // let d31 = time_p1.saturating_sub(time_p3);
-        // let d12 = time_p2.saturating_sub(time_p1);
-
-        // let d03 = if self.0[1].active { d03 } else { 0 };
-        // let d31 = if self.0[2].active { d31 } else { 0 };
-        // let d12 = if self.0[3].active { d12 } else { 0 };
-
-        // d03 + d31 + d12
-
-        // If a pair of ports is open, they have a propagation delta between them, and we can sum these deltas up to get the child delays of this slave (fork or cross have children)
+    pub fn intermediate_propagation_time_to(&self, port: &Port) -> u32 {
+        // If a pair of ports is open, they have a propagation delta between them, and we can sum
+        // these deltas up to get the child delays of this slave (fork or cross have children)
         self.0
             .windows(2)
             .map(|window| {
+                // Silly Rust
                 let [a, b] = window else {
-            return 0
-        };
+                    return 0
+                };
+
+                // Stop iterating as we've summed everything before the target port
+                if a.index() > port.index() {
+                    return 0;
+                }
 
                 // Both ports must be active to have a delta
                 if a.active && b.active {

--- a/src/slave/ports.rs
+++ b/src/slave/ports.rs
@@ -118,11 +118,13 @@ impl Ports {
         d3: Option<usize>,
         d1: Option<usize>,
         d2: Option<usize>,
-    ) {
+    ) -> Self {
         self.0[0].downstream_to = d0;
         self.0[1].downstream_to = d3;
         self.0[2].downstream_to = d1;
         self.0[3].downstream_to = d2;
+
+        *self
     }
 
     fn open_ports(&self) -> u8 {


### PR DESCRIPTION
This was a nice rabbit hole as the already existing topology propagation times weren't being calculated correctly either. I think.

Cross topo, e.g. with EK1122 is supported now, and should have the correct propagation times.