### PR TITLE
Fix `AlStatusCode::ApplicationControllerAvailableI` typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ An EtherCAT master written in Rust.
   - `EtherCrabWireSized`
   - `EtherCrabWireWrite`
 
+### Fixed
+
+- **(breaking)** (technically) [#143](https://github.com/ethercrab-rs/ethercrab/pull/143) Fix typo
+  in name `AlStatusCode::ApplicationControllerAvailableI` ->
+  `AlStatusCode::ApplicationControllerAvailable`
+
 ## [0.3.5] - 2023-12-22
 
 ### Changed

--- a/src/al_status_code.rs
+++ b/src/al_status_code.rs
@@ -110,7 +110,7 @@ pub enum AlStatusCode {
     /// Device Identification value updated
     DeviceIdentificationValueUpdated = 0x0061,
     /// Application controller available
-    ApplicationControllerAvailableI = 0x00F0,
+    ApplicationControllerAvailable = 0x00F0,
     // NOTE: Other codes < 0x8000 are reserved.
     // NOTE: Codes 0x8000 - 0xffff are vendor specific.
     /// Unknown status code.
@@ -178,7 +178,7 @@ impl core::fmt::Display for AlStatusCode {
             AlStatusCode::EepromError => "EEPROM Error",
             AlStatusCode::SlaveRestartedLocally => "Slave restarted locally",
             AlStatusCode::DeviceIdentificationValueUpdated => "Device Identification value updated",
-            AlStatusCode::ApplicationControllerAvailableI => "Application controller available",
+            AlStatusCode::ApplicationControllerAvailable => "Application controller available",
             AlStatusCode::Unknown(_) => "(unknown)",
         };
 


### PR DESCRIPTION
As title :) just removes the bogus `I` from the end.