### PR TITLE
Add `serde` support to `Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ An EtherCAT master written in Rust.
 - [#91] Add support for "cross" topologies, e.g. with EK1122.
 - [#102] PDU retry behaviour is now configurable between no retries, a limited count, or retrying
   forever with the `RetryBehaviour` struct and associated `ClientConfig.retry_behaviour` option.
+- [#103] Added optional `serde` feature to enable ser/de of some EtherCrab items.
 
 ### Changed
 
@@ -19,6 +20,8 @@ An EtherCAT master written in Rust.
   number of bytes sent over the network.
 - **(breaking)** [#101] `SendableFrame::write_ethernet_packet` is no longer `pub`. Instead, use
   `SendableFrame::send_blocking` or `SendableFrame::send`.
+- [#103] Removed inner `smoltcp::error::Error` from `PduError::Ethernet` and `PduError::CreateFrame`
+  as these don't add much meaning to the variant.
 
 ### Removed
 
@@ -188,5 +191,6 @@ An EtherCAT master written in Rust.
 [#99]: https://github.com/ethercrab-rs/ethercrab/pull/99
 [#101]: https://github.com/ethercrab-rs/ethercrab/pull/101
 [#102]: https://github.com/ethercrab-rs/ethercrab/pull/102
+[#103]: https://github.com/ethercrab-rs/ethercrab/pull/103
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ nom = { version = "7.1.3", default-features = false }
 num_enum = { version = "0.6.1", default-features = false }
 packed_struct = { version = "0.10.1", default-features = false }
 sealed = "0.5.0"
+serde = { version = "1.0.188", features = ["derive"], optional = true }
 smlang = "0.6.0"
 smoltcp = { version = "0.10.0", default-features = false, features = [
     "proto-ipv4",
@@ -75,6 +76,7 @@ default = ["std"]
 defmt = ["dep:defmt", "smoltcp/defmt"]
 log = ["dep:log"]
 std = ["pnet_datalink", "async-io", "smoltcp/phy-raw_socket", "log"]
+serde = ["dep:serde"]
 # Development only - DO NOT USE
 bench-hacks = []
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ An EtherCAT master written in pure Rust.
 - `defmt` - enable logging with the [`defmt`](https://docs.rs/defmt) crate.
 - `log` - enable logging with the [`log`](https://docs.rs/log) crate. This is enabled by default
   when the `std` feature is enabled.
+- `serde` - enable `serde` impls for some public items.
 
 For `no_std` targets, it is recommended to add this crate with
 

--- a/src/coe/abort_code.rs
+++ b/src/coe/abort_code.rs
@@ -1,6 +1,7 @@
 /// Defined in ETG1000.6 Table 41 – SDO Abort Codes
 #[derive(Debug, Copy, Clone, PartialEq, Eq, num_enum::FromPrimitive, num_enum::IntoPrimitive)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[repr(u32)]
 pub enum AbortCode {
     /// Toggle bit not changed

--- a/src/command.rs
+++ b/src/command.rs
@@ -27,6 +27,7 @@ const LRW: u8 = 0x0c;
 /// Write commands.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum Writes {
     /// BWR.
     Bwr {
@@ -168,6 +169,7 @@ impl Writes {
 /// Read commands that send no data.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum Reads {
     /// APRD.
     Aprd {
@@ -297,6 +299,7 @@ impl Reads {
 /// ```
 #[derive(Default, PartialEq, Eq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum Command {
     /// No operation.
     #[default]

--- a/src/error.rs
+++ b/src/error.rs
@@ -185,11 +185,11 @@ pub enum PduError {
     /// Failed to decode raw PDU data into a given data type.
     Decode,
     /// Something went wrong when encoding/decoding the raw Ethernet II frame.
-    Ethernet(smoltcp::wire::Error),
+    Ethernet,
     /// PDU data is too long to fit in the given buffer.
     TooLong,
     /// Failed to create an Ethernet II frame.
-    CreateFrame(smoltcp::wire::Error),
+    CreateFrame,
     /// A frame index was given that does not point to a frame.
     InvalidIndex(usize),
     /// A received frame is invalid.
@@ -210,9 +210,9 @@ impl core::fmt::Display for PduError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             PduError::Decode => f.write_str("failed to decode raw PDU data into type"),
-            PduError::Ethernet(e) => write!(f, "network: {}", e),
+            PduError::Ethernet => f.write_str("network"),
             PduError::TooLong => f.write_str("data is too long to fit in given buffer"),
-            PduError::CreateFrame(e) => write!(f, "failed to create frame: {}", e),
+            PduError::CreateFrame => f.write_str("failed to create frame"),
             PduError::InvalidIndex(index) => write!(f, "invalid PDU index {}", index),
             PduError::Validation(e) => write!(f, "received PDU validation failed: {}", e),
             PduError::InvalidFrameState => f.write_str("invalid PDU frame state"),
@@ -382,8 +382,8 @@ impl From<PduValidationError> for PduError {
 }
 
 impl From<smoltcp::wire::Error> for PduError {
-    fn from(e: smoltcp::wire::Error) -> Self {
-        Self::Ethernet(e)
+    fn from(_: smoltcp::wire::Error) -> Self {
+        Self::Ethernet
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use packed_struct::PackingError;
 /// An EtherCrab error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum Error {
     /// A low level error occurred when producing or consuming a PDU.
     Pdu(PduError),
@@ -161,6 +162,7 @@ impl From<BorrowError> for Error {
 /// The kind of item being looked for.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum Item {
     /// An EtherCAT slave device.
     Slave,
@@ -181,6 +183,7 @@ pub enum Item {
 /// Low-level PDU (Process Data Unit) error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum PduError {
     /// Failed to decode raw PDU data into a given data type.
     Decode,
@@ -224,6 +227,7 @@ impl core::fmt::Display for PduError {
 /// CoE mailbox error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum MailboxError {
     /// The mailbox operation was aborted.
     Aborted {
@@ -278,6 +282,7 @@ impl core::fmt::Display for MailboxError {
 /// EEPROM (SII) error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum EepromError {
     /// Failed to decode data from EEPROM.
     Decode,
@@ -331,6 +336,7 @@ impl core::fmt::Display for VisibleStringError {
 /// A PDU response failed to validate.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum PduValidationError {
     /// The index of the received PDU does not match that of the sent one.
     IndexMismatch {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! - `defmt` - enable logging with the [`defmt`](https://docs.rs/defmt) crate.
 //! - `log` - enable logging with the [`log`](https://docs.rs/log) crate. This is enabled by default
 //!   when the `std` feature is enabled.
+//! - `serde` - enable `serde` impls for some public items.
 //!
 //! For `no_std` targets, it is recommended to add this crate with
 //!

--- a/src/pdu_loop/frame_element/sendable_frame.rs
+++ b/src/pdu_loop/frame_element/sendable_frame.rs
@@ -141,7 +141,8 @@ impl<'sto> SendableFrame<'sto> {
 
         let buf = buf.get_mut(0..ethernet_len).ok_or(PduError::TooLong)?;
 
-        let mut ethernet_frame = EthernetFrame::new_checked(buf).map_err(PduError::CreateFrame)?;
+        let mut ethernet_frame =
+            EthernetFrame::new_checked(buf).map_err(|_| PduError::CreateFrame)?;
 
         ethernet_frame.set_src_addr(MASTER_ADDR);
         ethernet_frame.set_dst_addr(EthernetAddress::BROADCAST);

--- a/src/slave_state.rs
+++ b/src/slave_state.rs
@@ -15,6 +15,7 @@ use packed_struct::prelude::*;
     num_enum::IntoPrimitive,
 )]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[repr(u8)]
 pub enum SlaveState {
     /// No state recorded/read/known.


### PR DESCRIPTION
Currently only implemented for `ethercrab::error::Error` as this is all I need for now but is easy enough to add to more stuff in the future.