### PR TITLE
Reduce code size for `no-std` just slightly

### DIFF
--- a/examples/discover.rs
+++ b/examples/discover.rs
@@ -2,7 +2,7 @@
 
 use env_logger::Env;
 use ethercrab::{std::tx_rx_task, Client, ClientConfig, PduStorage, Timeouts};
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 /// Maximum number of slaves that can be stored. This must be a power of 2 greater than 1.
 const MAX_SLAVES: usize = 128;

--- a/examples/embassy-stm32/Cargo.toml
+++ b/examples/embassy-stm32/Cargo.toml
@@ -57,6 +57,8 @@ embassy-net = { version = "0.1.0", features = [
 [profile.release]
 debug = 2
 opt-level = "z"
+lto = true
+codegen-units = 1
 
 [patch.crates-io]
 embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "fcbfd22" }

--- a/src/al_status_code.rs
+++ b/src/al_status_code.rs
@@ -1,5 +1,5 @@
+use crate::fmt;
 use crate::pdu_data::PduRead;
-use core::fmt;
 
 /// AL (Application Layer) Status Code.
 ///
@@ -127,14 +127,14 @@ impl PduRead for AlStatusCode {
     type Error = ();
 
     fn try_from_slice(slice: &[u8]) -> Result<Self, Self::Error> {
-        let data = u16::from_le_bytes(slice.try_into().unwrap());
+        let data = u16::from_le_bytes(fmt::unwrap!(slice.try_into()));
 
         Ok(Self::from(data))
     }
 }
 
-impl fmt::Display for AlStatusCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Display for AlStatusCode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let s = match self {
             AlStatusCode::NoError => "0x0000: No error",
             AlStatusCode::UnspecifiedError => "0x0001: Unspecified error",

--- a/src/client.rs
+++ b/src/client.rs
@@ -98,7 +98,9 @@ impl<'sto> Client<'sto> {
         // Reset slaves to init
         self.bwr(
             RegisterAddress::AlControl,
-            AlControl::reset().pack().unwrap(),
+            fmt::unwrap!(AlControl::reset()
+                .pack()
+                .map_err(crate::error::WrappedPackingError::from)),
         )
         .await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -62,15 +62,15 @@ impl<'sto> Client<'sto> {
     /// Calling this method internally increments the counter, so subequent calls will produce a new
     /// value.
     pub(crate) fn mailbox_counter(&self) -> u8 {
-        self.mailbox_counter
+        fmt::unwrap!(self
+            .mailbox_counter
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
                 if n >= 7 {
                     Some(1)
                 } else {
                     Some(n + 1)
                 }
-            })
-            .unwrap()
+            }))
     }
 
     /// Write zeroes to every slave's memory in chunks.

--- a/src/ds402.rs
+++ b/src/ds402.rs
@@ -161,7 +161,7 @@ impl<'a> Ds402<'a> {
 
     /// Get the DS402 status word.
     pub fn status_word(&self) -> StatusWord {
-        let status = u16::from_le_bytes(self.slave.inputs_raw()[0..=1].try_into().unwrap());
+        let status = u16::from_le_bytes(fmt::unwrap!(self.slave.inputs_raw()[0..=1].try_into()));
 
         StatusWord::from_bits_truncate(status)
     }

--- a/src/eeprom/reader.rs
+++ b/src/eeprom/reader.rs
@@ -39,8 +39,8 @@ impl EepromSectionReader {
             let chunk = Self::read_eeprom_raw(slave, start_word).await?;
 
             let category_type =
-                CategoryType::from(u16::from_le_bytes(chunk[0..2].try_into().unwrap()));
-            let len_words = u16::from_le_bytes(chunk[2..4].try_into().unwrap());
+                CategoryType::from(u16::from_le_bytes(fmt::unwrap!(chunk[0..2].try_into())));
+            let len_words = u16::from_le_bytes(fmt::unwrap!(chunk[2..4].try_into()));
 
             // Position after header
             start_word += 2;

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -211,7 +211,7 @@ macro_rules! unwrap_opt_ {
         match $arg {
             ::core::option::Option::Some(t) => t,
             ::core::option::Option::None => {
-                ::core::panic!("unwrap of `{}` failed: {:?}", ::core::stringify!($arg), e);
+                ::core::panic!("unwrap of `{}` failed", ::core::stringify!($arg));
             }
         }
     };

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -2,6 +2,7 @@
 //!
 //! Like cookie_factory but much simpler and will quite happily panic.
 
+use crate::fmt;
 use packed_struct::{PackedStructInfo, PackedStructSlice};
 
 /// Write a `u16`, little-endian.
@@ -29,7 +30,9 @@ where
 {
     let (buf, rest) = buf.split_at_mut(T::packed_bits() / 8);
 
-    value.pack_to_slice(buf).unwrap();
+    fmt::unwrap!(value
+        .pack_to_slice(buf)
+        .map_err(crate::error::WrappedPackingError::from));
 
     rest
 }

--- a/src/slave/configuration.rs
+++ b/src/slave/configuration.rs
@@ -241,7 +241,9 @@ where
 
         self.write(
             RegisterAddress::sync_manager(sync_manager_index),
-            sm_config.pack().unwrap(),
+            fmt::unwrap!(sm_config
+                .pack()
+                .map_err(crate::error::WrappedPackingError::from)),
             "SM config",
         )
         .await?;
@@ -412,7 +414,7 @@ where
                     // data fields.
                     let parts = mapping.to_be_bytes();
 
-                    let index = u16::from_be_bytes(parts[0..=1].try_into().unwrap());
+                    let index = u16::from_be_bytes(fmt::unwrap!(parts[0..=1].try_into()));
                     let sub_index = parts[2];
                     let mapping_bit_len = parts[3];
 
@@ -503,7 +505,9 @@ where
 
         self.write(
             RegisterAddress::fmmu(fmmu_index as u8),
-            fmmu_config.pack().unwrap(),
+            fmt::unwrap!(fmmu_config
+                .pack()
+                .map_err(crate::error::WrappedPackingError::from)),
             "PDI FMMU",
         )
         .await?;

--- a/src/slave_group/configurator.rs
+++ b/src/slave_group/configurator.rs
@@ -34,7 +34,7 @@ impl<'a> SlaveGroupRef<'a> {
         Self {
             max_pdi_len: MAX_PDI,
             inner: {
-                let inner = unsafe { group.inner.get().as_mut().unwrap() };
+                let inner = unsafe { fmt::unwrap_opt!(group.inner.get().as_mut()) };
 
                 GroupInnerRef {
                     slaves: &mut inner.slaves,


### PR DESCRIPTION
```bash
cd examples/embassy-stm32
cargo size --release
```

`master`:

```
   text    data     bss     dec     hex filename
 141016     112   50612  191740   2ecfc ethercrab-stm32-embassy
```

This PR:

```
   text    data     bss     dec     hex filename
 111056     112   50560  161728   277c0 ethercrab-stm32-embassy
```