### PR TITLE
Package upgrades, update Embassy example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ An EtherCAT master written in Rust.
 - **(breaking)** [#124] Changed `PduTx::waker()` to `PduTx::replace_waker()`. Instead of calling
   e.g. `pdu_tx.waker().replace(ctx.waker().clone())`, now it should be
   `pdu_tx.replace_waker(ctx.waker())`.
+- (potentially breaking) [#125] Package upgrades, notably `async_io` and `futures_lite` from 1.x to
+  2.0.
 
 ## [0.3.1] - 2023-10-16
 
@@ -243,5 +245,6 @@ An EtherCAT master written in Rust.
 [#121]: https://github.com/ethercrab-rs/ethercrab/pull/121
 [#122]: https://github.com/ethercrab-rs/ethercrab/pull/122
 [#124]: https://github.com/ethercrab-rs/ethercrab/pull/124
+[#125]: https://github.com/ethercrab-rs/ethercrab/pull/125
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,22 +17,22 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu"]
 
 [dependencies]
-async-io = { version = "1.13.0", optional = true }
+async-io = { version = "2.0.0", optional = true }
 atomic-waker = "1.1.2"
 atomic_enum = "0.2.0"
-atomic_refcell = "0.1.10"
-bitflags = "2.3.3"
+atomic_refcell = "0.1.13"
+bitflags = "2.4.1"
 defmt = { version = "0.3.5", optional = true }
 embassy-futures = "0.1.0"
-embassy-time = "0.1.2"
-futures-lite = { version = "1.13.0", default-features = false }
+embassy-time = "0.1.5"
+futures-lite = { version = "2.0.0", default-features = false }
 heapless = "0.7.16"
-log = { version = "0.4.19", optional = true, default-features = false }
+log = { version = "0.4.20", optional = true, default-features = false }
 nom = { version = "7.1.3", default-features = false }
 num_enum = { version = "0.7.0", default-features = false }
 packed_struct = { version = "0.10.1", default-features = false }
 sealed = "0.5.0"
-serde = { version = "1.0.188", features = ["derive"], optional = true }
+serde = { version = "1.0.190", features = ["derive"], optional = true }
 smlang = "0.6.0"
 smoltcp = { version = "0.10.0", default-features = false, features = [
     "proto-ipv4",
@@ -42,29 +42,29 @@ smoltcp = { version = "0.10.0", default-features = false, features = [
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 pnet_datalink = { version = "0.34.0", features = ["std"], optional = true }
-blocking = "1.3.1"
+blocking = "1.4.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = "0.2.147"
-rustix = { version = "0.38.4", default-features = false, features = [
+libc = "0.2.149"
+rustix = { version = "0.38.21", default-features = false, features = [
     "process",
 ] }
 thread-priority = "0.13.1"
 
 [target.'cfg(miri)'.dependencies]
-tokio = { version = "1.29.1", features = ["rt", "macros", "time"] }
+tokio = { version = "1.33.0", features = ["rt", "macros", "time"] }
 
 [dev-dependencies]
-arbitrary = { version = "1.3.0", features = ["derive"] }
+arbitrary = { version = "1.3.1", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
-ctrlc = "3.4.0"
+ctrlc = "3.4.1"
 env_logger = "0.10.0"
 hdrhistogram = "7.5.2"
 heckcheck = "2.0.1"
 pcap-file = "2.0.0"
 pretty_assertions = "1.4.0"
 smol = "1.3.0"
-tokio = { version = "1.29.1", features = [
+tokio = { version = "1.33.0", features = [
     "rt-multi-thread",
     "macros",
     "sync",
@@ -75,7 +75,13 @@ tokio = { version = "1.29.1", features = [
 default = ["std"]
 defmt = ["dep:defmt", "smoltcp/defmt"]
 log = ["dep:log"]
-std = ["pnet_datalink", "async-io", "smoltcp/phy-raw_socket", "log"]
+std = [
+    "pnet_datalink",
+    "async-io",
+    "smoltcp/phy-raw_socket",
+    "log",
+    "futures-lite/std",
+]
 serde = ["dep:serde", "bitflags/serde"]
 # Development only - DO NOT USE
 bench-hacks = []

--- a/examples/embassy-stm32/Cargo.toml
+++ b/examples/embassy-stm32/Cargo.toml
@@ -46,13 +46,14 @@ embassy-stm32 = { version = "0.1.0", features = [
     "memory-x",
     "time-driver-any",
 ] }
-embassy-net = { version = "0.1.0", features = [
+embassy-net = { version = "0.2.0", features = [
     "defmt",
     "tcp",
     "dhcpv4",
     "medium-ethernet",
     "nightly",
 ] }
+embassy-net-driver = { version = "0.2.0", features = ["defmt"] }
 
 [profile.release]
 debug = 2
@@ -61,8 +62,9 @@ lto = true
 codegen-units = 1
 
 [patch.crates-io]
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "eff73d6dfa4c5920a55a5ee2bf5c0b2ef68fbae1" }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "eff73d6dfa4c5920a55a5ee2bf5c0b2ef68fbae1" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "eff73d6dfa4c5920a55a5ee2bf5c0b2ef68fbae1" }
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "eff73d6dfa4c5920a55a5ee2bf5c0b2ef68fbae1" }
-embassy-net = { git = "https://github.com/embassy-rs/embassy.git", rev = "eff73d6dfa4c5920a55a5ee2bf5c0b2ef68fbae1" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "b6fc682117a41e8e63a9632e06da5a17f46d9ab0" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "b6fc682117a41e8e63a9632e06da5a17f46d9ab0" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "b6fc682117a41e8e63a9632e06da5a17f46d9ab0" }
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "b6fc682117a41e8e63a9632e06da5a17f46d9ab0" }
+embassy-net = { git = "https://github.com/embassy-rs/embassy.git", rev = "b6fc682117a41e8e63a9632e06da5a17f46d9ab0" }
+embassy-net-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "b6fc682117a41e8e63a9632e06da5a17f46d9ab0" }

--- a/examples/embassy-stm32/rust-toolchain.toml
+++ b/examples/embassy-stm32/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly"
+components = ["llvm-tools"]
 targets = ["thumbv7em-none-eabi"]

--- a/src/al_control.rs
+++ b/src/al_control.rs
@@ -65,6 +65,8 @@ impl PduRead for AlControl {
 
     type Error = WrappedPackingError;
 
+    // Clippy: allow this because it's required in no_std
+    #[allow(clippy::needless_question_mark)]
     fn try_from_slice(slice: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::unpack_from_slice(slice)?)
     }

--- a/src/std/linux/mod.rs
+++ b/src/std/linux/mod.rs
@@ -94,8 +94,6 @@ impl Future for TxRxFut<'_> {
             }
             Poll::Ready(Err(e)) => {
                 fmt::error!("Receive PDU failed: {}", e);
-
-                ()
             }
             Poll::Pending => (),
         }

--- a/src/std/linux/mod.rs
+++ b/src/std/linux/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use async_io::Async;
 use core::{future::Future, pin::Pin, task::Poll};
-use futures_lite::io::{AsyncRead, AsyncWrite};
+use futures_lite::{AsyncRead, AsyncWrite};
 
 struct TxRxFut<'a> {
     socket: Async<RawSocketDesc>,


### PR DESCRIPTION
Just pottering around. Saves a few KB for `no_std`:

```bash
cd examples/embassy-stm32
cargo size --release
```

```
Baseline (master branch)

   text    data     bss     dec     hex filename
  91348     112   52784  144244   23374 ethercrab-stm32-embassy

This PR

   text    data     bss     dec     hex filename
  89072     112   52784  141968   22a90 ethercrab-stm32-embassy
```