### PR TITLE
Expose device propagation delay via a method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#122] Added `Slave{Ref}::propagation_delay()` to get the EtherCAT propagation delay for a
+  specific device on the network.
+
 ### Fixed
 
 - [#121] **Linux only:** Relax `'static` lifetime requirement on `std::tx_rx_task` to a named
@@ -229,5 +234,6 @@ An EtherCAT master written in Rust.
 [#114]: https://github.com/ethercrab-rs/ethercrab/pull/114
 [#119]: https://github.com/ethercrab-rs/ethercrab/pull/119
 [#121]: https://github.com/ethercrab-rs/ethercrab/pull/121
+[#122]: https://github.com/ethercrab-rs/ethercrab/pull/122
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -171,6 +171,14 @@ impl Slave {
         self.identity
     }
 
+    /// Get the network propagation delay of this device in nanoseconds.
+    ///
+    /// Note that before [`Client::init`](crate::client::Client::init) is called, this method will
+    /// always return `0`.
+    pub fn propagation_delay(&self) -> u32 {
+        self.propagation_delay
+    }
+
     pub(crate) fn io_segments(&self) -> &IoRanges {
         &self.config.io
     }
@@ -229,6 +237,14 @@ where
     /// Get the configured station address of the slave device.
     pub fn configured_address(&self) -> u16 {
         self.state.configured_address
+    }
+
+    /// Get the network propagation delay of this device in nanoseconds.
+    ///
+    /// Note that before [`Client::init`](crate::client::Client::init) is called, this method will
+    /// always return `0`.
+    pub fn propagation_delay(&self) -> u32 {
+        self.state.propagation_delay
     }
 
     /// Get CoE read/write mailboxes.


### PR DESCRIPTION
Adds the ability to get the propagation delay of a device to use for diagnostics, logging, etc.