### PR TITLE
Improve behaviour when frames are still in flight

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,17 +47,17 @@ miri_steps: &miri_steps
     - checkout
     - run: sudo apt update && sudo apt install -y libpcap-dev
     - restore_cache:
-        key: v4-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+        key: v5-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
 
     # Arbitrary nightly version - just the latest at time of writing. This can be changed freely.
-    - run: rustup toolchain add nightly-2023-07-03 --target $TARGET --component miri
+    - run: rustup toolchain add nightly-2023-11-02 --target $TARGET --component miri
     - run: |
         export MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation"
 
-        cargo +nightly-2023-07-03 miri test --target $TARGET
+        cargo +nightly-2023-11-02 miri test --target $TARGET
 
     - save_cache:
-        key: v4-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+        key: v5-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
         paths:
           - ./target
           - /home/circleci/.cargo/registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ An EtherCAT master written in Rust.
 - [#121] **Linux only:** Relax `'static` lifetime requirement on `std::tx_rx_task` to a named
   lifetime to allow non-`'static` storage to be used.
 - [#124] Fixed some spurious panics from race conditions by using atomic wakers.
+- [#127] Improve frame allocation reliability when contention is high.
 
 ### Changed
 
@@ -248,5 +249,6 @@ An EtherCAT master written in Rust.
 [#124]: https://github.com/ethercrab-rs/ethercrab/pull/124
 [#125]: https://github.com/ethercrab-rs/ethercrab/pull/125
 [#126]: https://github.com/ethercrab-rs/ethercrab/pull/126
+[#127]: https://github.com/ethercrab-rs/ethercrab/pull/127
 [0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ethercrab-rs/ethercrab/compare/fb37346...v0.1.0

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -158,7 +158,15 @@ impl<const N: usize> FrameElement<N> {
     pub unsafe fn claim_receiving(
         this: NonNull<FrameElement<N>>,
     ) -> Option<NonNull<FrameElement<N>>> {
-        Self::swap_state(this, FrameState::Sent, FrameState::RxBusy).ok()
+        Self::swap_state(this, FrameState::Sent, FrameState::RxBusy)
+            .map_err(|actual_state| {
+                fmt::error!(
+                    "Failed to claim receiving frame: expected state {:?}, but got {:?}",
+                    FrameState::Sent,
+                    actual_state
+                );
+            })
+            .ok()
     }
 }
 

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -139,7 +139,7 @@ impl<const N: usize> FrameElement<N> {
         // matters slightly less for all other state transitions because once we have a created
         // frame nothing else is able to take it unless it is put back into the `None` state.
         Self::swap_state(this, FrameState::None, FrameState::Created).map_err(|e| {
-            fmt::error!(
+            fmt::debug!(
                 "Failed to claim frame: status is {:?}, expected {:?}",
                 e,
                 FrameState::None

--- a/src/pdu_loop/frame_element/received_frame.rs
+++ b/src/pdu_loop/frame_element/received_frame.rs
@@ -70,7 +70,16 @@ impl<'sto> Drop for ReceivedFrame<'sto> {
     fn drop(&mut self) {
         fmt::trace!("Drop frame element idx {}", self.frame().index);
 
-        unsafe { FrameElement::set_state(self.inner.frame, FrameState::None) }
+        unsafe {
+            // Invariant: the frame can only be in `RxProcessing` at this point, so if this swap
+            // fails there's either a logic bug, or we should panic anyway because the hardware
+            // failed.
+            fmt::unwrap!(FrameElement::swap_state(
+                self.inner.frame,
+                FrameState::RxProcessing,
+                FrameState::None
+            ));
+        }
     }
 }
 

--- a/src/pdu_loop/frame_element/receiving_frame.rs
+++ b/src/pdu_loop/frame_element/receiving_frame.rs
@@ -42,7 +42,9 @@ impl<'sto> ReceivingFrame<'sto> {
         unsafe {
             // NOTE: claim_receiving sets the state to `RxBusy` during parsing of the incoming frame
             // so the previous state here should be RxBusy.
-            FrameElement::set_state(self.inner.frame, FrameState::RxDone);
+            FrameElement::swap_state(self.inner.frame, FrameState::RxBusy, FrameState::RxDone)
+                .map(|_| ())
+                .map_err(|_| Error::Pdu(PduError::InvalidFrameState))?;
         }
 
         unsafe { self.inner.wake() };
@@ -88,6 +90,22 @@ pub struct ReceiveFrameFut<'sto> {
 // not, the associated lifetime will prevent the framebox from being used in anything that requires
 // a 'static bound.
 unsafe impl<'sto> Send for ReceiveFrameFut<'sto> {}
+
+// If this impl is removed, timed out frames will never be reclaimed, clogging up the PDU loop and
+// crashing the program.
+impl<'sto> Drop for ReceiveFrameFut<'sto> {
+    fn drop(&mut self) {
+        match self.frame.take() {
+            Some(r) => {
+                fmt::debug!("Dropping in-flight future, possibly caused by timeout");
+
+                // Make frame available for reuse if this future is dropped.
+                unsafe { FrameElement::set_state(r.frame, FrameState::None) };
+            }
+            None => (),
+        }
+    }
+}
 
 impl<'sto> Future for ReceiveFrameFut<'sto> {
     type Output = Result<ReceivedFrame<'sto>, Error>;

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -152,12 +152,10 @@ impl<'sto> PduLoop<'sto> {
             match crate::timer_factory::timeout(timeout, frame).await {
                 Ok(result) => return Ok(result),
                 Err(Error::Timeout) => {
-                    fmt::error!("Frame {} timed out, releasing", frame_idx);
+                    fmt::error!("Frame {} timed out", frame_idx);
 
-                    // If we're retrying, this frees up the frame slot for reclamation, either by
-                    // this loop or other things that want to send stuff. If we're timing out on
-                    // first failure, this frees the frame up for reuse elsewhere.
-                    self.storage.release_frame(frame_idx);
+                    // NOTE: The `Drop` impl of `ReceiveFrameFut` frees the frame by setting its
+                    // state to `None`, ready for reuse.
                 }
                 Err(e) => return Err(e),
             }

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -102,6 +102,8 @@ impl<'sto> PduRx<'sto> {
             Ok(())
         })()
         .map_err(|e| {
+            fmt::error!("Parse frame failed: {}", e);
+
             frame.release_receiving_claim();
 
             e

--- a/src/pdu_loop/storage.rs
+++ b/src/pdu_loop/storage.rs
@@ -133,17 +133,43 @@ impl<'sto> PduStorageRef<'sto> {
             return Err(PduError::TooLong.into());
         }
 
-        let idx_u8 = self.idx.fetch_add(1, Ordering::Relaxed) % self.num_frames as u8;
+        let mut search = 0;
 
-        let idx = usize::from(idx_u8);
+        // Find next frame that is not currently in use.
+        let (frame, idx_u8) = loop {
+            let idx_u8 = self.idx.fetch_add(1, Ordering::Relaxed) % self.num_frames as u8;
 
-        fmt::trace!("Try to allocate frame #{}", idx);
+            let idx = usize::from(idx_u8);
 
-        // Claim frame so it is no longer free and can be used. It must be claimed before
-        // initialisation to avoid race conditions with other threads potentially claiming the same
-        // frame.
-        let frame = unsafe { NonNull::new_unchecked(self.frame_at_index(idx)) };
-        let frame = unsafe { FrameElement::claim_created(frame) }?;
+            fmt::trace!("Try to allocate frame #{}", idx);
+
+            // Claim frame so it is no longer free and can be used. It must be claimed before
+            // initialisation to avoid race conditions with other threads potentially claiming the
+            // same frame.
+            let frame = unsafe { NonNull::new_unchecked(self.frame_at_index(idx)) };
+            let frame = unsafe { FrameElement::claim_created(frame) };
+
+            if let Ok(f) = frame {
+                break (f, idx_u8);
+            }
+
+            search += 1;
+
+            // Escape hatch: we'll only loop through the frame storage array twice to put an upper
+            // bound on the number of times this loop can execute. It could be allowed to execute
+            // indefinitely and rely on PDU future timeouts to cancel, but that seems brittle hence
+            // this safety check.
+            //
+            // This can be mitigated by using a `RetryBehaviour` of `Count` or `Forever`.
+            if search > self.num_frames * 2 {
+                // We've searched twice and found no free slots. This means the application should
+                // either slow down its packet sends, or increase `N` in `PduStorage` as there
+                // aren't enough slots to hold all in-flight packets.
+                fmt::error!("No available frames in {} slots", self.num_frames);
+
+                return Err(PduError::SwapState.into());
+            }
+        };
 
         // Initialise frame with EtherCAT header and zeroed data buffer.
         unsafe {

--- a/src/pdu_loop/storage.rs
+++ b/src/pdu_loop/storage.rs
@@ -1,3 +1,4 @@
+use super::{pdu_rx::PduRx, pdu_tx::PduTx};
 use crate::{
     command::Command,
     error::{Error, PduError},
@@ -19,8 +20,6 @@ use core::{
     ptr::{addr_of_mut, NonNull},
     sync::atomic::{AtomicBool, AtomicU8, Ordering},
 };
-
-use super::{frame_element::FrameState, pdu_rx::PduRx, pdu_tx::PduTx};
 
 /// Stores PDU frames that are currently being prepared to send, in flight, or being received and
 /// processed.
@@ -167,16 +166,6 @@ impl<'sto> PduStorageRef<'sto> {
                 _lifetime: PhantomData,
             },
         })
-    }
-
-    pub(in crate::pdu_loop) fn release_frame(&self, idx: u8) {
-        let idx = usize::from(idx);
-
-        if idx < self.num_frames {
-            let frame = unsafe { NonNull::new_unchecked(self.frame_at_index(idx)) };
-
-            unsafe { FrameElement::set_state(frame, FrameState::None) };
-        }
     }
 
     /// Updates state from SENDING -> RX_BUSY


### PR DESCRIPTION
Prior to this PR, if the frame slot at the `N + 1`th index was still occupied, an error would occur. Now, the PDU loop storage code will loop through the entire slot space up to 2 times looking for a free slot to use.

This mitigates situations where a frame from a previous cycle or another thread is still marked as in use (e.g. because its payload data is still held). Now, the PDU loop will skip over that slot and go looking for the next free one. Not a total fix, but much improved when testing with 11 threads - one tx/rx and 10 others running tasks simultaneously.

Also adds a bunch of logging.