### PR TITLE
Reintroduce `SlaveClient`, size-optimise EEPROM

### DIFF
--- a/src/dc.rs
+++ b/src/dc.rs
@@ -6,7 +6,7 @@ use crate::{
     fmt,
     pdu_loop::CheckWorkingCounter,
     register::RegisterAddress,
-    slave::{ports::Topology, Slave, SlaveRef},
+    slave::{ports::Topology, slave_client::SlaveClient, Slave},
     Client,
 };
 
@@ -25,7 +25,7 @@ async fn latch_dc_times(client: &Client<'_>, slaves: &mut [Slave]) -> Result<(),
 
     // Read receive times for all slaves and store on slave structs
     for slave in slaves.iter_mut().filter(|slave| slave.flags.dc_supported) {
-        let sl = SlaveRef::new(client, slave.configured_address, ());
+        let sl = SlaveClient::new(client, slave.configured_address);
 
         // NOTE: Defined as a u64, not i64, in the spec
         // TODO: Remember why this is i64 here. SOEM uses i64 I think, and I seem to remember things

--- a/src/slave/configuration.rs
+++ b/src/slave/configuration.rs
@@ -45,7 +45,7 @@ where
 
         fmt::debug!(
             "Slave {:#06x} mailbox SMs configured. Transitioning to PRE-OP",
-            self.configured_address
+            self.client.configured_address
         );
 
         self.request_slave_state(SlaveState::PreOp).await?;
@@ -94,7 +94,7 @@ where
 
             fmt::debug!(
                 "Slave {:#06x} found sync managers {:?}",
-                self.configured_address,
+                self.client.configured_address,
                 sms
             );
 
@@ -239,14 +239,15 @@ where
             },
         };
 
-        self.write_slice(
-            RegisterAddress::sync_manager(sync_manager_index).into(),
-            &fmt::unwrap!(sm_config
-                .pack()
-                .map_err(crate::error::WrappedPackingError::from)),
-            "SM config",
-        )
-        .await?;
+        self.client
+            .write_slice(
+                RegisterAddress::sync_manager(sync_manager_index).into(),
+                &fmt::unwrap!(sm_config
+                    .pack()
+                    .map_err(crate::error::WrappedPackingError::from)),
+                "SM config",
+            )
+            .await?;
 
         fmt::debug!(
             "Slave {:#06x} SM{}: {}",
@@ -477,6 +478,7 @@ where
     ) -> Result<(), Error> {
         // Multiple SMs may use the same FMMU, so we'll read the existing config from the slave
         let mut fmmu_config = self
+            .client
             .read_slice(
                 RegisterAddress::fmmu(fmmu_index as u8).into(),
                 16,
@@ -507,14 +509,15 @@ where
             }
         };
 
-        self.write_slice(
-            RegisterAddress::fmmu(fmmu_index as u8).into(),
-            &fmt::unwrap!(fmmu_config
-                .pack()
-                .map_err(crate::error::WrappedPackingError::from)),
-            "PDI FMMU",
-        )
-        .await?;
+        self.client
+            .write_slice(
+                RegisterAddress::fmmu(fmmu_index as u8).into(),
+                &fmt::unwrap!(fmmu_config
+                    .pack()
+                    .map_err(crate::error::WrappedPackingError::from)),
+                "PDI FMMU",
+            )
+            .await?;
         fmt::debug!(
             "Slave {:#06x} FMMU{}: {}",
             self.state.configured_address,

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -22,13 +22,12 @@ use crate::{
     fmt,
     mailbox::MailboxType,
     pdu_data::{PduData, PduRead},
-    pdu_loop::{CheckWorkingCounter, PduResponse, RxFrameDataBuf},
+    pdu_loop::{CheckWorkingCounter, RxFrameDataBuf},
     register::RegisterAddress,
     register::SupportFlags,
     slave::{ports::Ports, types::SlaveConfig},
     slave_state::SlaveState,
     sync_manager_channel::SyncManagerChannel,
-    Timeouts,
 };
 use core::{
     any::type_name,

--- a/src/slave/slave_client.rs
+++ b/src/slave/slave_client.rs
@@ -1,0 +1,98 @@
+use crate::{
+    error::Error,
+    pdu_data::{PduData, PduRead},
+    pdu_loop::{CheckWorkingCounter, PduResponse, RxFrameDataBuf},
+    Client, Command, Timeouts,
+};
+
+#[derive(Debug)]
+pub struct SlaveClient<'client> {
+    pub configured_address: u16,
+    pub client: &'client Client<'client>,
+}
+
+impl<'client> SlaveClient<'client> {
+    pub(crate) fn new(client: &'client Client<'client>, configured_address: u16) -> Self {
+        Self {
+            configured_address,
+            client,
+        }
+    }
+
+    pub fn timeouts(&self) -> &Timeouts {
+        &self.client.timeouts
+    }
+
+    pub(crate) async fn read_ignore_wkc<T>(&self, register: u16) -> Result<PduResponse<T>, Error>
+    where
+        T: PduRead,
+    {
+        Command::fprd(self.configured_address, register)
+            .receive(&self.client)
+            .await
+    }
+
+    /// A wrapper around an FPWR service to this slave's configured address.
+    pub(crate) async fn write_ignore_wkc<T>(
+        &self,
+        register: u16,
+        value: T,
+    ) -> Result<PduResponse<T>, Error>
+    where
+        T: PduData,
+    {
+        Command::fpwr(self.configured_address, register)
+            .send_receive(&self.client, value)
+            .await
+    }
+
+    pub(crate) async fn read<T>(&self, register: u16, context: &'static str) -> Result<T, Error>
+    where
+        T: PduRead,
+    {
+        Command::fprd(self.configured_address, register)
+            .receive(&self.client)
+            .await?
+            .wkc(1, context)
+    }
+
+    pub(crate) async fn read_slice(
+        &self,
+        register: u16,
+        len: u16,
+        context: &'static str,
+    ) -> Result<RxFrameDataBuf<'_>, Error> {
+        Command::fprd(self.configured_address, register)
+            .receive_slice(&self.client, len)
+            .await?
+            .wkc(1, context)
+    }
+
+    pub(crate) async fn write_slice(
+        &self,
+        register: u16,
+        value: &[u8],
+        context: &'static str,
+    ) -> Result<RxFrameDataBuf<'_>, Error> {
+        Command::fpwr(self.configured_address, register)
+            .send_receive_slice(&self.client, value)
+            .await?
+            .wkc(1, context)
+    }
+
+    /// A wrapper around an FPWR service to this slave's configured address, ignoring any response.
+    pub(crate) async fn write<T>(
+        &self,
+        register: u16,
+        value: T,
+        context: &'static str,
+    ) -> Result<(), Error>
+    where
+        T: PduData,
+    {
+        Command::fpwr(self.configured_address, register)
+            .send(&self.client, value)
+            .await?
+            .wkc(1, context)
+    }
+}

--- a/src/slave/slave_client.rs
+++ b/src/slave/slave_client.rs
@@ -12,6 +12,7 @@ pub struct SlaveClient<'client> {
 }
 
 impl<'client> SlaveClient<'client> {
+    #[inline(always)]
     pub(crate) fn new(client: &'client Client<'client>, configured_address: u16) -> Self {
         Self {
             configured_address,
@@ -19,10 +20,12 @@ impl<'client> SlaveClient<'client> {
         }
     }
 
+    #[inline(always)]
     pub fn timeouts(&self) -> &Timeouts {
         &self.client.timeouts
     }
 
+    #[inline(always)]
     pub(crate) async fn read_ignore_wkc<T>(&self, register: u16) -> Result<PduResponse<T>, Error>
     where
         T: PduRead,
@@ -33,6 +36,7 @@ impl<'client> SlaveClient<'client> {
     }
 
     /// A wrapper around an FPWR service to this slave's configured address.
+    #[inline(always)]
     pub(crate) async fn write_ignore_wkc<T>(
         &self,
         register: u16,
@@ -46,6 +50,7 @@ impl<'client> SlaveClient<'client> {
             .await
     }
 
+    #[inline(always)]
     pub(crate) async fn read<T>(&self, register: u16, context: &'static str) -> Result<T, Error>
     where
         T: PduRead,
@@ -56,6 +61,7 @@ impl<'client> SlaveClient<'client> {
             .wkc(1, context)
     }
 
+    #[inline(always)]
     pub(crate) async fn read_slice(
         &self,
         register: u16,
@@ -68,6 +74,7 @@ impl<'client> SlaveClient<'client> {
             .wkc(1, context)
     }
 
+    #[inline(always)]
     pub(crate) async fn write_slice(
         &self,
         register: u16,
@@ -81,6 +88,7 @@ impl<'client> SlaveClient<'client> {
     }
 
     /// A wrapper around an FPWR service to this slave's configured address, ignoring any response.
+    #[inline(always)]
     pub(crate) async fn write<T>(
         &self,
         register: u16,


### PR DESCRIPTION
Split `SlaveClient` from `SlaveRef`. This removes a generic, so code size is reduced from less monomorphisation. 

Also some EEPROM code size optimisations.

`master`

```
   text    data     bss     dec     hex filename
  96012     112   50560  146684   23cfc ethercrab-stm32-embassy
```

This PR

```
   text    data     bss     dec     hex filename
  90604     112   50560  141276   227dc ethercrab-stm32-embassy
```