### PR TITLE
Print frame index in hex too

### DIFF
--- a/src/pdu_loop/frame_element/receiving_frame.rs
+++ b/src/pdu_loop/frame_element/receiving_frame.rs
@@ -40,7 +40,8 @@ impl<'sto> ReceivingFrame<'sto> {
 
         let waker = unsafe { self.inner.take_waker() }.ok_or_else(|| {
             fmt::error!(
-                "Attempted to wake frame #{} with no waker, possibly caused by timeout",
+                "Attempted to wake frame #{} ({:#04x}) with no waker, possibly caused by timeout",
+                frame.index,
                 frame.index
             );
 


### PR DESCRIPTION
This makes it easier to match up Wireshark traces to error logs.