### PR TITLE
Release in-flight frames when the send fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,18 +82,20 @@ target_steps_no_std: &target_steps_no_std
           - /home/circleci/.cargo/registry
 
 target_steps_embassy: &target_steps_embassy
-  working_directory: ~/project/examples/embassy-stm32
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
     - image: cimg/rust:1.72
   steps:
     - checkout
     - restore_cache:
-        key: v4-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
-    - run: cargo build --release
+        key: v5-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+    - run: |
+        cd examples/embassy-stm32
+
+        cargo build --release
 
     - save_cache:
-        key: v4-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+        key: v5-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
         paths:
           - ./target
           - /home/circleci/.cargo/registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 target_steps: &target_steps
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.71
+    - image: cimg/rust:1.72
   steps:
     - checkout
     - restore_cache:
@@ -42,7 +42,7 @@ target_steps: &target_steps
 miri_steps: &miri_steps
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.71
+    - image: cimg/rust:1.72
   steps:
     - checkout
     - run: sudo apt update && sudo apt install -y libpcap-dev
@@ -65,7 +65,7 @@ miri_steps: &miri_steps
 target_steps_no_std: &target_steps_no_std
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.71
+    - image: cimg/rust:1.72
   steps:
     - checkout
     - restore_cache:
@@ -85,7 +85,7 @@ target_steps_embassy: &target_steps_embassy
   working_directory: ~/project/examples/embassy-stm32
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.71
+    - image: cimg/rust:1.72
   steps:
     - checkout
     - restore_cache:
@@ -102,7 +102,7 @@ macos_steps: &macos_steps
   resource_class: large
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.71
+    - image: cimg/rust:1.72
   steps:
     - checkout
     - restore_cache:
@@ -137,7 +137,7 @@ jobs:
     resource_class: large
     docker:
       # NOTE: Exact version is overridden in `rust-toolchain.toml`
-      - image: cimg/rust:1.71
+      - image: cimg/rust:1.72
     steps:
       - checkout
       - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ An EtherCAT master written in Rust.
 ### Changed
 
 - [#92] If no slave devices are detected, `Client::init` will no longer exit with an error.
+- **(breaking)** [#TODO] `SendableFrame::send_blocking` and `SendableFrame::send` must now return
+  the number of bytes sent over the network.
+- **(breaking)** [#TODO] `SendableFrame::write_ethernet_packet` is no longer `pub`. Instead, use
+  `SendableFrame::send_blocking` or `SendableFrame::send`.
 
 ### Removed
 
@@ -180,5 +184,6 @@ An EtherCAT master written in Rust.
 [#91]: https://github.com/ethercrab-rs/ethercrab/pull/91
 [#92]: https://github.com/ethercrab-rs/ethercrab/pull/92
 [#99]: https://github.com/ethercrab-rs/ethercrab/pull/99
+[#TODO]: https://github.com/ethercrab-rs/ethercrab/pull/TODO
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ An EtherCAT master written in Rust.
 ### Changed
 
 - [#92] If no slave devices are detected, `Client::init` will no longer exit with an error.
-- **(breaking)** [#TODO] `SendableFrame::send_blocking` and `SendableFrame::send` must now return
-  the number of bytes sent over the network.
-- **(breaking)** [#TODO] `SendableFrame::write_ethernet_packet` is no longer `pub`. Instead, use
+- **(breaking)** [#101] `SendableFrame::send_blocking` and `SendableFrame::send` must now return the
+  number of bytes sent over the network.
+- **(breaking)** [#101] `SendableFrame::write_ethernet_packet` is no longer `pub`. Instead, use
   `SendableFrame::send_blocking` or `SendableFrame::send`.
 
 ### Removed
@@ -184,6 +184,6 @@ An EtherCAT master written in Rust.
 [#91]: https://github.com/ethercrab-rs/ethercrab/pull/91
 [#92]: https://github.com/ethercrab-rs/ethercrab/pull/92
 [#99]: https://github.com/ethercrab-rs/ethercrab/pull/99
-[#TODO]: https://github.com/ethercrab-rs/ethercrab/pull/TODO
+[#101]: https://github.com/ethercrab-rs/ethercrab/pull/101
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/benches/pdu_loop.rs
+++ b/benches/pdu_loop.rs
@@ -30,7 +30,7 @@ fn do_bench(b: &mut Bencher) {
                 .send(&mut packet_buf, |bytes| async {
                     written_packet.copy_from_slice(bytes);
 
-                    Ok(())
+                    Ok(bytes.len())
                 })
                 .await
                 .unwrap();

--- a/benches/pdu_loop.rs
+++ b/benches/pdu_loop.rs
@@ -19,7 +19,7 @@ fn do_bench(b: &mut Bencher) {
         //  --- Prepare frame
 
         let frame_fut =
-            pdu_loop.pdu_tx_readwrite(Command::Write(Command::fpwr(0x5678, 0x1234)), &DATA);
+            pdu_loop.pdu_tx_readwrite(Command::Write(Command::fpwr(0x5678, 0x1234)), &DATA, None);
 
         // --- Send frame
 

--- a/benches/pdu_loop.rs
+++ b/benches/pdu_loop.rs
@@ -1,3 +1,4 @@
+use core::time::Duration;
 use criterion::{criterion_group, criterion_main, Bencher, Criterion, Throughput};
 use ethercrab::{Command, PduStorage};
 
@@ -18,8 +19,11 @@ fn do_bench(b: &mut Bencher) {
     b.iter(|| {
         //  --- Prepare frame
 
-        let frame_fut =
-            pdu_loop.pdu_tx_readwrite(Command::Write(Command::fpwr(0x5678, 0x1234)), &DATA, None);
+        let frame_fut = pdu_loop.pdu_tx_readwrite(
+            Command::Write(Command::fpwr(0x5678, 0x1234)),
+            &DATA,
+            Duration::from_secs(1),
+        );
 
         // --- Send frame
 

--- a/benches/pdu_loop.rs
+++ b/benches/pdu_loop.rs
@@ -19,11 +19,8 @@ fn do_bench(b: &mut Bencher) {
     b.iter(|| {
         //  --- Prepare frame
 
-        let frame_fut = pdu_loop.pdu_tx_readwrite(
-            Command::Write(Command::fpwr(0x5678, 0x1234)),
-            &DATA,
-            Duration::from_secs(1),
-        );
+        let frame_fut =
+            pdu_loop.pdu_tx_readwrite(Command::fpwr(0x5678, 0x1234), &DATA, Duration::from_secs(1));
 
         // --- Send frame
 

--- a/benches/pdu_loop.rs
+++ b/benches/pdu_loop.rs
@@ -50,7 +50,7 @@ fn do_bench(b: &mut Bencher) {
 }
 
 pub fn tx_rx(c: &mut Criterion) {
-    let mut group = c.benchmark_group("pdu-loop");
+    let mut group = c.benchmark_group("pdu_loop");
 
     group.throughput(Throughput::Elements(1));
 

--- a/examples/embassy-stm32/src/main.rs
+++ b/examples/embassy-stm32/src/main.rs
@@ -47,11 +47,11 @@ async fn tx_rx_task(
     fn send_ecat(tx: embassy_stm32::eth::TxToken<'_, '_>, frame: SendableFrame<'_>) {
         tx.consume(frame.len(), |tx_buf| {
             defmt::unwrap!(frame
-                .send_blocking(tx_buf, |_ethernet_frame| {
+                .send_blocking(tx_buf, |ethernet_frame| {
                     // Frame is copied into `tx_buf` inside `send_blocking` so we don't need to do
                     // anything here. The frame is sent once the outer closure in `tx.consume` ends.
 
-                    Ok(())
+                    Ok(ethernet_frame.len())
                 })
                 .map_err(|e| defmt::error!("Send blocking: {}", e)));
         });

--- a/src/client.rs
+++ b/src/client.rs
@@ -449,7 +449,8 @@ impl<'sto> Client<'sto> {
         timeout(
             self.timeouts.pdu,
             // TODO: Bit weird to re-wrap the read in a `Command` but whatever
-            self.pdu_loop.pdu_tx_readonly(Command::Read(command), len),
+            self.pdu_loop
+                .pdu_tx_readonly(Command::Read(command), len, self.timeouts.pdu),
         )
         .await
         .map(|response| response.into_data())

--- a/src/client.rs
+++ b/src/client.rs
@@ -460,19 +460,10 @@ impl<'sto> Client<'sto> {
         command: Writes,
         value: &[u8],
     ) -> Result<(RxFrameDataBuf<'_>, u16), Error> {
-        timeout(
-            self.timeouts.pdu,
-            // TODO: Bit weird to re-wrap the write in a `Command` but whatever
-            self.pdu_loop
-                .pdu_tx_readwrite(Command::Write(command), value),
-        )
-        .await
-        .map_err(|e| {
-            fmt::error!("Write service timeout, command {:?}", command);
-
-            e
-        })
-        .map(|response| response.into_data())
+        self.pdu_loop
+            .pdu_tx_readwrite(Command::Write(command), value, Some(self.timeouts.pdu))
+            .await
+            .map(|response| response.into_data())
     }
 
     pub(crate) async fn write_service_len(
@@ -481,19 +472,10 @@ impl<'sto> Client<'sto> {
         value: &[u8],
         len: u16,
     ) -> Result<(RxFrameDataBuf<'_>, u16), Error> {
-        timeout(
-            self.timeouts.pdu,
-            // TODO: Bit weird to re-wrap the write in a `Command` but whatever
-            self.pdu_loop
-                .pdu_tx_readwrite_len(Command::Write(command), value, len),
-        )
-        .await
-        .map_err(|e| {
-            fmt::error!("Write service timeout, command {:?}", command);
-
-            e
-        })
-        .map(|response| response.into_data())
+        self.pdu_loop
+            .pdu_tx_readwrite_len(Command::Write(command), value, len, Some(self.timeouts.pdu))
+            .await
+            .map(|response| response.into_data())
     }
 
     pub(crate) fn max_frame_data(&self) -> usize {

--- a/src/client.rs
+++ b/src/client.rs
@@ -461,7 +461,7 @@ impl<'sto> Client<'sto> {
         value: &[u8],
     ) -> Result<(RxFrameDataBuf<'_>, u16), Error> {
         self.pdu_loop
-            .pdu_tx_readwrite(Command::Write(command), value, Some(self.timeouts.pdu))
+            .pdu_tx_readwrite(Command::Write(command), value, self.timeouts.pdu)
             .await
             .map(|response| response.into_data())
     }
@@ -473,7 +473,7 @@ impl<'sto> Client<'sto> {
         len: u16,
     ) -> Result<(RxFrameDataBuf<'_>, u16), Error> {
         self.pdu_loop
-            .pdu_tx_readwrite_len(Command::Write(command), value, len, Some(self.timeouts.pdu))
+            .pdu_tx_readwrite_len(Command::Write(command), value, len, self.timeouts.pdu)
             .await
             .map(|response| response.into_data())
     }

--- a/src/pdu_loop/frame_element/created_frame.rs
+++ b/src/pdu_loop/frame_element/created_frame.rs
@@ -28,6 +28,10 @@ impl<'sto> CreatedFrame<'sto> {
     pub fn buf_mut(&mut self) -> &mut [u8] {
         unsafe { self.inner.buf_mut() }
     }
+
+    pub fn index(&self) -> u8 {
+        unsafe { self.inner.frame() }.index
+    }
 }
 
 // SAFETY: This unsafe impl is required due to `FrameBox` containing a `NonNull`, however this impl

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -27,9 +27,10 @@ pub enum FrameState {
     Created = 1,
     /// The frame has been populated with data and is ready to send when the TX loop next runs.
     Sendable = 2,
-    /// The frame has been sent over the network interface and we are waiting for a response from
-    /// the network.
+    /// The frame is being sent over the network interface.
     Sending = 3,
+    /// The frame was successfully sent, and is now waiting for a response from the network.
+    Sent = 4,
     /// A frame response has been received and validation/parsing is in progress.
     RxBusy = 5,
     /// Frame response parsing is complete and the returned data is now stored in the frame. The
@@ -155,7 +156,7 @@ impl<const N: usize> FrameElement<N> {
     pub unsafe fn claim_receiving(
         this: NonNull<FrameElement<N>>,
     ) -> Option<NonNull<FrameElement<N>>> {
-        Self::swap_state(this, FrameState::Sending, FrameState::RxBusy).ok()
+        Self::swap_state(this, FrameState::Sent, FrameState::RxBusy).ok()
     }
 }
 

--- a/src/pdu_loop/frame_element/receiving_frame.rs
+++ b/src/pdu_loop/frame_element/receiving_frame.rs
@@ -120,7 +120,7 @@ impl<'sto> Future for ReceiveFrameFut<'sto> {
         };
 
         match was {
-            FrameState::Sendable | FrameState::Sending | FrameState::RxBusy => {
+            FrameState::Sendable | FrameState::Sending | FrameState::Sent | FrameState::RxBusy => {
                 unsafe { rxin.replace_waker(cx.waker().clone()) };
 
                 self.frame = Some(rxin);

--- a/src/pdu_loop/frame_element/receiving_frame.rs
+++ b/src/pdu_loop/frame_element/receiving_frame.rs
@@ -29,7 +29,7 @@ impl<'sto> ReceivingFrame<'sto> {
     /// This method may only be called once the frame response (header and data) has been validated
     /// and stored in the frame element.
     pub fn mark_received(
-        self,
+        &self,
         flags: PduFlags,
         irq: u16,
         working_counter: u16,
@@ -76,6 +76,11 @@ impl<'sto> ReceivingFrame<'sto> {
 
     pub fn command(&self) -> Command {
         unsafe { self.inner.frame() }.command
+    }
+
+    /// Set frame state back to `Sent` from `Receiving`.
+    pub(crate) fn release_receiving_claim(&self) {
+        unsafe { FrameElement::set_state(self.inner.frame, FrameState::Sent) };
     }
 }
 

--- a/src/pdu_loop/frame_element/sendable_frame.rs
+++ b/src/pdu_loop/frame_element/sendable_frame.rs
@@ -133,7 +133,10 @@ impl<'sto> SendableFrame<'sto> {
     /// The consumed part of the buffer is returned on success, ready for passing to the network
     /// device. If the buffer is not large enough to hold the full frame, this method will return
     /// [`Error::Pdu(PduError::TooLong)`](PduError::TooLong).
-    pub fn write_ethernet_packet<'buf>(&self, buf: &'buf mut [u8]) -> Result<&'buf [u8], PduError> {
+    pub(crate) fn write_ethernet_packet<'buf>(
+        &self,
+        buf: &'buf mut [u8],
+    ) -> Result<&'buf [u8], PduError> {
         let ethernet_len = self.len();
 
         let buf = buf.get_mut(0..ethernet_len).ok_or(PduError::TooLong)?;

--- a/src/pdu_loop/frame_element/sendable_frame.rs
+++ b/src/pdu_loop/frame_element/sendable_frame.rs
@@ -57,7 +57,7 @@ impl<'sto> SendableFrame<'sto> {
     /// The frame has been sent by the network driver.
     pub(crate) fn mark_sent(self) {
         unsafe {
-            FrameElement::set_state(self.inner.frame, FrameState::Sending);
+            FrameElement::set_state(self.inner.frame, FrameState::Sent);
         }
     }
 

--- a/src/pdu_loop/frame_element/sendable_frame.rs
+++ b/src/pdu_loop/frame_element/sendable_frame.rs
@@ -27,9 +27,16 @@ use smoltcp::wire::{EthernetAddress, EthernetFrame};
 /// # static PDU_STORAGE: PduStorage<2, 2> = PduStorage::new();
 /// let (mut pdu_tx, _pdu_rx, _pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
 ///
+/// let mut buf = [0u8; 1530];
+///
 /// poll_fn(|ctx| {
-///     if let Some(packet) = pdu_tx.next_sendable_frame() {
-///         // Send packet over the network interface here
+///     if let Some(frame) = pdu_tx.next_sendable_frame() {
+///         frame.send_blocking(&mut buf, |data| {
+///             // Send packet over the network interface here
+///
+///             // Return the number of bytes sent over the network
+///             Ok(data.len())
+///         });
 ///
 ///         // Wake the future so it's polled again in case there are more frames to send
 ///         ctx.waker().wake_by_ref();
@@ -58,6 +65,14 @@ impl<'sto> SendableFrame<'sto> {
     pub(crate) fn mark_sent(self) {
         unsafe {
             FrameElement::set_state(self.inner.frame, FrameState::Sent);
+        }
+    }
+
+    /// Used on send failure to release the frame sending claim so the frame can attempt to be sent
+    /// again, or reclaimed for reuse.
+    fn release_sending_claim(self) {
+        unsafe {
+            FrameElement::set_state(self.inner.frame, FrameState::Sendable);
         }
     }
 
@@ -137,36 +152,68 @@ impl<'sto> SendableFrame<'sto> {
     }
 
     /// Send the frame using a callback returning a future.
-    pub async fn send<'buf, F, O>(self, packet_buf: &'buf mut [u8], send: F) -> Result<(), Error>
+    ///
+    /// The closure must return the number of bytes sent over the network interface. If this does
+    /// not match the length of the packet passed to the closure, this method will return an error.
+    pub async fn send<'buf, F, O>(self, packet_buf: &'buf mut [u8], send: F) -> Result<usize, Error>
     where
         F: FnOnce(&'buf [u8]) -> O,
-        O: Future<Output = Result<(), Error>>,
+        O: Future<Output = Result<usize, Error>>,
     {
         let bytes = self.write_ethernet_packet(packet_buf)?;
 
-        send(bytes).await?;
+        match send(bytes).await {
+            Ok(bytes_sent) if bytes_sent == bytes.len() => {
+                self.mark_sent();
 
-        // FIXME: Release frame on failure
+                Ok(bytes_sent)
+            }
+            Ok(bytes_sent) => {
+                self.release_sending_claim();
 
-        self.mark_sent();
+                Err(Error::PartialSend {
+                    len: bytes.len(),
+                    sent: bytes_sent,
+                })
+            }
+            Err(res) => {
+                self.release_sending_claim();
 
-        Ok(())
+                Err(res)
+            }
+        }
     }
 
     /// Send the frame using a blocking callback.
+    ///
+    /// The closure must return the number of bytes sent over the network interface. If this does
+    /// not match the length of the packet passed to the closure, this method will return an error.
     pub fn send_blocking<'buf>(
         self,
         packet_buf: &'buf mut [u8],
-        send: impl FnOnce(&'buf [u8]) -> Result<(), Error>,
-    ) -> Result<(), Error> {
+        send: impl FnOnce(&'buf [u8]) -> Result<usize, Error>,
+    ) -> Result<usize, Error> {
         let bytes = self.write_ethernet_packet(packet_buf)?;
 
-        send(bytes)?;
+        match send(bytes) {
+            Ok(bytes_sent) if bytes_sent == bytes.len() => {
+                self.mark_sent();
 
-        // FIXME: Release frame on failure
+                Ok(bytes_sent)
+            }
+            Ok(bytes_sent) => {
+                self.release_sending_claim();
 
-        self.mark_sent();
+                Err(Error::PartialSend {
+                    len: bytes.len(),
+                    sent: bytes_sent,
+                })
+            }
+            Err(res) => {
+                self.release_sending_claim();
 
-        Ok(())
+                Err(res)
+            }
+        }
     }
 }

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -206,6 +206,8 @@ mod tests {
     use smoltcp::wire::{EthernetAddress, EthernetFrame};
 
     #[tokio::test]
+    // MIRI doesn't like this test as it leaks memory
+    #[cfg_attr(miri, ignore)]
     async fn timed_out_frame_is_reallocatable() {
         // One 16 byte frame
         static STORAGE: PduStorage<1, 16> = PduStorage::new();

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -273,7 +273,7 @@ mod tests {
                     .send(&mut packet_buf, |bytes| async {
                         written_packet.copy_from_slice(bytes);
 
-                        Ok(())
+                        Ok(bytes.len())
                     })
                     .await
                     .expect("send");
@@ -414,7 +414,7 @@ mod tests {
                             .send(&mut packet_buf, |bytes| async {
                                 s.send(bytes.to_vec()).unwrap();
 
-                                Ok(())
+                                Ok(bytes.len())
                             })
                             .await
                             .unwrap();

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -52,7 +52,7 @@ impl<'sto> PduRx<'sto> {
 
         let mut frame = self
             .storage
-            .get_receiving(index)
+            .claim_receiving(index)
             .ok_or_else(|| PduError::InvalidIndex(usize::from(index)))?;
 
         if frame.index() != index {

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -55,50 +55,55 @@ impl<'sto> PduRx<'sto> {
             .claim_receiving(index)
             .ok_or_else(|| PduError::InvalidIndex(usize::from(index)))?;
 
-        if frame.index() != index {
-            return Err(Error::Pdu(PduError::Validation(
-                PduValidationError::IndexMismatch {
-                    sent: frame.index(),
-                    received: index,
-                },
-            )));
-        }
+        (|| {
+            if frame.index() != index {
+                return Err(Error::Pdu(PduError::Validation(
+                    PduValidationError::IndexMismatch {
+                        sent: frame.index(),
+                        received: index,
+                    },
+                )));
+            }
 
-        let (i, command) = Command::parse(command_code, i)?;
+            let (i, command) = Command::parse(command_code, i)?;
 
-        // Check for weird bugs where a slave might return a different command than the one sent for
-        // this PDU index.
-        if command.code() != frame.command().code() {
-            return Err(Error::Pdu(PduError::Validation(
-                PduValidationError::CommandMismatch {
-                    sent: command,
-                    received: frame.command(),
-                },
-            )));
-        }
+            // Check for weird bugs where a slave might return a different command than the one sent for
+            // this PDU index.
+            if command.code() != frame.command().code() {
+                return Err(Error::Pdu(PduError::Validation(
+                    PduValidationError::CommandMismatch {
+                        sent: command,
+                        received: frame.command(),
+                    },
+                )));
+            }
 
-        let (i, flags) = map_res(take(2usize), PduFlags::unpack_from_slice)(i)?;
-        let (i, irq) = le_u16(i)?;
-        let (i, data) = take(flags.length)(i)?;
-        let (i, working_counter) = le_u16(i)?;
+            let (i, flags) = map_res(take(2usize), PduFlags::unpack_from_slice)(i)?;
+            let (i, irq) = le_u16(i)?;
+            let (i, data) = take(flags.length)(i)?;
+            let (i, working_counter) = le_u16(i)?;
 
-        fmt::trace!(
-            "Received frame with index {:#04x}, WKC {}",
-            index,
-            working_counter,
-        );
+            fmt::trace!(
+                "Received frame with index {:#04x}, WKC {}",
+                index,
+                working_counter,
+            );
 
-        // `_i` should be empty as we `take()`d an exact amount above.
-        debug_assert_eq!(i.len(), 0, "trailing data in received frame");
+            // `_i` should be empty as we `take()`d an exact amount above.
+            debug_assert_eq!(i.len(), 0, "trailing data in received frame");
 
-        let frame_data = frame.buf_mut();
+            let frame_data = frame.buf_mut();
 
-        frame_data[0..usize::from(flags.len())].copy_from_slice(data);
+            frame_data[0..usize::from(flags.len())].copy_from_slice(data);
 
-        // FIXME: Release frame if any of this method fails
+            frame.mark_received(flags, irq, working_counter)?;
 
-        frame.mark_received(flags, irq, working_counter)?;
+            Ok(())
+        })()
+        .map_err(|e| {
+            frame.release_receiving_claim();
 
-        Ok(())
+            e
+        })
     }
 }

--- a/src/pdu_loop/storage.rs
+++ b/src/pdu_loop/storage.rs
@@ -169,7 +169,7 @@ impl<'sto> PduStorageRef<'sto> {
     }
 
     /// Updates state from SENDING -> RX_BUSY
-    pub(in crate::pdu_loop) fn get_receiving(&self, idx: u8) -> Option<ReceivingFrame<'sto>> {
+    pub(in crate::pdu_loop) fn claim_receiving(&self, idx: u8) -> Option<ReceivingFrame<'sto>> {
         let idx = usize::from(idx);
 
         if idx >= self.num_frames {

--- a/src/slave/ports.rs
+++ b/src/slave/ports.rs
@@ -217,9 +217,7 @@ impl Ports {
             .windows(2)
             .map(|window| {
                 // Silly Rust
-                let [a, b] = window else {
-                    return 0
-                };
+                let [a, b] = window else { return 0 };
 
                 // Stop iterating as we've summed everything before the target port
                 if a.index() >= port.index() {

--- a/src/std/linux/mod.rs
+++ b/src/std/linux/mod.rs
@@ -89,7 +89,11 @@ impl Future for TxRxFut<'_> {
             Poll::Ready(Err(e)) => {
                 fmt::error!("Receive PDU failed: {}", e);
 
-                return Poll::Ready(Err(Error::ReceiveFrame));
+                // Try again - hopefully the network will be back
+                // TODO: Filter only on errors that we can recover from
+                // TODO: Retry counter/timeout?
+                // FIXME: Wake after a delay. I think this deadlocks the tx/rx loop
+                // ctx.waker().wake_by_ref();
             }
             Poll::Pending => (),
         }

--- a/src/std/not_linux.rs
+++ b/src/std/not_linux.rs
@@ -70,7 +70,7 @@ pub fn tx_rx_task(
                                 })
                                 .expect("TX");
 
-                            Ok(())
+                            Ok(frame_bytes.len())
                         })
                         .await
                         .expect("TX");

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -104,7 +104,7 @@ impl Future for DummyTxRxFut<'_> {
                 .send_blocking(&mut buf, |got| {
                     assert_eq!(expected.as_ref(), got, "TX line {}", self.packet_number);
 
-                    Ok(())
+                    Ok(got.len())
                 })
                 .expect("Failed to send");
 


### PR DESCRIPTION
This should allow frame send retry attempts so EtherCrab is more resilient against temporary (within `Timeouts::pdu`) network outages.