### PR TITLE
No longer check mailbox counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- [#130](https://github.com/ethercrab-rs/ethercrab/pull/130) Counter in mailbox response is no
+  longer checked.
+
 ## [0.3.2] - 2023-11-02
 
 ### Added
@@ -205,8 +210,8 @@ An EtherCAT master written in Rust.
 - Initial release
 
 <!-- next-url -->
-[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.2...HEAD
 
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.2...HEAD
 [0.3.2]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.0...v0.3.2
 [0.3.1]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.2.1...v0.3.0

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -53,6 +53,14 @@ pub struct MailboxHeader {
     pub mailbox_type: MailboxType,
     /// Mailbox counter from 1 to 7 inclusive. Wraps around to 1 when count exceeds 7. 0 is
     /// reserved.
+    ///
+    /// Described in ETG1000.4, Section 5.6, Table 29 - Mailbox:
+    ///
+    /// > The Slave shall increment the Cnt value for each new mailbox service, the Master shall
+    /// > check this for detection of lost mailbox services. The Master shall change (should
+    /// > increment) the Cnt value. The slave shall check this for detection of a write repeat
+    /// > service. The Slave shall not check the sequence of the Cnt value. The master and the slave
+    /// > Cnt values are independent
     #[packed_field(bits = "41..=43")]
     pub counter: u8,
     // _reserved1: u8

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -421,7 +421,7 @@ where
             }))
         }
         // Validate that the mailbox response is to the request we just sent
-        else if headers.mailbox_type() != MailboxType::Coe || headers.counter() != counter {
+        else if headers.mailbox_type() != MailboxType::Coe {
             fmt::error!(
                 "Invalid SDO response. Type: {:?} (expected {:?}), counter {} (expected {})",
                 headers.mailbox_type(),


### PR DESCRIPTION
The spec seems a little vague on what to actually do with the counter, and as far as I can read into SOEM's rather dence C it doesn't seem to check the value either. Based on this, I've removed the check in EtherCrab.

Closes #128 