### PR TITLE
Allow configuration of retry behaviour for timed out PDUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ An EtherCAT master written in Rust.
 ### Added
 
 - [#91] Add support for "cross" topologies, e.g. with EK1122.
+- [#102] PDU retry behaviour is now configurable between no retries, a limited count, or retrying
+  forever with the `RetryBehaviour` struct and associated `ClientConfig.retry_behaviour` option.
 
 ### Changed
 
@@ -185,5 +187,6 @@ An EtherCAT master written in Rust.
 [#92]: https://github.com/ethercrab-rs/ethercrab/pull/92
 [#99]: https://github.com/ethercrab-rs/ethercrab/pull/99
 [#101]: https://github.com/ethercrab-rs/ethercrab/pull/101
+[#102]: https://github.com/ethercrab-rs/ethercrab/pull/102
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/benches/pdu_loop.rs
+++ b/benches/pdu_loop.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 use criterion::{criterion_group, criterion_main, Bencher, Criterion, Throughput};
-use ethercrab::{Command, PduStorage};
+use ethercrab::{Command, PduStorage, RetryBehaviour};
 
 const DATA: [u8; 8] = [0x11u8, 0x22, 0x33, 0x44, 0xaa, 0xbb, 0xcc, 0xdd];
 
@@ -19,8 +19,12 @@ fn do_bench(b: &mut Bencher) {
     b.iter(|| {
         //  --- Prepare frame
 
-        let frame_fut =
-            pdu_loop.pdu_tx_readwrite(Command::fpwr(0x5678, 0x1234), &DATA, Duration::from_secs(1));
+        let frame_fut = pdu_loop.pdu_tx_readwrite(
+            Command::fpwr(0x5678, 0x1234),
+            &DATA,
+            Duration::from_secs(1),
+            RetryBehaviour::None,
+        );
 
         // --- Send frame
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -445,8 +445,12 @@ impl<'sto> Client<'sto> {
     ) -> Result<PduResponse<RxFrameDataBuf<'_>>, Error> {
         timeout(
             self.timeouts.pdu,
-            self.pdu_loop
-                .pdu_tx_readonly(command, len, self.timeouts.pdu),
+            self.pdu_loop.pdu_tx_readonly(
+                command,
+                len,
+                self.timeouts.pdu,
+                self.config.retry_behaviour,
+            ),
         )
         .await
         .map(|response| response.into_data())
@@ -458,7 +462,12 @@ impl<'sto> Client<'sto> {
         value: &[u8],
     ) -> Result<(RxFrameDataBuf<'_>, u16), Error> {
         self.pdu_loop
-            .pdu_tx_readwrite(command, value, self.timeouts.pdu)
+            .pdu_tx_readwrite(
+                command,
+                value,
+                self.timeouts.pdu,
+                self.config.retry_behaviour,
+            )
             .await
             .map(|response| response.into_data())
     }
@@ -470,7 +479,13 @@ impl<'sto> Client<'sto> {
         len: u16,
     ) -> Result<(RxFrameDataBuf<'_>, u16), Error> {
         self.pdu_loop
-            .pdu_tx_readwrite_len(Command::Write(command), value, len, self.timeouts.pdu)
+            .pdu_tx_readwrite_len(
+                Command::Write(command),
+                value,
+                len,
+                self.timeouts.pdu,
+                self.config.retry_behaviour,
+            )
             .await
             .map(|response| response.into_data())
     }

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -25,6 +25,8 @@ impl Default for ClientConfig {
 }
 
 /// Network communication retry policy.
+///
+/// Retries will be performed at the rate defined by [`Timeouts::pdu`](crate::Timeouts::pdu).
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 pub enum RetryBehaviour {
     /// Do not attempt to retry timed out packet sends (default).

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -47,6 +47,7 @@ pub enum RetryBehaviour {
 impl RetryBehaviour {
     pub(crate) fn loop_counts(&self) -> usize {
         match self {
+            // Try at least once when used in a range like `for _ in 0..<counts>`.
             RetryBehaviour::None => 1,
             RetryBehaviour::Count(n) => *n,
             RetryBehaviour::Forever => usize::MAX,

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -10,12 +10,44 @@ pub struct ClientConfig {
     ///
     /// If this is set to zero, no static sync will be performed.
     pub dc_static_sync_iterations: u32,
+
+    /// EtherCAT packet (PDU) network retry behaviour.
+    pub retry_behaviour: RetryBehaviour,
 }
 
 impl Default for ClientConfig {
     fn default() -> Self {
         Self {
             dc_static_sync_iterations: 10_000,
+            retry_behaviour: RetryBehaviour::default(),
+        }
+    }
+}
+
+/// Network communication retry policy.
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub enum RetryBehaviour {
+    /// Do not attempt to retry timed out packet sends (default).
+    ///
+    /// If this option is chosen, any timeouts will raise an
+    /// [`Error::Timeout`](crate::error::Error::Timeout).
+    #[default]
+    None,
+
+    /// Attempt to resend a PDU up to `N` times, then raise an
+    /// [`Error::Timeout`](crate::error::Error::Timeout).
+    Count(usize),
+
+    /// Attempt to resend the PDU forever.
+    Forever,
+}
+
+impl RetryBehaviour {
+    pub(crate) fn loop_counts(&self) -> usize {
+        match self {
+            RetryBehaviour::None => 1,
+            RetryBehaviour::Count(n) => *n,
+            RetryBehaviour::Forever => usize::MAX,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ use smoltcp::wire::{EthernetAddress, EthernetProtocol};
 
 pub use al_status_code::AlStatusCode;
 pub use client::Client;
-pub use client_config::ClientConfig;
+pub use client_config::{ClientConfig, RetryBehaviour};
 pub use coe::SubIndex;
 pub use command::{Command, Reads, Writes};
 pub use pdu_loop::{PduLoop, PduRx, PduStorage, PduTx, SendableFrame};

--- a/src/std/linux/mod.rs
+++ b/src/std/linux/mod.rs
@@ -92,7 +92,9 @@ impl Future for TxRxFut<'_> {
             Poll::Ready(Err(e)) => {
                 fmt::error!("Receive PDU failed: {}", e);
 
-                return Poll::Ready(Err(Error::ReceiveFrame));
+                // PDU failed but don't exit future - it will either be timed out or retried from
+                // elsewhere in the EtherCrab code.
+                ()
             }
             Poll::Pending => (),
         }

--- a/src/std/linux/mod.rs
+++ b/src/std/linux/mod.rs
@@ -92,8 +92,6 @@ impl Future for TxRxFut<'_> {
             Poll::Ready(Err(e)) => {
                 fmt::error!("Receive PDU failed: {}", e);
 
-                // PDU failed but don't exit future - it will either be timed out or retried from
-                // elsewhere in the EtherCrab code.
                 ()
             }
             Poll::Pending => (),


### PR DESCRIPTION
This builds on #101 and makes the retry behaviour much more robust. In my local testing, I can unplug the EtherCAT network cable and replug it and the slaves (EL2828, EL2889 in my case) pick the PDI back up again. 

According to <https://infosys.beckhoff.com/english.php?content=../content/1033/el34x3/1036979339.html&id=>, the slaves won't fall out of OP when no PDI is received but their watchdogs will trigger, causing outputs to be turned off for safety.