### PR TITLE
Shuffle `SlaveRef` methods around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ An EtherCAT master written in Rust.
 
 - [#135](https://github.com/ethercrab-rs/ethercrab/pull/135) macOS only: `tx_rx_task` now uses
   native networking (BPF) instead of `libpcapng` to improve reliability.
+- **(breaking)** [#136](https://github.com/ethercrab-rs/ethercrab/pull/136) Fix unsoundness issue
+  where `SlaveRef::io_raw` could be called multiple times, allowing multiple mutable references into
+  the device's output data.
+- **(breaking)** [#136](https://github.com/ethercrab-rs/ethercrab/pull/136) Rename
+  `SlaveRef::io_raw` to `SlaveRef::io_raw_mut`. `SlaveRef::io_raw` remains, but now only returns
+  non-mutable references to both the device inputs and outputs.
+
+  Also renames `SlaveRef::outputs_raw` to `SlaveRef::outputs_raw_mut`. `SlaveRef::outputs` now
+  returns a non-mutable reference to the device output data.
 
 ## [0.3.4] - 2023-11-20
 

--- a/Justfile
+++ b/Justfile
@@ -35,6 +35,8 @@ linux-bench *args:
 
 generate-readme:
      cargo readme > README.md
+     # Remove unprocessed doc links
+     sed -i 's/\[\(`[^`]*`\)] /\1 /g' README.md
 
 check-readme: (generate-readme)
      git diff --quiet --exit-code README.md

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A performant, `async`-first EtherCAT master written in pure Rust.
 
 ## Crate features
 
-- `std` (enabled by default) - exposes the [`std`] module, containing helpers to run the TX/RX
+- `std` (enabled by default) - exposes the `std` module, containing helpers to run the TX/RX
   loop on desktop operating systems.
 - `defmt` - enable logging with the [`defmt`](https://docs.rs/defmt) crate.
 - `log` - enable logging with the [`log`](https://docs.rs/log) crate. This is enabled by default
@@ -140,8 +140,8 @@ async fn main() -> Result<(), Error> {
         group.tx_rx(&client).await.expect("TX/RX");
 
         // Increment every output byte for every slave device by one
-        for slave in group.iter(&client) {
-            let (_i, o) = slave.io_raw();
+        for mut slave in group.iter(&client) {
+            let (_i, o) = slave.io_raw_mut();
 
             for byte in o.iter_mut() {
                 *byte = byte.wrapping_add(1);

--- a/examples/akd.rs
+++ b/examples/akd.rs
@@ -124,7 +124,7 @@ async fn main() -> Result<(), Error> {
 
     log::info!("Discovered {} slaves", group.len());
 
-    let slave = group.slave(&client, 0).expect("first slave not found");
+    let mut slave = group.slave(&client, 0).expect("first slave not found");
 
     // Run twice to prime PDI
     group.tx_rx(&client).await.expect("TX/RX");
@@ -154,7 +154,7 @@ async fn main() -> Result<(), Error> {
 
         group.tx_rx(&client).await.expect("TX/RX");
 
-        let (i, o) = slave.io_raw();
+        let (i, o) = slave.io_raw_mut();
 
         let status = {
             let status = u16::from_le_bytes(i[4..=5].try_into().unwrap());
@@ -173,7 +173,7 @@ async fn main() -> Result<(), Error> {
             loop {
                 group.tx_rx(&client).await.expect("TX/RX");
 
-                let (i, _o) = slave.io_raw();
+                let (i, _o) = slave.io_raw_mut();
 
                 let status = {
                     let status = u16::from_le_bytes(i[4..=5].try_into().unwrap());
@@ -196,7 +196,7 @@ async fn main() -> Result<(), Error> {
     {
         log::info!("Putting drive in shutdown state");
 
-        let (_i, o) = slave.io_raw();
+        let (_i, o) = slave.io_raw_mut();
 
         let (_pos_cmd, control) = o.split_at_mut(4);
         let value = AkdControlWord::SHUTDOWN;
@@ -206,7 +206,7 @@ async fn main() -> Result<(), Error> {
         loop {
             group.tx_rx(&client).await.expect("TX/RX");
 
-            let (i, _o) = slave.io_raw();
+            let (i, _o) = slave.io_raw_mut();
 
             let status = {
                 let status = u16::from_le_bytes(i[4..=5].try_into().unwrap());
@@ -228,7 +228,7 @@ async fn main() -> Result<(), Error> {
     {
         log::info!("Switching drive on");
 
-        let (_i, o) = slave.io_raw();
+        let (_i, o) = slave.io_raw_mut();
 
         let (_pos_cmd, control) = o.split_at_mut(4);
         let reset = AkdControlWord::SWITCH_ON
@@ -240,7 +240,7 @@ async fn main() -> Result<(), Error> {
         loop {
             group.tx_rx(&client).await.expect("TX/RX");
 
-            let (i, o) = slave.io_raw();
+            let (i, o) = slave.io_raw_mut();
 
             let status = {
                 let status = u16::from_le_bytes(i[4..=5].try_into().unwrap());
@@ -273,7 +273,7 @@ async fn main() -> Result<(), Error> {
     loop {
         group.tx_rx(&client).await.expect("TX/RX");
 
-        let (i, o) = slave.io_raw();
+        let (i, o) = slave.io_raw_mut();
 
         let (pos, status) = {
             let pos = u32::from_le_bytes(i[0..=3].try_into().unwrap());

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -108,8 +108,8 @@ async fn main() -> Result<(), Error> {
             .receive::<u64>(&client)
             .await?;
 
-        for slave in group.iter(&client) {
-            let (_i, o) = slave.io_raw();
+        for mut slave in group.iter(&client) {
+            let (_i, o) = slave.io_raw_mut();
 
             for byte in o.iter_mut() {
                 *byte = byte.wrapping_add(1);

--- a/examples/ec400.rs
+++ b/examples/ec400.rs
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Error> {
             //     .await?;
 
             let status = servo.status_word();
-            let (i, o) = servo.slave().io_raw();
+            let (i, o) = servo.slave().io_raw_mut();
 
             let (pos, vel) = {
                 let pos = i32::from_le_bytes(i[2..=5].try_into().unwrap());
@@ -211,7 +211,7 @@ async fn main() -> Result<(), Error> {
         }
 
         let status = servo.status_word();
-        let (i, o) = servo.slave().io_raw();
+        let (i, o) = servo.slave().io_raw_mut();
 
         let (pos, vel) = {
             let pos = i32::from_le_bytes(i[2..=5].try_into().unwrap());

--- a/examples/ek1100.rs
+++ b/examples/ek1100.rs
@@ -101,8 +101,8 @@ async fn main() -> Result<(), Error> {
         group.tx_rx(&client).await.expect("TX/RX");
 
         // Increment every output byte for every slave device by one
-        for slave in group.iter(&client) {
-            let (_i, o) = slave.io_raw();
+        for mut slave in group.iter(&client) {
+            let (_i, o) = slave.io_raw_mut();
 
             for byte in o.iter_mut() {
                 *byte = byte.wrapping_add(1);

--- a/examples/embassy-stm32/src/main.rs
+++ b/examples/embassy-stm32/src/main.rs
@@ -190,7 +190,7 @@ async fn main(spawner: Spawner) {
         defmt::unwrap!(group.tx_rx(&client).await);
 
         // Increment every output byte for every slave device by one
-        for slave in group.iter(&client) {
+        for mut slave in group.iter(&client) {
             let (_i, o) = slave.io_raw_mut();
 
             for byte in o.iter_mut() {

--- a/examples/embassy-stm32/src/main.rs
+++ b/examples/embassy-stm32/src/main.rs
@@ -191,7 +191,7 @@ async fn main(spawner: Spawner) {
 
         // Increment every output byte for every slave device by one
         for slave in group.iter(&client) {
-            let (_i, o) = slave.io_raw();
+            let (_i, o) = slave.io_raw_mut();
 
             for byte in o.iter_mut() {
                 *byte = byte.wrapping_add(1);

--- a/examples/jitter.rs
+++ b/examples/jitter.rs
@@ -146,8 +146,8 @@ fn main() -> Result<(), Error> {
             group.tx_rx(&client).await.expect("TX/RX");
 
             // Increment every output byte for every slave device by one
-            for slave in group.iter(&client) {
-                let (_i, o) = slave.io_raw();
+            for mut slave in group.iter(&client) {
+                let (_i, o) = slave.io_raw_mut();
 
                 for byte in o.iter_mut() {
                     *byte = byte.wrapping_add(1);

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -133,13 +133,13 @@ async fn main() -> Result<(), ethercrab::error::Error> {
         let mut tick = Instant::now();
 
         // EK1100 is first slave, EL2889 is second
-        let el2889 = slow_outputs
+        let mut el2889 = slow_outputs
             .slave(&client_slow, 1)
             .expect("EL2889 not present!");
 
         // Set initial output state
-        el2889.io_raw().1[0] = 0x01;
-        el2889.io_raw().1[1] = 0x80;
+        el2889.io_raw_mut().1[0] = 0x01;
+        el2889.io_raw_mut().1[1] = 0x80;
 
         loop {
             slow_outputs.tx_rx(&client_slow).await.expect("TX/RX");
@@ -148,7 +148,7 @@ async fn main() -> Result<(), ethercrab::error::Error> {
             if tick.elapsed() > slow_duration {
                 tick = Instant::now();
 
-                let (_i, o) = el2889.io_raw();
+                let (_i, o) = el2889.io_raw_mut();
 
                 // Make a nice pattern on EL2889 LEDs
                 o[0] = o[0].rotate_left(1);
@@ -169,8 +169,8 @@ async fn main() -> Result<(), ethercrab::error::Error> {
             fast_outputs.tx_rx(&client).await.expect("TX/RX");
 
             // Increment every output byte for every slave device by one
-            for slave in fast_outputs.iter(&client) {
-                let (_i, o) = slave.io_raw();
+            for mut slave in fast_outputs.iter(&client) {
+                let (_i, o) = slave.io_raw_mut();
 
                 for byte in o.iter_mut() {
                     *byte = byte.wrapping_add(1);

--- a/src/ds402.rs
+++ b/src/ds402.rs
@@ -167,7 +167,7 @@ impl<'a> Ds402<'a> {
     }
 
     fn set_control_word(&mut self, state: ControlWord) {
-        let (control, _rest) = self.slave.outputs_raw().split_at_mut(2);
+        let (control, _rest) = self.slave.outputs_raw_mut().split_at_mut(2);
 
         let state = state.bits().to_le_bytes();
 
@@ -197,8 +197,8 @@ impl<'a> Ds402Sm<'a> {
     }
 
     /// Get a reference to the underlying EtherCAT slave device.
-    pub fn slave(&self) -> &SlaveRef<'a, SlavePdi<'a>> {
-        &self.sm.context().slave
+    pub fn slave(&mut self) -> &mut SlaveRef<'a, SlavePdi<'a>> {
+        &mut self.sm.context_mut().slave
     }
 
     /// Get the DS402 status word.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,8 @@
 //!         group.tx_rx(&client).await.expect("TX/RX");
 //!
 //!         // Increment every output byte for every slave device by one
-//!         for slave in group.iter(&client) {
-//!             let (_i, o) = slave.io_raw();
+//!         for mut slave in group.iter(&client) {
+//!             let (_i, o) = slave.io_raw_mut();
 //!
 //!             for byte in o.iter_mut() {
 //!                 *byte = byte.wrapping_add(1);

--- a/src/slave/pdi.rs
+++ b/src/slave/pdi.rs
@@ -89,8 +89,8 @@ impl<'a, 'group> SlaveRef<'a, SlavePdi<'group>> {
 
     /// Get a tuple of (&I, &O) for this slave in the Process Data Image (PDI).
     ///
-    /// To get a mutable reference to the slave outputs, see either [`io_raw_mut`] or
-    /// [`outputs_mut`].
+    /// To get a mutable reference to the slave outputs, see either
+    /// [`io_raw_mut`](SlaveRef::io_raw_mut) or [`outputs_raw_mut`](SlaveRef::outputs_raw_mut).
     ///
     /// # Examples
     ///

--- a/src/slave/pdi.rs
+++ b/src/slave/pdi.rs
@@ -38,8 +38,35 @@ impl<'group> SlavePdi<'group> {
 
 /// Methods used when a slave device is part of a group and part of the PDI has been mapped to it.
 impl<'a, 'group> SlaveRef<'a, SlavePdi<'group>> {
-    /// Get a tuple of (I, O) for this slave in the Process Data Image (PDI).
-    pub fn io_raw(&self) -> (&[u8], &mut [u8]) {
+    /// Get a tuple of (&I, &mut O) for this slave in the Process Data Image (PDI).
+    ///
+    /// # Examples
+    ///
+    /// ## Disallow multiple mutable references
+    ///
+    /// ```compile_fail,E0499
+    /// // error[E0499]: cannot borrow `slave` as mutable more than once at a time
+    /// # use ethercrab::{
+    /// #     error::Error, std::tx_rx_task, Client, ClientConfig, PduStorage, SlaveGroup,
+    /// #      SlaveGroupState, Timeouts,
+    /// # };
+    /// # async fn case() {
+    /// # static PDU_STORAGE: PduStorage<8, 8> = PduStorage::new();
+    /// # let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
+    /// # let client = Client::new(pdu_loop, Timeouts::default(), ClientConfig::default());
+    /// let mut group = client.init_single_group::<8, 8>().await.expect("Init");
+    /// let group = group.into_op(&client).await.expect("Op");
+    /// let mut slave = group.slave(&client, 0).expect("No device");
+    ///
+    /// let (i1, o1) = slave.io_raw_mut();
+    ///
+    /// // Danger: second reference to mutable outputs! This will fail to copmile.
+    /// let (i2, o2) = slave.io_raw_mut();
+    ///
+    /// o1[0] = 0xaa;
+    /// # }
+    /// ```
+    pub fn io_raw_mut(&mut self) -> (&[u8], &mut [u8]) {
         (
             self.state.inputs,
             // SAFETY: `self.state.inputs` and `self.state.outputs` can never overlap for valid
@@ -48,6 +75,9 @@ impl<'a, 'group> SlaveRef<'a, SlavePdi<'group>> {
             // SAFETY: Only one instance of `SlavePdi` can exist for any given slave (and therefore
             // any given non-overlapping PDI slice) due to the usage of `AtomicRefCell` and runtime
             // checked borrows.
+            //
+            // SAFETY: `io_raw_mut` must be `&mut self`, not `&self` to ensure the mutable borrow cannot
+            // be held more than once at a time.
             unsafe {
                 core::slice::from_raw_parts_mut(
                     self.state.outputs.as_ptr() as *mut u8,
@@ -57,7 +87,43 @@ impl<'a, 'group> SlaveRef<'a, SlavePdi<'group>> {
         )
     }
 
-    /// Get just the inputs for this slave in the Process Data Image (PDI).
+    /// Get a tuple of (&I, &O) for this slave in the Process Data Image (PDI).
+    ///
+    /// To get a mutable reference to the slave outputs, see either [`io_raw_mut`] or
+    /// [`outputs_mut`].
+    ///
+    /// # Examples
+    ///
+    /// ## Disallow multiple mutable references
+    ///
+    /// ```compile_fail,E0502
+    /// // error[E0502]: cannot borrow `slave` as immutable because it is also borrowed as mutable
+    /// # use ethercrab::{
+    /// #     error::Error, std::tx_rx_task, Client, ClientConfig, PduStorage, SlaveGroup,
+    /// #      SlaveGroupState, Timeouts,
+    /// # };
+    /// # async fn case() {
+    /// # static PDU_STORAGE: PduStorage<8, 8> = PduStorage::new();
+    /// # let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
+    /// # let client = Client::new(pdu_loop, Timeouts::default(), ClientConfig::default());
+    /// let mut group = client.init_single_group::<8, 8>().await.expect("Init");
+    /// let group = group.into_op(&client).await.expect("Op");
+    /// let mut slave = group.slave(&client, 0).expect("No device");
+    ///
+    /// let (i1, o1_mut) = slave.io_raw_mut();
+    ///
+    /// // Not allowed: outputs are already mutably borrowed so we cannot hold another reference to
+    /// // them until that borrow is dropped.
+    /// let (i2, o2) = slave.io_raw();
+    ///
+    /// o1_mut[0] = 0xff;
+    /// # }
+    /// ```
+    pub fn io_raw(&self) -> (&[u8], &[u8]) {
+        (self.state.inputs, self.state.outputs)
+    }
+
+    /// Get a reference to the raw input data for this slave in the Process Data Image (PDI).
     pub fn inputs_raw(&self) -> &[u8] {
         self.state.inputs
     }

--- a/src/slave/pdi.rs
+++ b/src/slave/pdi.rs
@@ -128,8 +128,14 @@ impl<'a, 'group> SlaveRef<'a, SlavePdi<'group>> {
         self.state.inputs
     }
 
-    /// Get just the outputs for this slave in the Process Data Image (PDI).
-    pub fn outputs_raw(&mut self) -> &mut [u8] {
+    /// Get a reference to the raw output data for this slave in the Process Data Image (PDI).
+    pub fn outputs_raw(&self) -> &[u8] {
+        self.state.outputs
+    }
+
+    /// Get a mutable reference to the raw output data for this slave in the Process Data Image
+    /// (PDI).
+    pub fn outputs_raw_mut(&mut self) -> &mut [u8] {
         self.state.outputs
     }
 }

--- a/tests/replay-ek1100-el2828-el2889.rs
+++ b/tests/replay-ek1100-el2828-el2889.rs
@@ -71,17 +71,17 @@ async fn replay_ek1100_el2828_el2889() -> Result<(), Error> {
     let mut slow_cycle_time = tokio::time::interval(Duration::from_millis(10));
     slow_cycle_time.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-    let el2889 = slow_outputs.slave(&client, 1).expect("EL2889 not present!");
+    let mut el2889 = slow_outputs.slave(&client, 1).expect("EL2889 not present!");
 
     // Set initial output state
-    el2889.io_raw().1[0] = 0x01;
-    el2889.io_raw().1[1] = 0x80;
+    el2889.io_raw_mut().1[0] = 0x01;
+    el2889.io_raw_mut().1[1] = 0x80;
 
     // Animate slow pattern for 8 ticks
     for _ in 0..8 {
         slow_outputs.tx_rx(&client).await.expect("TX/RX");
 
-        let (_i, o) = el2889.io_raw();
+        let (_i, o) = el2889.io_raw_mut();
 
         // Make a nice pattern on EL2889 LEDs
         o[0] = o[0].rotate_left(1);
@@ -98,8 +98,8 @@ async fn replay_ek1100_el2828_el2889() -> Result<(), Error> {
         fast_outputs.tx_rx(&client).await.expect("TX/RX");
 
         // Increment every output byte for every slave device by one
-        for slave in fast_outputs.iter(&client) {
-            let (_i, o) = slave.io_raw();
+        for mut slave in fast_outputs.iter(&client) {
+            let (_i, o) = slave.io_raw_mut();
 
             for byte in o.iter_mut() {
                 *byte = byte.wrapping_add(1);


### PR DESCRIPTION
Breaking change. Sorry about that! The fix is a rename and the odd `mut` here and there so hopefully not too bad.

Some fixes and additions for `SlaveRef` methods:

- Adds `io_raw_mut` and `outputs_mut`. `io_raw` and `outputs` now only return immutable references.
- Fixes a soundness bug where multiple calls to `io_raw` would result in multiple mutable references being held to the same data.