### PR TITLE
Relax std task storage lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ An EtherCAT master written in Rust.
 
 ### Fixed
 
-- [#121] Relax `'static` lifetime requirement on `std::tx_rx_task` to a named lifetime to allow
-  non-`'static` storage to be used.
+- [#121] **Linux only:** Relax `'static` lifetime requirement on `std::tx_rx_task` to a named
+  lifetime to allow non-`'static` storage to be used.
 
 ## [0.3.1] - 2023-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- [#121] Relax `'static` lifetime requirement on `std::tx_rx_task` to a named lifetime to allow
+  non-`'static` storage to be used.
+
 ## [0.3.1] - 2023-10-16
 
 ## [0.3.0] - 2023-10-12
@@ -182,8 +187,8 @@ An EtherCAT master written in Rust.
 - Initial release
 
 <!-- next-url -->
-[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.0...HEAD
 
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.0...HEAD
 [0.3.1]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/ethercrab-rs/ethercrab/compare/v0.2.0...v0.2.1
@@ -223,5 +228,6 @@ An EtherCAT master written in Rust.
 [#113]: https://github.com/ethercrab-rs/ethercrab/pull/113
 [#114]: https://github.com/ethercrab-rs/ethercrab/pull/114
 [#119]: https://github.com/ethercrab-rs/ethercrab/pull/119
+[#121]: https://github.com/ethercrab-rs/ethercrab/pull/121
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/src/std/linux/mod.rs
+++ b/src/std/linux/mod.rs
@@ -107,11 +107,11 @@ impl Future for TxRxFut<'_> {
 }
 
 /// Spawn a TX and RX task.
-pub fn tx_rx_task(
+pub fn tx_rx_task<'sto>(
     interface: &str,
-    pdu_tx: PduTx<'static>,
-    pdu_rx: PduRx<'static>,
-) -> Result<impl Future<Output = Result<(), Error>>, std::io::Error> {
+    pdu_tx: PduTx<'sto>,
+    pdu_rx: PduRx<'sto>,
+) -> Result<impl Future<Output = Result<(), Error>> + 'sto, std::io::Error> {
     let socket = RawSocketDesc::new(interface)?;
 
     let async_socket = async_io::Async::new(socket)?;


### PR DESCRIPTION
This PR relaxes the `'static` bound down to a specified lifetime. This can remain static for any `static PduStorage`s so shouldn't be a breaking change, but now additionally allows the use of scoped threads or similar.