### PR TITLE
Add `ethercrab-wire` and `ethercrab-wire-derive` crates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-target_steps: &target_steps
+target_steps_std: &target_steps_std
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
     - image: cimg/rust:1.72
@@ -25,8 +25,8 @@ target_steps: &target_steps
 
     - run: rustup target add $TARGET || true
     - run: cargo fmt --all -- --check
-    - run: just check-readme
-    - run: cargo test --target $TARGET
+    - run: just check-readmes
+    - run: cargo test --target $TARGET --workspace
     - run: cargo bench --no-run --target $TARGET
     - run: cargo build --target $TARGET --examples --release
     - run: cargo build --target $TARGET --no-default-features
@@ -125,7 +125,7 @@ jobs:
     resource_class: large
     environment:
       - TARGET: "x86_64-unknown-linux-gnu"
-    <<: *target_steps
+    <<: *target_steps_std
 
   miri-x86_64-unknown-linux-gnu:
     resource_class: large

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ An EtherCAT master written in Rust.
 - [#134](https://github.com/ethercrab-rs/ethercrab/pull/134) Refactor sub device EEPROM reader to be
   more efficient when skipping sections of the device EEPROM map.
 
+### Added
+
+- [#TODO](https://github.com/ethercrab-rs/ethercrab/pull/TODO) Added the `ethercat-wire` and
+  `ethercat-wire-derive` crates.
+
+  These crates are **EXPERIMENTAL**. They may be improved for public use in the future but are
+  currently designed around EtherCrab's internal needs and may be rough and/or buggy. Use with
+  caution, and expect breaking changes.
+
+- [#TODO](https://github.com/ethercrab-rs/ethercrab/pull/TODO) Re-export the following traits from
+  `ethercrab-wire` for dealing with packing/unpacking data:
+
+  - `EtherCrabWireRead`
+  - `EtherCrabWireReadSized`
+  - `EtherCrabWireReadWrite`
+  - `EtherCrabWireSized`
+  - `EtherCrabWireWrite`
+
 ## [0.3.5] - 2023-12-22
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ exclude = ["dumps", "doc", "NOTES.md", "SPECNOTES.md"]
 resolver = "2"
 rust-version = "1.75"
 
+[workspace]
+members = ["ethercrab-wire", "ethercrab-wire-derive"]
+
 [package.metadata.docs.rs]
 default-target = "x86_64-unknown-linux-gnu"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu"]
@@ -41,6 +44,7 @@ smoltcp = { version = "0.11.0", default-features = false, features = [
     "socket-raw",
     "medium-ethernet",
 ] }
+ethercrab-wire = { version = "0.0.0", path = "./ethercrab-wire" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 pnet_datalink = { version = "0.34.0", features = ["std"], optional = true }
@@ -85,6 +89,7 @@ defmt = [
     "smoltcp/defmt",
     "embedded-io-async/defmt-03",
     "heapless/defmt-03",
+    "ethercrab-wire/defmt-03",
 ]
 log = ["dep:log"]
 std = [
@@ -94,6 +99,7 @@ std = [
     "log",
     "futures-lite/std",
     "embedded-io-async/std",
+    "ethercrab-wire/std",
 ]
 serde = ["dep:serde", "bitflags/serde"]
 # Development only - DO NOT USE

--- a/Justfile
+++ b/Justfile
@@ -33,13 +33,17 @@ linux-bench *args:
      fd . --type executable ./target/release/deps -x sudo setcap cap_net_raw=pe
      cargo bench --features __internals {{args}}
 
-generate-readme:
-     cargo readme > README.md
+_generate-readme path:
+     cargo readme --project-root "{{path}}" --template README.tpl --output README.md
      # Remove unprocessed doc links
      sed -i 's/\[\(`[^`]*`\)] /\1 /g' README.md
 
-check-readme: (generate-readme)
-     git diff --quiet --exit-code README.md
+_check-readme path: (_generate-readme path)
+     git diff --quiet --exit-code "{{path}}/README.md"
+
+check-readmes: (_check-readme ".") (_check-readme "./ethercrab-wire") (_check-readme "./ethercrab-wire-derive")
+
+generate-readmes: (_generate-readme ".") (_generate-readme "./ethercrab-wire") (_generate-readme "./ethercrab-wire-derive")
 
 dump-eeprom *args:
      cargo build --example dump-eeprom --features "std __internals" --release && \

--- a/ethercrab-wire-derive/CHANGELOG.md
+++ b/ethercrab-wire-derive/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+Derives for `ethercrab`.
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
+
+### Added
+
+- Initial release
+
+<!-- next-url -->
+
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/HEAD...HEAD

--- a/ethercrab-wire-derive/Cargo.toml
+++ b/ethercrab-wire-derive/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ethercrab-wire-derive"
+version = "0.0.0"
+edition = "2021"
+categories = ["science::robotics", "no-std", "network-programming"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/ethercrab-rs/ethercrab"
+documentation = "https://docs.rs/ethercrab-derive"
+description = "Derive macros for EtherCrab"
+resolver = "2"
+keywords = ["ethercat", "ethercrab"]
+
+[lib]
+proc-macro = true
+# Explicitly written here to make cargo-readme happy <https://github.com/webern/cargo-readme/issues/32>
+path = "src/lib.rs"
+
+[dependencies]
+proc-macro2 = "1.0.73"
+quote = "1.0.34"
+syn = { version = "2.0.44", features = ["full"] }
+
+[dev-dependencies]
+trybuild = "1.0.86"
+ethercrab-wire = { path = "../ethercrab-wire" }
+syn = { version = "2.0.44", features = ["full", "extra-traits"] }

--- a/ethercrab-wire-derive/README.md
+++ b/ethercrab-wire-derive/README.md
@@ -1,0 +1,21 @@
+# `ethercrab-wire`
+
+[![Build Status](https://circleci.com/gh/ethercrab-rs/ethercrab/tree/master.svg?style=shield)](https://circleci.com/gh/ethercrab-rs/ethercrab/tree/master)
+[![Crates.io](https://img.shields.io/crates/v/ethercrab-wire.svg)](https://crates.io/crates/ethercrab-wire)
+[![Docs.rs](https://docs.rs/ethercrab-wire/badge.svg)](https://docs.rs/ethercrab-wire)
+
+## Experimental
+
+This crate may expand in the future but is currently only used internally by
+[`ethercrab`](https://crates.io/crates/ethercrab) itself. It is experimental and may change at
+any time, so please do not depend on or rely on any of this crate's items.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/ethercrab-wire-derive/README.tpl
+++ b/ethercrab-wire-derive/README.tpl
@@ -1,0 +1,17 @@
+# `ethercrab-wire`
+
+[![Build Status](https://circleci.com/gh/ethercrab-rs/ethercrab/tree/master.svg?style=shield)](https://circleci.com/gh/ethercrab-rs/ethercrab/tree/master)
+[![Crates.io](https://img.shields.io/crates/v/ethercrab-wire.svg)](https://crates.io/crates/ethercrab-wire)
+[![Docs.rs](https://docs.rs/ethercrab-wire/badge.svg)](https://docs.rs/ethercrab-wire)
+
+{{readme}}
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/ethercrab-wire-derive/src/generate_enum.rs
+++ b/ethercrab-wire-derive/src/generate_enum.rs
@@ -1,0 +1,248 @@
+use crate::parse_enum::EnumMeta;
+use quote::quote;
+use std::str::FromStr;
+use syn::DeriveInput;
+
+pub fn generate_enum_write(
+    parsed: EnumMeta,
+    input: &DeriveInput,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let name = input.ident.clone();
+    let repr_type = parsed.repr_type;
+    let size_bytes = match repr_type.to_string().as_str() {
+        "u8" => 1usize,
+        "u16" => 2,
+        "u32" => 4,
+        invalid => unreachable!("Invalid repr {}", invalid),
+    };
+
+    let pack = if parsed.catch_all.is_some() {
+        let match_arms = parsed.variants.clone().into_iter().map(|variant| {
+            let value =
+                proc_macro2::TokenStream::from_str(&variant.discriminant.to_string()).unwrap();
+            let variant_name = variant.name;
+
+            if variant.catch_all {
+                quote! {
+                    #name::#variant_name (value) => { *value }
+                }
+            } else {
+                quote! {
+                    #name::#variant_name => { #value }
+                }
+            }
+        });
+
+        quote! {
+            let value: #repr_type = match self {
+                #(#match_arms),*
+            };
+
+            buf.copy_from_slice(&value.to_le_bytes());
+        }
+    } else {
+        quote! {
+            buf.copy_from_slice(&(*self as #repr_type).to_le_bytes());
+        }
+    };
+
+    let out = quote! {
+        impl ::ethercrab_wire::EtherCrabWireWrite for #name {
+            fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
+                let mut buf = &mut buf[0..#size_bytes];
+
+                #pack
+
+                buf
+            }
+
+            fn packed_len(&self) -> usize {
+                #size_bytes
+            }
+        }
+
+        impl ::ethercrab_wire::EtherCrabWireWriteSized for #name {
+            fn pack(&self) -> Self::Buffer {
+                let mut buf = [0u8; #size_bytes];
+
+                <Self as ::ethercrab_wire::EtherCrabWireWrite>::pack_to_slice_unchecked(self, &mut buf);
+
+                buf
+            }
+        }
+
+
+    };
+
+    Ok(out)
+}
+
+pub fn generate_enum_read(
+    parsed: EnumMeta,
+    input: &DeriveInput,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let name = input.ident.clone();
+    let repr_type = parsed.repr_type;
+    let size_bytes = match repr_type.to_string().as_str() {
+        "u8" => 1usize,
+        "u16" => 2,
+        "u32" => 4,
+        invalid => unreachable!("Invalid repr {}", invalid),
+    };
+
+    let primitive_variants = parsed
+        .variants
+        .clone()
+        .into_iter()
+        .filter(|variant| !variant.catch_all);
+
+    let result_match_arms = primitive_variants.clone().map(|variant| {
+        let value = proc_macro2::TokenStream::from_str(&variant.discriminant.to_string()).unwrap();
+        let variant_name = variant.name;
+
+        quote! {
+            #value => { Ok(Self::#variant_name) }
+        }
+    });
+
+    let fallthrough = if let Some(ref catch_all_variant) = parsed.catch_all {
+        let catch_all = catch_all_variant.name.clone();
+
+        quote! {
+            other => Ok(Self::#catch_all(other))
+        }
+    } else if let Some(ref default_variant) = parsed.default_variant {
+        let default = default_variant.name.clone();
+
+        quote! {
+            _other => Ok(Self::#default)
+        }
+    } else {
+        quote! {
+            _other => { Err(::ethercrab_wire::WireError::InvalidValue) }
+        }
+    };
+
+    let match_arms = primitive_variants.clone().map(|variant| {
+        let value = proc_macro2::TokenStream::from_str(&variant.discriminant.to_string()).unwrap();
+        let variant_name = variant.name;
+
+        quote! {
+            #value => { Self::#variant_name }
+        }
+    });
+
+    let from_primitive_impl = if let Some(catch_all_variant) = &parsed.catch_all {
+        let catch_all = catch_all_variant.name.clone();
+        let match_arms = match_arms.clone();
+
+        quote! {
+            impl From<#repr_type> for #name {
+                fn from(value: #repr_type) -> Self {
+                    match value {
+                        #(#match_arms),*
+                        other => Self::#catch_all(other)
+                    }
+                }
+            }
+        }
+    } else if let Some(default_variant) = parsed.default_variant {
+        let default = default_variant.name;
+        let match_arms = match_arms.clone();
+
+        quote! {
+            impl From<#repr_type> for #name {
+                fn from(value: #repr_type) -> Self {
+                    match value {
+                        #(#match_arms),*
+                        other => Self::#default
+                    }
+                }
+            }
+        }
+    } else {
+        let match_arms = result_match_arms.clone();
+
+        quote! {
+            impl TryFrom<#repr_type> for #name {
+                type Error = ::ethercrab_wire::WireError;
+
+                fn try_from(value: #repr_type) -> Result<Self, Self::Error> {
+                    match value {
+                        #(#match_arms),*
+                        _other => Err(::ethercrab_wire::WireError::InvalidValue)
+                    }
+                }
+            }
+        }
+    };
+
+    let into_primitive_impl = if parsed.catch_all.is_some() {
+        let match_arms_from = parsed.variants.clone().into_iter().map(|variant| {
+            let value =
+                proc_macro2::TokenStream::from_str(&variant.discriminant.to_string()).unwrap();
+            let variant_name = variant.name;
+
+            if variant.catch_all {
+                quote! {
+                    #name::#variant_name (value) => { value }
+                }
+            } else {
+                quote! {
+                    #name::#variant_name => { #value }
+                }
+            }
+        });
+
+        quote! {
+            impl From<#name> for #repr_type {
+                fn from(value: #name) -> Self {
+                    match value {
+                        #(#match_arms_from),*
+                    }
+                }
+            }
+        }
+    } else {
+        quote! {
+            impl From<#name> for #repr_type {
+                fn from(value: #name) -> Self {
+                    value as #repr_type
+                }
+            }
+        }
+    };
+
+    let out = quote! {
+        impl ::ethercrab_wire::EtherCrabWireRead for #name {
+            fn unpack_from_slice(buf: &[u8]) -> Result<Self, ::ethercrab_wire::WireError> {
+                let raw = buf.get(0..#size_bytes).map(|bytes| {
+                    #repr_type::from_le_bytes(bytes.try_into().unwrap())
+                }).ok_or(::ethercrab_wire::WireError::ReadBufferTooShort {
+                    expected: #size_bytes,
+                    got: buf.len(),
+                })?;
+
+                match raw {
+                    #(#result_match_arms),*
+                    #fallthrough,
+                }
+            }
+        }
+
+        impl ::ethercrab_wire::EtherCrabWireSized for #name {
+            const PACKED_LEN: usize = #size_bytes;
+
+            type Buffer = [u8; #size_bytes];
+
+            fn buffer() -> Self::Buffer {
+                [0u8; #size_bytes]
+            }
+        }
+
+        #from_primitive_impl
+        #into_primitive_impl
+    };
+
+    Ok(out)
+}

--- a/ethercrab-wire-derive/src/generate_struct.rs
+++ b/ethercrab-wire-derive/src/generate_struct.rs
@@ -1,0 +1,177 @@
+use crate::parse_struct::StructMeta;
+use proc_macro2::{Ident, Span};
+use quote::quote;
+use std::str::FromStr;
+use syn::DeriveInput;
+
+pub fn generate_struct_write(
+    parsed: StructMeta,
+    input: &DeriveInput,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let name = input.ident.clone();
+    let size_bytes = parsed.width_bits.div_ceil(8);
+
+    let fields_pack = parsed.fields.clone().into_iter().map(|field| {
+        let name = field.name;
+        let field_ty = field.ty;
+        let byte_start = field.bytes.start;
+        let bit_start = field.bit_offset;
+
+        if field.skip {
+            return quote! {};
+        }
+
+        let ty_name = field
+            .ty_name
+            .unwrap_or_else(|| Ident::new("UnknownTypeStopLookingAtMe", Span::call_site()));
+
+        // Small optimisation
+        if ty_name == "u8" || ty_name == "bool" {
+            let mask = (2u16.pow(field.bits.len() as u32) - 1) << bit_start;
+            let mask = proc_macro2::TokenStream::from_str(&format!("{:#010b}", mask)).unwrap();
+
+            quote! {
+                buf[#byte_start] |= ((self.#name as u8) << #bit_start) & #mask;
+            }
+        }
+        // Single byte fields need merging into the other data
+        else if field.bytes.len() == 1 {
+            let mask = (2u16.pow(field.bits.len() as u32) - 1) << bit_start;
+            let mask = proc_macro2::TokenStream::from_str(&format!("{:#010b}", mask)).unwrap();
+
+            quote! {
+                let mut field_buf = [0u8; 1];
+                let res = <#field_ty as ::ethercrab_wire::EtherCrabWireWrite>::pack_to_slice_unchecked(&self.#name, &mut field_buf)[0];
+
+                buf[#byte_start] |= (res << #bit_start) & #mask;
+            }
+        }
+        // Assumption: multi-byte fields are byte-aligned. This should be validated during parse.
+        else {
+            let byte_end = field.bytes.end;
+
+            quote! {
+                <#field_ty as ::ethercrab_wire::EtherCrabWireWrite>::pack_to_slice_unchecked(&self.#name, &mut buf[#byte_start..#byte_end]);
+            }
+        }
+    });
+
+    let out = quote! {
+        impl ::ethercrab_wire::EtherCrabWireWrite for #name {
+            fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
+                let buf = match buf.get_mut(0..#size_bytes) {
+                    Some(buf) => buf,
+                    None => unreachable!()
+                };
+
+                #(#fields_pack)*
+
+                buf
+            }
+
+            fn packed_len(&self) -> usize {
+                #size_bytes
+            }
+        }
+
+        impl ::ethercrab_wire::EtherCrabWireWriteSized for #name {
+            fn pack(&self) -> Self::Buffer {
+                let mut buf = [0u8; #size_bytes];
+
+                <Self as ::ethercrab_wire::EtherCrabWireWrite>::pack_to_slice_unchecked(self, &mut buf);
+
+                buf
+            }
+        }
+    };
+
+    Ok(out)
+}
+
+pub fn generate_struct_read(
+    parsed: StructMeta,
+    input: &DeriveInput,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let name = input.ident.clone();
+    let size_bytes = parsed.width_bits.div_ceil(8);
+
+    let fields_unpack = parsed.fields.clone().into_iter().map(|field| {
+        let ty = field.ty;
+        let name = field.name;
+        let byte_start = field.bytes.start;
+        let bit_start = field.bit_offset;
+        let ty_name = field
+            .ty_name
+            .unwrap_or_else(|| Ident::new("UnknownTypeStopLookingAtMe", Span::call_site()));
+
+        if field.skip {
+            return quote! {
+                #name: Default::default()
+            }
+        }
+
+        if field.bits.len() <= 8 {
+            let mask = (2u16.pow(field.bits.len() as u32) - 1) << bit_start;
+            let mask =
+                proc_macro2::TokenStream::from_str(&format!("{:#010b}", mask)).unwrap();
+
+            if ty_name == "bool" {
+                quote! {
+                    #name: ((buf[#byte_start] & #mask) >> #bit_start) > 0
+                }
+            }
+            // Small optimisation
+            else if ty_name == "u8" {
+                quote! {
+                    #name: (buf[#byte_start] & #mask) >> #bit_start
+                }
+            }
+            // Anything else will be a struct or an enum
+            else {
+                quote! {
+                    #name: {
+                        let masked = (buf[#byte_start] & #mask) >> #bit_start;
+
+                        <#ty as ::ethercrab_wire::EtherCrabWireRead>::unpack_from_slice(&[masked])?
+                    }
+                }
+            }
+        }
+        // Assumption: multi-byte fields are byte-aligned. This must be validated during parse.
+        else {
+            let start_byte = field.bytes.start;
+            let end_byte = field.bytes.end;
+
+            quote! {
+                #name: <#ty as ::ethercrab_wire::EtherCrabWireRead>::unpack_from_slice(&buf[#start_byte..#end_byte])?
+            }
+        }
+    });
+
+    let out = quote! {
+        impl ::ethercrab_wire::EtherCrabWireRead for #name {
+            fn unpack_from_slice(buf: &[u8]) -> Result<Self, ::ethercrab_wire::WireError> {
+                let buf = buf.get(0..#size_bytes).ok_or(::ethercrab_wire::WireError::ReadBufferTooShort {
+                    expected: #size_bytes,
+                    got: buf.len(),
+                })?;
+
+                Ok(Self {
+                    #(#fields_unpack),*
+                })
+            }
+        }
+
+        impl ::ethercrab_wire::EtherCrabWireSized for #name {
+            const PACKED_LEN: usize = #size_bytes;
+
+            type Buffer = [u8; #size_bytes];
+
+            fn buffer() -> Self::Buffer {
+                [0u8; #size_bytes]
+            }
+        }
+    };
+
+    Ok(out)
+}

--- a/ethercrab-wire-derive/src/help.rs
+++ b/ethercrab-wire-derive/src/help.rs
@@ -1,0 +1,217 @@
+use proc_macro2::Span;
+use std::collections::HashSet;
+use syn::{
+    punctuated::Punctuated, spanned::Spanned, Expr, ExprArray, ExprLit, Ident, Lit, Meta, Token,
+    Type,
+};
+
+pub const MY_ATTRIBUTE: &str = "wire";
+
+fn my_attributes(attrs: &[syn::Attribute]) -> impl Iterator<Item = &syn::Attribute> {
+    attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident(MY_ATTRIBUTE))
+}
+
+pub fn bit_width_attr(attrs: &[syn::Attribute]) -> Result<Option<usize>, syn::Error> {
+    let bits = usize_attr(attrs, "bits")?;
+    let bytes = usize_attr(attrs, "bytes")?.map(|bytes| bytes * 8);
+
+    if bits.is_some() && bytes.is_some() {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            "'bits' and 'bytes' attribute not allowed at the same time",
+        ));
+    }
+
+    Ok(bits.or(bytes))
+}
+
+pub fn usize_attr(attrs: &[syn::Attribute], search: &str) -> Result<Option<usize>, syn::Error> {
+    for attr in my_attributes(attrs) {
+        let Ok(nested) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        else {
+            continue;
+        };
+
+        for meta in nested {
+            match meta {
+                syn::Meta::Path(_) => (),
+                syn::Meta::List(_) => (),
+                syn::Meta::NameValue(nv) if nv.path.is_ident(search) => {
+                    if let Expr::Lit(ExprLit {
+                        lit: Lit::Int(lit), ..
+                    }) = &nv.value
+                    {
+                        return Ok(Some(lit.base10_parse::<usize>()?));
+                    }
+                }
+                _ => (),
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Check that all attributes are supported
+pub fn all_valid_attrs(attrs: &[syn::Attribute], allowed: &[&str]) -> Result<(), syn::Error> {
+    let allowed = allowed
+        .iter()
+        .map(|s| Ident::new(s, Span::call_site()))
+        .collect::<HashSet<_>>();
+
+    let mut idents = HashSet::new();
+
+    for attr in my_attributes(attrs) {
+        // Skip other attributes like doc comments etc
+        let Ok(nested) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        else {
+            continue;
+        };
+
+        for meta in nested {
+            let ident = match meta {
+                syn::Meta::Path(p) => p.get_ident().cloned().expect("Path identifier required"),
+                syn::Meta::List(_) => unreachable!("Unsupported"),
+                syn::Meta::NameValue(nv) => nv
+                    .path
+                    .get_ident()
+                    .cloned()
+                    .expect("NameValue identifier required"),
+            };
+
+            let None = idents.replace(ident.clone()) else {
+                panic!("Duplicate attribute found {}", ident);
+            };
+        }
+    }
+
+    let mut bad = idents.difference(&allowed);
+
+    if let Some(first) = bad.next() {
+        return Err(syn::Error::new(first.span(), "Invalid attribute"));
+    }
+
+    Ok(())
+}
+
+pub fn attr_exists(attrs: &[syn::Attribute], search: &str) -> Result<bool, syn::Error> {
+    for attr in my_attributes(attrs) {
+        let Ok(nested) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        else {
+            continue;
+        };
+
+        for meta in nested {
+            match meta {
+                syn::Meta::Path(p) if p.is_ident(search) => return Ok(true),
+                _ => (),
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+// pub fn field_is_enum_attr(attrs: &[syn::Attribute]) -> Result<bool, syn::Error> {
+//     for attr in my_attributes(attrs) {
+//         let Ok(nested) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+//         else {
+//             continue;
+//         };
+
+//         for meta in nested {
+//             match meta {
+//                 syn::Meta::Path(_) => (),
+//                 syn::Meta::List(_) => (),
+//                 syn::Meta::NameValue(nv) if nv.path.is_ident("ty") => {
+//                     if let Expr::Lit(ExprLit {
+//                         lit: Lit::Str(s), ..
+//                     }) = &nv.value
+//                     {
+//                         return Ok(s.value() == "enum");
+//                     }
+//                 }
+//                 _ => (),
+//             }
+//         }
+//     }
+
+//     Ok(false)
+// }
+
+pub fn enum_repr_ty(attrs: &[syn::Attribute], ident: &Ident) -> Result<Ident, syn::Error> {
+    for attr in attrs {
+        match attr.meta.clone() {
+            syn::Meta::List(l) if l.path.is_ident("repr") => {
+                let ty = l.parse_args::<Type>()?;
+
+                if let Type::Path(ty) = ty {
+                    return ty
+                        .path
+                        .get_ident()
+                        .cloned()
+                        .ok_or_else(|| syn::Error::new(ident.span(), "Repr is not a valid type"));
+                }
+            }
+            _ => (),
+        }
+    }
+
+    Err(syn::Error::new(
+        ident.span(),
+        "Enums must have a #[repr()] attribute",
+    ))
+}
+
+/// Look for 'alternatives = [1,2,3]` attribute on enum variant.
+pub fn variant_alternatives(attrs: &[syn::Attribute]) -> Result<Vec<u32>, syn::Error> {
+    for attr in my_attributes(attrs) {
+        let Ok(nested) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        else {
+            continue;
+        };
+
+        for meta in nested {
+            match meta {
+                syn::Meta::Path(_) => (),
+                syn::Meta::List(_) => (),
+                syn::Meta::NameValue(nv) if nv.path.is_ident("alternatives") => {
+                    if let Expr::Array(ExprArray { elems, .. }) = &nv.value {
+                        return elems
+                            .iter()
+                            .map(|elem| {
+                                let Expr::Lit(ExprLit {
+                                    lit: Lit::Int(lit), ..
+                                }) = elem.clone()
+                                else {
+                                    return Err(syn::Error::new(
+                                        elem.span(),
+                                        "Alternatives must be numbers",
+                                    ));
+                                };
+
+                                lit.base10_parse::<u32>()
+                            })
+                            .collect::<Result<Vec<_>, _>>();
+                    }
+                }
+                _ => (),
+            }
+        }
+    }
+
+    Ok(Vec::new())
+}
+
+pub fn variant_is_default(attrs: &[syn::Attribute]) -> Result<bool, syn::Error> {
+    for attr in attrs {
+        match attr.meta {
+            Meta::Path(ref p) if p.is_ident("default") => return Ok(true),
+            _ => continue,
+        }
+    }
+
+    Ok(false)
+}

--- a/ethercrab-wire-derive/src/lib.rs
+++ b/ethercrab-wire-derive/src/lib.rs
@@ -1,0 +1,123 @@
+//! # Experimental
+//!
+//! This crate may expand in the future but is currently only used internally by
+//! [`ethercrab`](https://crates.io/crates/ethercrab) itself. It is experimental and may change at
+//! any time, so please do not depend on or rely on any of this crate's items.
+
+#![deny(missing_docs)]
+#![deny(missing_copy_implementations)]
+#![deny(trivial_casts)]
+#![deny(trivial_numeric_casts)]
+#![deny(unused_import_braces)]
+#![deny(unused_qualifications)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::private_intra_doc_links)]
+
+mod generate_enum;
+mod generate_struct;
+mod help;
+mod parse_enum;
+mod parse_struct;
+
+use generate_enum::{generate_enum_read, generate_enum_write};
+use generate_struct::{generate_struct_read, generate_struct_write};
+use parse_enum::parse_enum;
+use parse_struct::parse_struct;
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, Data, DeriveInput};
+
+/// Items that can be written to/read from the wire.
+#[proc_macro_derive(EtherCrabWireReadWrite, attributes(wire))]
+pub fn ether_crab_wire(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let res = match input.clone().data {
+        Data::Enum(e) => parse_enum(e, input.clone()).and_then(|parsed| {
+            let mut tokens = generate_enum_write(parsed.clone(), &input)?;
+
+            tokens.extend(generate_enum_read(parsed, &input)?);
+
+            Ok(tokens)
+        }),
+        Data::Struct(s) => parse_struct(s, input.clone()).and_then(|parsed| {
+            let mut tokens = generate_struct_write(parsed.clone(), &input)?;
+
+            tokens.extend(generate_struct_read(parsed, &input)?);
+
+            Ok(tokens)
+        }),
+        Data::Union(_) => Err(syn::Error::new(
+            input.ident.span(),
+            "Unions are not supported",
+        )),
+    };
+
+    let res = match res {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    TokenStream::from(res)
+}
+
+/// Items that can only be read from the wire.
+#[proc_macro_derive(EtherCrabWireRead, attributes(wire))]
+pub fn ether_crab_wire_read(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let res = match input.clone().data {
+        Data::Enum(e) => {
+            parse_enum(e, input.clone()).and_then(|parsed| generate_enum_read(parsed, &input))
+        }
+        Data::Struct(s) => {
+            parse_struct(s, input.clone()).and_then(|parsed| generate_struct_read(parsed, &input))
+        }
+        Data::Union(_) => Err(syn::Error::new(
+            input.ident.span(),
+            "Unions are not supported",
+        )),
+    };
+
+    let res = match res {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    TokenStream::from(res)
+}
+
+/// Items that can only be written to the wire.
+#[proc_macro_derive(EtherCrabWireWrite, attributes(wire))]
+pub fn ether_crab_wire_write(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let res = match input.clone().data {
+        Data::Enum(e) => {
+            parse_enum(e, input.clone()).and_then(|parsed| generate_enum_write(parsed, &input))
+        }
+        Data::Struct(s) => {
+            parse_struct(s, input.clone()).and_then(|parsed| generate_struct_write(parsed, &input))
+        }
+        Data::Union(_) => Err(syn::Error::new(
+            input.ident.span(),
+            "Unions are not supported",
+        )),
+    };
+
+    let res = match res {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    TokenStream::from(res)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn trybuild_cases() {
+        let t = trybuild::TestCases::new();
+
+        t.compile_fail("ui/*.rs");
+    }
+}

--- a/ethercrab-wire-derive/src/parse_enum.rs
+++ b/ethercrab-wire-derive/src/parse_enum.rs
@@ -1,0 +1,147 @@
+use crate::help::{
+    all_valid_attrs, attr_exists, enum_repr_ty, variant_alternatives, variant_is_default,
+};
+use syn::{DataEnum, DeriveInput, Expr, ExprLit, Ident, Lit};
+
+#[derive(Clone)]
+pub struct EnumMeta {
+    /// Width in bits on the wire.
+    // pub width: usize,
+    pub repr_type: Ident,
+
+    pub variants: Vec<VariantMeta>,
+
+    pub catch_all: Option<VariantMeta>,
+    pub default_variant: Option<VariantMeta>,
+}
+
+#[derive(Clone)]
+pub struct VariantMeta {
+    pub name: Ident,
+    pub discriminant: u32,
+    pub catch_all: bool,
+    pub default: bool,
+    pub alternatives: Vec<u32>,
+}
+
+pub fn parse_enum(
+    e: DataEnum,
+    DeriveInput { attrs, ident, .. }: DeriveInput,
+) -> syn::Result<EnumMeta> {
+    // let width = bit_width_attr(&attrs)?;
+
+    all_valid_attrs(&attrs, &["bits", "bytes"])?;
+
+    let repr = enum_repr_ty(&attrs, &ident)?;
+
+    let allowed = ["u8", "u16", "u32"];
+
+    let valid = allowed.iter().any(|allow| repr == allow);
+
+    if !valid {
+        return Err(syn::Error::new(
+            repr.span(),
+            format!("Allowed reprs are {}", allowed.join(", ")),
+        ));
+    }
+
+    // let Some(width) = width else {
+    //     return Err(syn::Error::new(
+    //         ident.span(),
+    //         "Enum bit width is required, e.g. #[wire(bits = 8)]",
+    //     ));
+    // };
+
+    // --- Variants
+
+    let mut discriminant_accum = 0;
+    let mut variants = Vec::new();
+    let mut catch_all = None;
+    let mut default_variant = None;
+
+    for variant in e.variants {
+        all_valid_attrs(&variant.attrs, &["alternatives", "catch_all"])?;
+
+        let ident = variant.ident;
+
+        let variant_discriminant = match variant.discriminant {
+            Some((
+                _,
+                Expr::Lit(ExprLit {
+                    lit: Lit::Int(discr),
+                    ..
+                }),
+            )) => discr.base10_parse::<u32>()?,
+            None => discriminant_accum + 1,
+            _ => return Err(syn::Error::new(repr.span(), "Invalid discriminant format")),
+        };
+
+        let is_default = variant_is_default(&variant.attrs)?;
+        let is_catch_all = attr_exists(&variant.attrs, "catch_all")?;
+
+        let alternatives = variant_alternatives(&variant.attrs)?;
+
+        if is_catch_all && !alternatives.is_empty() {
+            return Err(syn::Error::new(
+                ident.span(),
+                "Catch all cannot have alternatives",
+            ));
+        }
+
+        let record = VariantMeta {
+            name: ident.clone(),
+            discriminant: variant_discriminant,
+            catch_all: is_catch_all,
+            alternatives: alternatives.clone(),
+            default: is_default,
+        };
+
+        if is_catch_all {
+            let old = catch_all.replace(record.clone());
+
+            if old.is_some() {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    "Only one catch all variant is allowed",
+                ));
+            }
+        }
+
+        if is_default {
+            let old = default_variant.replace(record.clone());
+
+            if old.is_some() {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    "Only one default variant is allowed",
+                ));
+            }
+        }
+
+        discriminant_accum = variant_discriminant;
+
+        variants.push(record.clone());
+
+        for alternative in alternatives {
+            let alt = VariantMeta {
+                name: ident.clone(),
+                discriminant: alternative,
+                alternatives: Vec::new(),
+                default: false,
+                catch_all: false,
+            };
+
+            variants.push(alt);
+
+            discriminant_accum = alternative;
+        }
+    }
+
+    Ok(EnumMeta {
+        // width,
+        repr_type: repr,
+        variants,
+        catch_all,
+        default_variant,
+    })
+}

--- a/ethercrab-wire-derive/src/parse_struct.rs
+++ b/ethercrab-wire-derive/src/parse_struct.rs
@@ -1,0 +1,183 @@
+use crate::help::{all_valid_attrs, attr_exists, bit_width_attr, usize_attr};
+use std::ops::Range;
+use syn::{DataStruct, DeriveInput, Fields, FieldsNamed, Ident, Type, Visibility};
+
+#[derive(Clone)]
+pub struct StructMeta {
+    /// Width in bits on the wire.
+    pub width_bits: usize,
+
+    pub fields: Vec<FieldMeta>,
+}
+
+#[derive(Clone)]
+pub struct FieldMeta {
+    pub vis: Visibility,
+    pub name: Ident,
+    pub ty: Type,
+    // Will be None for arrays
+    pub ty_name: Option<Ident>,
+    pub bit_start: usize,
+    pub bit_end: usize,
+    pub byte_start: usize,
+    pub byte_end: usize,
+    /// Offset of the starting bit in the starting byte.
+    pub bit_offset: usize,
+
+    pub bits: Range<usize>,
+    pub bytes: Range<usize>,
+
+    pub pre_skip: Option<usize>,
+    pub post_skip: Option<usize>,
+
+    pub skip: bool,
+}
+
+pub fn parse_struct(
+    s: DataStruct,
+    DeriveInput { attrs, ident, .. }: DeriveInput,
+) -> syn::Result<StructMeta> {
+    // --- Struct attributes
+
+    all_valid_attrs(&attrs, &["bits", "bytes"])?;
+
+    let width = bit_width_attr(&attrs)?;
+
+    let Some(width) = width else {
+        return Err(syn::Error::new(
+            ident.span(),
+            "Struct total bit width is required, e.g. #[wire(bits = 32)]",
+        ));
+    };
+
+    // --- Fields
+
+    let Fields::Named(FieldsNamed { named: fields, .. }) = s.fields else {
+        return Err(syn::Error::new(
+            ident.span(),
+            "Only structs with named fields can be derived.",
+        ));
+    };
+
+    let mut total_field_width = 0;
+
+    let mut field_meta = Vec::new();
+
+    for field in fields {
+        all_valid_attrs(
+            &field.attrs,
+            &[
+                "bits",
+                "bytes",
+                "skip",
+                "pre_skip",
+                "pre_skip_bytes",
+                "post_skip",
+                "post_skip_bytes",
+            ],
+        )?;
+
+        // Unwrap: this is a named-field struct so the field will always have a name.
+        let field_name = field.ident.unwrap();
+        let field_width = bit_width_attr(&field.attrs)?;
+
+        // Whether to ignore this field when sending AND receiving
+        let skip = attr_exists(&field.attrs, "skip")?;
+
+        let pre_skip = usize_attr(&field.attrs, "pre_skip")?
+            .or(usize_attr(&field.attrs, "pre_skip_bytes")?.map(|bytes| bytes * 8))
+            .filter(|_| !skip);
+
+        let post_skip = usize_attr(&field.attrs, "post_skip")?
+            .or(usize_attr(&field.attrs, "post_skip_bytes")?.map(|bytes| bytes * 8))
+            .filter(|_| !skip);
+
+        if let Some(skip) = pre_skip {
+            total_field_width += skip;
+        }
+
+        let bit_start = total_field_width;
+        let bit_end = field_width
+            .map(|w| total_field_width + w)
+            .unwrap_or(total_field_width);
+        let byte_start = bit_start / 8;
+        let byte_end = bit_end.div_ceil(8);
+        let bytes = byte_start..byte_end;
+        let bit_offset = bit_start % 8;
+        let bits = bit_start..bit_end;
+
+        let ty_name = match field.ty.clone() {
+            Type::Path(path) => path.path.get_ident().cloned(),
+            _ => None,
+        };
+
+        let meta = FieldMeta {
+            name: field_name,
+            vis: field.vis,
+            ty: field.ty,
+            ty_name,
+
+            bits,
+            bytes,
+
+            bit_start,
+            bit_end,
+            byte_start,
+            byte_end,
+
+            bit_offset,
+
+            pre_skip,
+            post_skip,
+
+            skip,
+        };
+
+        // Validation if we're not skipping this field
+        if !skip {
+            let Some(field_width) = field_width else {
+                return Err(syn::Error::new(
+                    meta.name.span(),
+                    "Field must have a width attribute, e.g. #[wire(bits = 4)]",
+                ));
+            };
+
+            if meta.bytes.len() > 1 && (bit_offset > 0 || field_width % 8 > 0) {
+                return Err(syn::Error::new(
+                    meta.name.span(),
+                    format!("Multibyte fields must be byte-aligned at start and end. Current bit position {}", total_field_width),
+                ));
+            }
+
+            if meta.bits.len() < 8 && meta.bytes.len() > 1 {
+                return Err(syn::Error::new(
+                    meta.name.span(),
+                    "Fields smaller than 8 bits may not cross byte boundaries",
+                ));
+            }
+
+            total_field_width += field_width;
+        }
+
+        if let Some(skip) = post_skip {
+            total_field_width += skip;
+        }
+
+        field_meta.push(meta);
+    }
+
+    if total_field_width != width {
+        return Err(syn::Error::new(
+            ident.span(),
+            format!(
+                "Total field width is {}, expected {} from struct definition",
+                total_field_width, width
+            ),
+        ));
+    }
+
+    Ok(StructMeta {
+        width_bits: width,
+        fields: field_meta,
+    })
+}

--- a/ethercrab-wire-derive/ui/union.rs
+++ b/ethercrab-wire-derive/ui/union.rs
@@ -1,0 +1,7 @@
+#[derive(ethercrab_wire::EtherCrabWireWrite)]
+union Whatever {
+    i: u32,
+    f: f32,
+}
+
+fn main() {}

--- a/ethercrab-wire-derive/ui/union.stderr
+++ b/ethercrab-wire-derive/ui/union.stderr
@@ -1,0 +1,5 @@
+error: Unions are not supported
+ --> ui/union.rs:2:7
+  |
+2 | union Whatever {
+  |       ^^^^^^^^

--- a/ethercrab-wire/CHANGELOG.md
+++ b/ethercrab-wire/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+Traits used for converting optionally packed values to/from raw data as represented in the EtherCAT
+specification.
+
+Primarily used by `ethercrab`.
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
+
+### Added
+
+- Initial release
+
+<!-- next-url -->
+
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/HEAD...HEAD

--- a/ethercrab-wire/Cargo.toml
+++ b/ethercrab-wire/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ethercrab-wire"
+version = "0.0.0"
+edition = "2021"
+categories = ["science::robotics", "no-std", "network-programming"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/ethercrab-rs/ethercrab"
+documentation = "https://docs.rs/ethercrab-wire"
+description = "On-the-wire tools for the EtherCrab crate"
+keywords = ["no-std", "ethercat", "ethercrab"]
+resolver = "2"
+rust-version = "1.75"
+
+[dependencies]
+defmt = { version = "0.3.5", optional = true }
+ethercrab-wire-derive = { version = "0.0.0", path = "../ethercrab-wire-derive" }
+heapless = { version = "0.8.0", default-features = false }
+
+[features]
+std = []
+defmt-03 = ["dep:defmt", "heapless/defmt-03"]

--- a/ethercrab-wire/README.md
+++ b/ethercrab-wire/README.md
@@ -1,0 +1,23 @@
+# `ethercrab-wire`
+
+[![Build Status](https://circleci.com/gh/ethercrab-rs/ethercrab/tree/master.svg?style=shield)](https://circleci.com/gh/ethercrab-rs/ethercrab/tree/master)
+[![Crates.io](https://img.shields.io/crates/v/ethercrab-wire.svg)](https://crates.io/crates/ethercrab-wire)
+[![Docs.rs](https://docs.rs/ethercrab-wire/badge.svg)](https://docs.rs/ethercrab-wire)
+
+Traits used to pack/unpack structs and enums from EtherCAT packets on the wire.
+
+## Experimental
+
+This crate is currently minimal and very rough as it is only used internally by
+[`ethercrab`](https://crates.io/crates/ethercrab). It is not recommended for public use (yet)
+and may change at any time.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/ethercrab-wire/README.tpl
+++ b/ethercrab-wire/README.tpl
@@ -1,0 +1,17 @@
+# `ethercrab-wire`
+
+[![Build Status](https://circleci.com/gh/ethercrab-rs/ethercrab/tree/master.svg?style=shield)](https://circleci.com/gh/ethercrab-rs/ethercrab/tree/master)
+[![Crates.io](https://img.shields.io/crates/v/ethercrab-wire.svg)](https://crates.io/crates/ethercrab-wire)
+[![Docs.rs](https://docs.rs/ethercrab-wire/badge.svg)](https://docs.rs/ethercrab-wire)
+
+{{readme}}
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/ethercrab-wire/src/error.rs
+++ b/ethercrab-wire/src/error.rs
@@ -1,0 +1,53 @@
+//! Encode/decode error.
+
+/// Wire encode/decode errors.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+pub enum WireError {
+    /// The buffer to extract a type from is too short to do so.
+    ReadBufferTooShort {
+        /// Minimum required buffer length.
+        expected: usize,
+        /// Actual length given.
+        got: usize,
+    },
+    /// The buffer to write the packed data into is too short.
+    WriteBufferTooShort {
+        /// Minimum required buffer length.
+        expected: usize,
+        /// Actual length given.
+        got: usize,
+    },
+    /// Invalid enum or struct value.
+    ///
+    /// If this comes from an enum, consider adding a variant with `#[wire(catch_all)]` or
+    /// `#[wire(alternatives = [])]`.
+    InvalidValue,
+    /// Failed to create an array of the correct length.
+    ArrayLength,
+    /// Valid UTF8 input data is required to decode to a string.
+    InvalidUtf8,
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for WireError {}
+
+impl core::fmt::Display for WireError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            WireError::ReadBufferTooShort { expected, got } => write!(
+                f,
+                "Need at least {} read buffer bytes, got {}",
+                expected, got
+            ),
+            WireError::WriteBufferTooShort { expected, got } => write!(
+                f,
+                "Need at least {} write buffer bytes, got {}",
+                expected, got
+            ),
+            WireError::InvalidValue => f.write_str("Invalid decoded value"),
+            WireError::ArrayLength => f.write_str("Incorrect array length"),
+            WireError::InvalidUtf8 => f.write_str("Invalid UTF8"),
+        }
+    }
+}

--- a/ethercrab-wire/src/impls.rs
+++ b/ethercrab-wire/src/impls.rs
@@ -1,0 +1,279 @@
+//! Builtin implementations for various types.
+
+use crate::{
+    EtherCrabWireRead, EtherCrabWireReadSized, EtherCrabWireSized, EtherCrabWireWrite,
+    EtherCrabWireWriteSized, WireError,
+};
+
+macro_rules! impl_primitive_wire_field {
+    ($ty:ty, $size:expr) => {
+        impl EtherCrabWireWrite for $ty {
+            fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
+                // This unsafe doesn't save us any binary space at all in the stm32-embassy example
+                // so we won't use it.
+                // let chunk = unsafe { buf.get_unchecked_mut(0..$size) };
+
+                let chunk = &mut buf[0..$size];
+
+                chunk.copy_from_slice(&self.to_le_bytes());
+
+                chunk
+            }
+
+            fn pack_to_slice<'buf>(&self, buf: &'buf mut [u8]) -> Result<&'buf [u8], WireError> {
+                if buf.len() < $size {
+                    return Err(WireError::WriteBufferTooShort {
+                        expected: $size,
+                        got: buf.len(),
+                    });
+                }
+
+                Ok(self.pack_to_slice_unchecked(buf))
+            }
+
+            fn packed_len(&self) -> usize {
+                $size
+            }
+        }
+
+        impl EtherCrabWireRead for $ty {
+            fn unpack_from_slice(buf: &[u8]) -> Result<Self, WireError> {
+                buf.get(0..$size)
+                    .ok_or(WireError::ReadBufferTooShort {
+                        expected: $size,
+                        got: buf.len(),
+                    })
+                    .map(|raw| match raw.try_into() {
+                        Ok(res) => res,
+                        Err(_) => unreachable!(),
+                    })
+                    .map(Self::from_le_bytes)
+            }
+        }
+
+        impl EtherCrabWireSized for $ty {
+            const PACKED_LEN: usize = $size;
+
+            type Buffer = [u8; $size];
+
+            fn buffer() -> Self::Buffer {
+                [0u8; $size]
+            }
+        }
+
+        impl EtherCrabWireWriteSized for $ty {
+            fn pack(&self) -> Self::Buffer {
+                self.to_le_bytes()
+            }
+        }
+
+        // MSRV: generic_const_exprs: Once we can do `N * T::PACKED_BYTES` this impl can go away and
+        // be replaced by a single generic one.
+        impl<const N: usize> EtherCrabWireSized for [$ty; N] {
+            const PACKED_LEN: usize = N * $size;
+
+            type Buffer = [u8; N];
+
+            fn buffer() -> Self::Buffer {
+                [0u8; N]
+            }
+        }
+    };
+}
+
+impl_primitive_wire_field!(u8, 1);
+impl_primitive_wire_field!(u16, 2);
+impl_primitive_wire_field!(u32, 4);
+impl_primitive_wire_field!(u64, 8);
+impl_primitive_wire_field!(i8, 1);
+impl_primitive_wire_field!(i16, 2);
+impl_primitive_wire_field!(i32, 4);
+impl_primitive_wire_field!(i64, 8);
+
+impl EtherCrabWireWrite for bool {
+    fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
+        buf[0] = *self as u8;
+
+        &buf[0..1]
+    }
+
+    fn packed_len(&self) -> usize {
+        1
+    }
+}
+
+impl EtherCrabWireRead for bool {
+    fn unpack_from_slice(buf: &[u8]) -> Result<Self, WireError> {
+        if buf.is_empty() {
+            return Err(WireError::ReadBufferTooShort {
+                expected: 1,
+                got: 0,
+            });
+        }
+
+        Ok(buf[0] == 1)
+    }
+}
+
+impl EtherCrabWireSized for bool {
+    const PACKED_LEN: usize = 1;
+
+    type Buffer = [u8; Self::PACKED_LEN];
+
+    fn buffer() -> Self::Buffer {
+        [0u8; 1]
+    }
+}
+
+impl EtherCrabWireWriteSized for bool {
+    fn pack(&self) -> Self::Buffer {
+        [*self as u8; 1]
+    }
+}
+
+impl EtherCrabWireWrite for () {
+    fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
+        &buf[0..0]
+    }
+
+    fn packed_len(&self) -> usize {
+        0
+    }
+}
+
+impl EtherCrabWireRead for () {
+    fn unpack_from_slice(_buf: &[u8]) -> Result<Self, WireError> {
+        Ok(())
+    }
+}
+
+impl EtherCrabWireSized for () {
+    const PACKED_LEN: usize = 0;
+
+    type Buffer = [u8; 0];
+
+    fn buffer() -> Self::Buffer {
+        [0u8; 0]
+    }
+}
+
+impl EtherCrabWireWriteSized for () {
+    fn pack(&self) -> Self::Buffer {
+        [0u8; 0]
+    }
+}
+
+impl<const N: usize> EtherCrabWireWrite for [u8; N] {
+    fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
+        let buf = &mut buf[0..N];
+
+        buf.copy_from_slice(self);
+
+        buf
+    }
+
+    fn packed_len(&self) -> usize {
+        N
+    }
+}
+
+impl EtherCrabWireWrite for &[u8] {
+    fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
+        let buf = &mut buf[0..self.len()];
+
+        buf.copy_from_slice(self);
+
+        buf
+    }
+
+    fn packed_len(&self) -> usize {
+        self.len()
+    }
+}
+
+// Blanket impl for references
+impl<T> EtherCrabWireWrite for &T
+where
+    T: EtherCrabWireWrite,
+{
+    fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
+        EtherCrabWireWrite::pack_to_slice_unchecked(*self, buf)
+    }
+
+    fn packed_len(&self) -> usize {
+        EtherCrabWireWrite::packed_len(*self)
+    }
+}
+
+// Blanket impl for arrays of known-sized types
+impl<const N: usize, T> EtherCrabWireRead for [T; N]
+where
+    T: EtherCrabWireReadSized,
+{
+    fn unpack_from_slice(buf: &[u8]) -> Result<Self, WireError> {
+        if buf.len() < T::PACKED_LEN * N {
+            return Err(WireError::ReadBufferTooShort {
+                expected: T::PACKED_LEN * N,
+                got: buf.len(),
+            });
+        }
+
+        heapless::Vec::<T, N>::unpack_from_slice(buf)
+            .and_then(|res| res.into_array().map_err(|_e| WireError::ArrayLength))
+    }
+}
+
+// --- heapless::Vec ---
+
+impl<const N: usize, T> EtherCrabWireRead for heapless::Vec<T, N>
+where
+    T: EtherCrabWireReadSized,
+{
+    fn unpack_from_slice(buf: &[u8]) -> Result<Self, WireError> {
+        let res = buf
+            .chunks_exact(T::PACKED_LEN)
+            .take(N)
+            .map(T::unpack_from_slice)
+            .collect::<Result<heapless::Vec<_, N>, WireError>>();
+
+        match res {
+            Ok(res) => Ok(res),
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+// MSRV: generic_const_exprs: When we can do `N * T::PACKED_LEN`, this specific impl for `u8` can be
+// replaced with `T: EtherCrabWireSized`.
+impl<const N: usize, T> EtherCrabWireSized for heapless::Vec<T, N>
+where
+    T: Into<u8>,
+{
+    const PACKED_LEN: usize = N;
+
+    type Buffer = [u8; N];
+
+    fn buffer() -> Self::Buffer {
+        [0u8; N]
+    }
+}
+
+// --- heapless::String ---
+
+impl<const N: usize> EtherCrabWireRead for heapless::String<N> {
+    fn unpack_from_slice(buf: &[u8]) -> Result<Self, WireError> {
+        core::str::from_utf8(buf)
+            .map_err(|_| WireError::InvalidUtf8)
+            .and_then(|s| Self::try_from(s).map_err(|_| WireError::ArrayLength))
+    }
+}
+
+impl<const N: usize> EtherCrabWireSized for heapless::String<N> {
+    const PACKED_LEN: usize = N;
+
+    type Buffer = [u8; N];
+
+    fn buffer() -> Self::Buffer {
+        [0u8; N]
+    }
+}

--- a/ethercrab-wire/src/lib.rs
+++ b/ethercrab-wire/src/lib.rs
@@ -1,0 +1,89 @@
+//! Traits used to pack/unpack structs and enums from EtherCAT packets on the wire.
+//!
+//! # Experimental
+//!
+//! This crate is currently minimal and very rough as it is only used internally by
+//! [`ethercrab`](https://crates.io/crates/ethercrab). It is not recommended for public use (yet)
+//! and may change at any time.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(missing_docs)]
+#![deny(missing_copy_implementations)]
+#![deny(trivial_casts)]
+#![deny(trivial_numeric_casts)]
+#![deny(unused_import_braces)]
+#![deny(unused_qualifications)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::private_intra_doc_links)]
+
+mod error;
+mod impls;
+
+pub use error::WireError;
+pub use ethercrab_wire_derive::{EtherCrabWireRead, EtherCrabWireReadWrite, EtherCrabWireWrite};
+
+/// A type to be received from the wire, according to EtherCAT spec rules (packed bits, little
+/// endian).
+pub trait EtherCrabWireRead: Sized {
+    /// Unpack this type from the beginning of the given buffer.
+    fn unpack_from_slice(buf: &[u8]) -> Result<Self, WireError>;
+}
+
+/// A type to be sent/received on the wire, according to EtherCAT spec rules (packed bits, little
+/// endian).
+pub trait EtherCrabWireWrite {
+    /// Pack the type and write it into the beginning of `buf`.
+    ///
+    /// The default implementation of this method will return an error if the buffer is not long
+    /// enough.
+    fn pack_to_slice<'buf>(&self, buf: &'buf mut [u8]) -> Result<&'buf [u8], WireError> {
+        if buf.len() < self.packed_len() {
+            return Err(WireError::WriteBufferTooShort {
+                expected: self.packed_len(),
+                got: buf.len(),
+            });
+        }
+
+        Ok(self.pack_to_slice_unchecked(buf))
+    }
+
+    /// Pack the type and write it into the beginning of `buf`.
+    ///
+    /// # Panics
+    ///
+    /// This method must panic if `buf` is too short to hold the packed data.
+    fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8];
+
+    /// Get the length in bytes of this item when packed.
+    fn packed_len(&self) -> usize;
+}
+
+/// A type that can be both written to the wire and read back from it.
+pub trait EtherCrabWireReadWrite: EtherCrabWireRead + EtherCrabWireWrite {}
+
+impl<T> EtherCrabWireReadWrite for T where T: EtherCrabWireRead + EtherCrabWireWrite {}
+
+/// Implemented for types with a known size at compile time.
+pub trait EtherCrabWireSized {
+    /// Packed size in bytes.
+    const PACKED_LEN: usize;
+
+    /// Used to define an array of the correct length. This type should generlaly be of the form
+    /// `[u8; N]` where `N` is a fixed value or const generic as per the type this trait is
+    /// implemented on.
+    type Buffer: AsRef<[u8]> + AsMut<[u8]>;
+
+    /// Create a buffer sized to contain the packed representation of this item.
+    fn buffer() -> Self::Buffer;
+}
+
+/// Implemented for writeable types with a known size at compile time.
+pub trait EtherCrabWireWriteSized: EtherCrabWireSized {
+    /// Pack this item to a fixed sized array.
+    fn pack(&self) -> Self::Buffer;
+}
+
+/// A readable type that has a size known at compile time.
+pub trait EtherCrabWireReadSized: EtherCrabWireRead + EtherCrabWireSized {}
+
+impl<T> EtherCrabWireReadSized for T where T: EtherCrabWireRead + EtherCrabWireSized {}

--- a/ethercrab-wire/tests/heapless.rs
+++ b/ethercrab-wire/tests/heapless.rs
@@ -1,0 +1,11 @@
+use ethercrab_wire::EtherCrabWireRead;
+
+#[test]
+fn heapless_str() {
+    let input = "Hello world".as_bytes();
+
+    assert_eq!(
+        heapless::String::<32>::unpack_from_slice(input),
+        Ok("Hello world".try_into().unwrap())
+    );
+}

--- a/ethercrab-wire/tests/irl.rs
+++ b/ethercrab-wire/tests/irl.rs
@@ -1,0 +1,208 @@
+use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireReadWrite};
+
+#[test]
+fn sync_manager_channel() {
+    #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, EtherCrabWireReadWrite)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[wire(bits = 8)]
+    pub struct Control {
+        #[wire(bits = 2)]
+        pub operation_mode: OperationMode,
+        #[wire(bits = 2)]
+        pub direction: Direction,
+        #[wire(bits = 1)]
+        pub ecat_event_enable: bool,
+        #[wire(bits = 1)]
+        pub dls_user_event_enable: bool,
+        #[wire(bits = 1, post_skip = 1)]
+        pub watchdog_enable: bool,
+    }
+
+    #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, EtherCrabWireReadWrite)]
+    #[wire(bits = 2)]
+    #[repr(u8)]
+    pub enum OperationMode {
+        #[default]
+        Normal = 0x00,
+        Mailbox = 0x02,
+    }
+
+    #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, EtherCrabWireReadWrite)]
+    #[wire(bits = 2)]
+    #[repr(u8)]
+    pub enum Direction {
+        #[default]
+        MasterRead = 0x00,
+        MasterWrite = 0x01,
+    }
+}
+
+#[test]
+fn pdo() {
+    #[derive(Clone, PartialEq, ethercrab_wire::EtherCrabWireReadWrite)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[wire(bytes = 6)]
+    pub struct Pdo {
+        #[wire(bytes = 2)]
+        pub(crate) index: u16,
+        #[wire(bytes = 1)]
+        pub(crate) num_entries: u8,
+        #[wire(bytes = 1)]
+        pub(crate) sync_manager: u8,
+        #[wire(bytes = 1)]
+        pub(crate) dc_sync: u8,
+        /// Index into EEPROM Strings section for PDO name.
+        #[wire(bytes = 1)]
+        pub(crate) name_string_idx: u8,
+
+        // NOTE: This field is skipped during parsing from the wire and is populated later.
+        #[wire(skip)]
+        pub(crate) entries: heapless::Vec<u8, 16>,
+    }
+}
+
+#[test]
+fn slave_state() {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, EtherCrabWireReadWrite)]
+    #[repr(u8)]
+    pub enum SlaveState {
+        /// No state recorded/read/known.
+        None = 0x00,
+        /// EtherCAT `INIT` state.
+        Init = 0x01,
+        /// EtherCAT `PRE-OP` state.
+        PreOp = 0x02,
+        /// EtherCAT `BOOT` state.
+        Bootstrap = 0x03,
+        /// EtherCAT `SAFE-OP` state.
+        SafeOp = 0x04,
+        /// EtherCAT `OP` state.
+        Op = 0x8,
+        /// State is a combination of above variants or is an unknown value.
+        #[wire(catch_all)]
+        Other(u8),
+    }
+}
+
+#[test]
+fn bare_enum() {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, EtherCrabWireReadWrite)]
+    #[repr(u8)]
+    pub enum SlaveState {
+        /// No state recorded/read/known.
+        None = 0x00,
+        /// EtherCAT `INIT` state.
+        Init = 0x01,
+        /// EtherCAT `PRE-OP` state.
+        PreOp = 0x02,
+        /// EtherCAT `BOOT` state.
+        Bootstrap = 0x03,
+        /// EtherCAT `SAFE-OP` state.
+        SafeOp = 0x04,
+        /// EtherCAT `OP` state.
+        Op = 0x8,
+    }
+}
+
+#[test]
+fn arr() {
+    #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, EtherCrabWireReadWrite)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[wire(bytes = 4)]
+    pub struct Control {
+        #[wire(bytes = 4)]
+        pub data: [u8; 4],
+    }
+}
+
+#[test]
+fn enum_u16() {
+    #[derive(Debug, Copy, Clone, ethercrab_wire::EtherCrabWireReadWrite)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[repr(u16)]
+    pub enum AlStatusCode {
+        NoError = 0x0000,
+        #[wire(catch_all)]
+        Unknown(u16),
+    }
+}
+
+#[test]
+fn enum_alternatives() {
+    #[derive(
+        Default, Debug, Copy, Clone, PartialEq, Eq, ethercrab_wire::EtherCrabWireReadWrite,
+    )]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[repr(u16)]
+    pub enum Alternatives {
+        #[default]
+        Nop = 0,
+        #[wire(alternatives = [2,3,4,5,6,7,8,9])]
+        DeviceSpecific = 1,
+    }
+}
+
+#[test]
+fn enum_default_and_catch_all() {
+    #[derive(Default, Debug, Copy, Clone, ethercrab_wire::EtherCrabWireReadWrite)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[repr(u16)]
+    pub enum AlStatusCode {
+        NoError = 0x0000,
+        #[default]
+        Something = 0x0001,
+        #[wire(catch_all)]
+        Unknown(u16),
+    }
+}
+
+#[test]
+fn enum_default_only() {
+    #[derive(Default, Debug, Copy, Clone, ethercrab_wire::EtherCrabWireReadWrite)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[repr(u16)]
+    pub enum AlStatusCode {
+        NoError = 0x0000,
+        #[default]
+        Something = 0x0001,
+    }
+}
+
+#[test]
+fn heapless_vec() {
+    #[derive(
+        Default, Debug, Copy, Clone, PartialEq, Eq, ethercrab_wire::EtherCrabWireReadWrite,
+    )]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[repr(u8)]
+    pub enum SyncManagerType {
+        /// Not used or unknown.
+        #[default]
+        Unknown = 0x00,
+        /// Used for writing into the slave.
+        MailboxWrite = 0x01,
+        /// Used for reading from the slave.
+        MailboxRead = 0x02,
+        /// Used for process data outputs from master.
+        ProcessDataWrite = 0x03,
+        /// Used for process data inputs to master.
+        ProcessDataRead = 0x04,
+    }
+
+    let data = [0x00u8, 0x04u8, 0x02u8];
+
+    let result = heapless::Vec::<SyncManagerType, 16>::unpack_from_slice(&data);
+
+    assert_eq!(
+        result,
+        Ok(heapless::Vec::try_from(
+            [
+                SyncManagerType::Unknown,
+                SyncManagerType::ProcessDataRead,
+                SyncManagerType::MailboxRead,
+            ]
+            .as_ref()
+        )
+        .unwrap())
+    )
+}

--- a/ethercrab-wire/tests/pack.rs
+++ b/ethercrab-wire/tests/pack.rs
@@ -1,0 +1,235 @@
+use ethercrab_wire::{EtherCrabWireReadWrite, EtherCrabWireWrite};
+
+#[test]
+fn one_bit() {
+    #[derive(Debug, EtherCrabWireReadWrite)]
+    #[wire(bits = 1)]
+    struct Bit {
+        #[wire(bits = 1)]
+        foo: u8,
+    }
+}
+
+#[test]
+fn one_byte() {
+    #[derive(Debug, EtherCrabWireReadWrite)]
+    #[wire(bits = 8)]
+    struct Byte {
+        #[wire(bits = 8)]
+        foo: u8,
+    }
+}
+
+#[test]
+fn basic_enum_byte() {
+    #[derive(Debug, Copy, Clone, EtherCrabWireReadWrite)]
+    #[repr(u8)]
+    #[wire(bits = 8)]
+    enum Check {
+        Foo = 0x01,
+        Bar = 0x02,
+        Baz = 0xaa,
+        Quux = 0xef,
+    }
+
+    // TODO
+}
+
+#[test]
+fn basic_struct() {
+    #[derive(Debug, EtherCrabWireReadWrite)]
+    #[wire(bits = 56)]
+    struct Check {
+        #[wire(bits = 8)]
+        foo: u8,
+        #[wire(bits = 16)]
+        bar: u16,
+        #[wire(bits = 32)]
+        baz: u32,
+    }
+
+    let check = Check {
+        foo: 0xaa,
+        bar: 0xbbcc,
+        baz: 0x33445566,
+    };
+
+    let mut buf = [0u8; 16];
+
+    let out = check.pack_to_slice(&mut buf).unwrap();
+
+    let expected = [
+        0xaau8, // u8
+        0xcc, 0xbb, // u16
+        0x66, 0x55, 0x44, 0x33, // u32
+    ];
+
+    assert_eq!(out, &expected);
+}
+
+#[test]
+fn bools() {
+    #[derive(Debug, EtherCrabWireReadWrite)]
+    #[wire(bits = 3)]
+    struct Check {
+        #[wire(bits = 1)]
+        foo: bool,
+        #[wire(bits = 1)]
+        bar: bool,
+        #[wire(bits = 1)]
+        baz: bool,
+    }
+
+    let check = Check {
+        foo: true,
+        bar: false,
+        baz: true,
+    };
+
+    let mut buf = [0u8; 16];
+
+    let out = check.pack_to_slice(&mut buf).unwrap();
+
+    let expected = [0b101];
+
+    assert_eq!(out, &expected);
+}
+
+#[test]
+fn pack_struct_single_byte() {
+    #[derive(Debug, EtherCrabWireReadWrite)]
+    #[wire(bits = 8)]
+    struct Check {
+        #[wire(bits = 2)]
+        foo: u8,
+        #[wire(bits = 3)]
+        bar: u8,
+        #[wire(bits = 3)]
+        baz: u8,
+    }
+
+    let check = Check {
+        foo: 0b11,
+        bar: 0b101,
+        baz: 0x010,
+    };
+
+    let mut buf = [0u8; 8];
+
+    let out = check.pack_to_slice(&mut buf).unwrap();
+
+    let expected = [0b11 | (0b101 << 2) | (0x010 << 5)];
+
+    assert_eq!(out, &expected);
+
+    assert_eq!(buf, [expected[0], 0, 0, 0, 0, 0, 0, 0]);
+}
+
+#[test]
+fn pack_struct_nested_enum() {
+    #[derive(Debug, Copy, Clone, EtherCrabWireReadWrite)]
+    #[repr(u8)]
+    enum Nested {
+        Foo = 0x01,
+        Bar = 0x02,
+        Baz = 0x03,
+        Quux = 0x04,
+    }
+
+    #[derive(Debug, EtherCrabWireReadWrite)]
+    #[wire(bits = 8)]
+    struct Check {
+        #[wire(bits = 2)]
+        foo: u8,
+        #[wire(bits = 3)]
+        bar: Nested,
+        #[wire(bits = 3)]
+        baz: u8,
+    }
+
+    let check = Check {
+        foo: 0b11,
+        bar: Nested::Baz,
+        baz: 0x010,
+    };
+
+    let expected = [0b11u8 | (0x03 << 2) | (0x010 << 5)];
+
+    let mut buf = [0u8; 16];
+
+    let out = check.pack_to_slice(&mut buf).unwrap();
+
+    assert_eq!(out, &expected, "{:#010b} {:#010b}", out[0], expected[0]);
+}
+
+#[test]
+fn nested_structs() {
+    #[derive(Debug, EtherCrabWireReadWrite)]
+    #[wire(bits = 80)]
+    struct Check {
+        #[wire(bits = 32)]
+        foo: u32,
+        #[wire(bits = 24)]
+        control: Inner,
+        #[wire(bits = 24)]
+        status: Inner,
+    }
+
+    #[derive(Debug, Copy, Clone, EtherCrabWireReadWrite)]
+    #[wire(bits = 24)]
+    struct Inner {
+        #[wire(bits = 1)]
+        yes: bool,
+        #[wire(bits = 1)]
+        no: bool,
+        #[wire(pre_skip = 6, bits = 16)]
+        stuff: u16,
+    }
+
+    let check = Check {
+        foo: 0x44556677,
+        control: Inner {
+            yes: true,
+            no: false,
+            stuff: 0xaabb,
+        },
+        status: Inner {
+            yes: false,
+            no: true,
+            stuff: 0xccdd,
+        },
+    };
+
+    let expected = [
+        0x77u8, 0x66u8, 0x55u8, 0x44u8, // u32
+        0b01, 0xbb, 0xaa, // Control
+        0b10, 0xdd, 0xcc, // Status
+    ];
+
+    let mut buf = [0u8; 16];
+
+    let out = check.pack_to_slice(&mut buf).unwrap();
+
+    assert_eq!(out, &expected);
+}
+
+// // If I don't need this I won't implement it because it makes things a bunch more complex.
+// #[test]
+// fn u16_across_bytes() {
+//     #[derive(Debug, EtherCrabWireReadWrite)]
+//     #[wire(bits = 24)]
+//     struct Check {
+//         #[wire(bits = 3)]
+//         foo: u8,
+//         #[wire(bits = 16)]
+//         bar: u16,
+//         #[wire(bits = 5)]
+//         baz: u8,
+//     }
+
+//     let check = Check {
+//         foo: 0b00,
+//         bar: u16::MAX,
+//         baz: 0x00000,
+//     };
+// }

--- a/ethercrab-wire/tests/unpack.rs
+++ b/ethercrab-wire/tests/unpack.rs
@@ -1,0 +1,118 @@
+use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireReadWrite, EtherCrabWireWrite};
+
+#[test]
+fn basic_struct() {
+    #[derive(Debug, EtherCrabWireReadWrite, PartialEq)]
+    #[wire(bits = 56)]
+    struct Check {
+        #[wire(bits = 8)]
+        foo: u8,
+        #[wire(bits = 16)]
+        bar: u16,
+        #[wire(bits = 32)]
+        baz: u32,
+    }
+
+    let expected = Check {
+        foo: 0xaa,
+        bar: 0xbbcc,
+        baz: 0x33445566,
+    };
+
+    let buf = [
+        0xaau8, // u8
+        0xcc, 0xbb, // u16
+        0x66, 0x55, 0x44, 0x33, // u32
+    ];
+
+    let out = Check::unpack_from_slice(&buf).unwrap();
+
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn unpack_struct_nested_enum() {
+    #[derive(Debug, Copy, Clone, EtherCrabWireReadWrite, PartialEq)]
+    #[repr(u8)]
+    enum Nested {
+        Foo = 0x01,
+        Bar = 0x02,
+        Baz = 0x03,
+        Quux = 0x04,
+    }
+
+    #[derive(Debug, EtherCrabWireReadWrite, PartialEq)]
+    #[wire(bits = 8)]
+    struct Check {
+        #[wire(bits = 2)]
+        foo: u8,
+        #[wire(bits = 3)]
+        bar: Nested,
+        #[wire(bits = 3)]
+        baz: u8,
+    }
+
+    let expected = Check {
+        foo: 0b11,
+        bar: Nested::Baz,
+        // 0x010 is too big to fit in 3 bits, so it will be zero on deserialise
+        baz: 0,
+    };
+
+    let buf = [0b11 | (0x03 << 2) | (0x010 << 5)];
+
+    let out = Check::unpack_from_slice(&buf);
+
+    assert_eq!(out, Ok(expected));
+}
+
+#[test]
+fn nested_structs() {
+    #[derive(Debug, EtherCrabWireReadWrite)]
+    #[wire(bits = 80)]
+    struct Check {
+        #[wire(bits = 32)]
+        foo: u32,
+        #[wire(bits = 24)]
+        control: Inner,
+        #[wire(bits = 24)]
+        status: Inner,
+    }
+
+    #[derive(Debug, Copy, Clone, EtherCrabWireReadWrite)]
+    #[wire(bits = 24)]
+    struct Inner {
+        #[wire(bits = 1)]
+        yes: bool,
+        #[wire(bits = 1)]
+        no: bool,
+        #[wire(pre_skip = 6, bits = 16)]
+        stuff: u16,
+    }
+
+    let check = Check {
+        foo: 0x44556677,
+        control: Inner {
+            yes: true,
+            no: false,
+            stuff: 0xaabb,
+        },
+        status: Inner {
+            yes: false,
+            no: true,
+            stuff: 0xccdd,
+        },
+    };
+
+    let expected = [
+        0x77u8, 0x66u8, 0x55u8, 0x44u8, // u32
+        0b01, 0xbb, 0xaa, // Control
+        0b10, 0xdd, 0xcc, // Status
+    ];
+
+    let mut buf = [0u8; 16];
+
+    let out = check.pack_to_slice(&mut buf).unwrap();
+
+    assert_eq!(out, &expected);
+}

--- a/examples/dump-eeprom.rs
+++ b/examples/dump-eeprom.rs
@@ -8,7 +8,7 @@ use embedded_io_async::Read;
 use env_logger::Env;
 use ethercrab::{
     error::Error,
-    internals::{DeviceEeprom, EepromDataProvider, SlaveClient},
+    internals::{ChunkReader, DeviceEeprom, SlaveClient},
     std::tx_rx_task,
     Client, ClientConfig, PduStorage, SlaveGroupState, Timeouts,
 };
@@ -82,21 +82,48 @@ async fn main() -> Result<(), Error> {
 
     let slave_client = SlaveClient::new(&client, base_address + index);
 
-    let provider = DeviceEeprom::new(&slave_client);
+    let mut len_buf = [0u8; 2];
 
-    let len = provider.len().await.expect("Len");
+    // ETG2020 page 7: 0x003e is the EEPROM address size register in kilobit minus 1 (u16).
+    ChunkReader::new(DeviceEeprom::new(&slave_client), 0x003e, 2)
+        .read_exact(&mut len_buf)
+        .await
+        .expect("Could not read EEPROM len");
+
+    // Kilobits to bits to bytes, and undoing the offset
+    let len = ((u16::from_le_bytes(len_buf) + 1) * 1024) / 8;
 
     log::info!("--> Device EEPROM is {} bytes long", len);
 
-    let mut reader = provider.reader();
+    let mut provider = ChunkReader::new(DeviceEeprom::new(&slave_client), 0, len);
 
     let mut buf = vec![0u8; usize::from(len)];
 
-    reader.read_exact(&mut buf).await.expect("Read exact");
+    provider.read_exact(&mut buf).await.expect("Read");
 
     std::io::stdout().write_all(&buf[..]).expect("Stdout write");
 
-    log::info!("Done, wrote {} bytes", buf.len());
+    log::info!("Done, wrote {} bytes to stdout", buf.len());
 
     Ok(())
+
+    // let slave_client = SlaveClient::new(&client, base_address + index);
+
+    // let provider = DeviceEeprom::new(&slave_client);
+
+    // let len = provider.len().await.expect("Len");
+
+    // log::info!("--> Device EEPROM is {} bytes long", len);
+
+    // let mut reader = provider.reader();
+
+    // let mut buf = vec![0u8; usize::from(len)];
+
+    // reader.read_exact(&mut buf).await.expect("Read exact");
+
+    // std::io::stdout().write_all(&buf[..]).expect("Stdout write");
+
+    // log::info!("Done, wrote {} bytes", buf.len());
+
+    // Ok(())
 }

--- a/examples/embassy-stm32/Cargo.toml
+++ b/examples/embassy-stm32/Cargo.toml
@@ -3,7 +3,7 @@ name = "ethercrab-stm32-embassy"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[workspace]
 
 [dependencies]
 ethercrab = { path = "../..", default-features = false, features = ["defmt"] }

--- a/release.toml
+++ b/release.toml
@@ -5,5 +5,7 @@ pre-release-replacements = [
   { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate" },
   { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/{{tag_name}}...HEAD" },
 ]
-pre-release-commit-message = "Commit new release"
-tag-message = "Release {{crate_name}} {{version}}"
+pre-release-commit-message = "Release {{crate_name}} v{{version}}"
+tag-message = "Release {{crate_name}} v{{version}}"
+allow-branch = ["master"]
+tag-prefix = "{{crate_name}}-"

--- a/src/eeprom/device_reader.rs
+++ b/src/eeprom/device_reader.rs
@@ -22,6 +22,7 @@ pub struct DeviceEeprom<'slave> {
 }
 
 impl<'slave> DeviceEeprom<'slave> {
+    /// Create a new device EEPROM instance.
     pub fn new(client: &'slave SlaveClient<'slave>) -> Self {
         Self { client }
     }

--- a/src/eeprom/mod.rs
+++ b/src/eeprom/mod.rs
@@ -15,6 +15,8 @@ pub mod file_reader;
 /// A data source for EEPROM reads.
 pub trait EepromDataProvider: Clone {
     /// Read a chunk of either 4 or 8 bytes from the backing store.
+    // Internal only so I don't mind async fn in trait
+    #[allow(async_fn_in_trait)]
     async fn read_chunk(&mut self, start_word: u16) -> Result<impl Deref<Target = [u8]>, Error>;
 }
 

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -3,5 +3,5 @@
 //! Anything exported by this module should be considered unstable and may change at any time.
 
 pub use crate::eeprom::device_reader::DeviceEeprom;
-pub use crate::eeprom::EepromDataProvider;
+pub use crate::eeprom::ChunkReader;
 pub use crate::slave::slave_client::SlaveClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,10 @@ pub use client::Client;
 pub use client_config::{ClientConfig, RetryBehaviour};
 pub use coe::SubIndex;
 pub use command::{Command, Reads, Writes};
+pub use ethercrab_wire::{
+    EtherCrabWireRead, EtherCrabWireReadSized, EtherCrabWireReadWrite, EtherCrabWireSized,
+    EtherCrabWireWrite, EtherCrabWireWriteSized,
+};
 pub use pdu_loop::{PduLoop, PduRx, PduStorage, PduTx, SendableFrame};
 pub use register::RegisterAddress;
 pub use slave::{Slave, SlaveIdentity, SlavePdi, SlaveRef};


### PR DESCRIPTION
To replace `packed_struct`, `num-enum` and `nom`.

These are experimental crates that have custom derives for reading/writing from/to EtherCAT wire representations. They will hopefully become more useful to end users in the future for things like autoconfiguration from ESI files and such.

This is a split of #139 as that PR is huge and unwieldy due to high doses of  scope creep.

These crates will be released with a breaking minor release of `ethercrab` when it has migrated to use these traits.