### PR TITLE
Change `PduError::InvalidIndex` to hold a `u8`, not a `usize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ An EtherCAT master written in Rust.
   - `SlaveRef::register_read` from `PduData` to `EtherCrabWireWrite`
   - `SlaveRef::register_write` from `PduData` to `EtherCrabWireReadWrite`
 
+- **(breaking)** [#144](https://github.com/ethercrab-rs/ethercrab/pull/144)
+  `PduError::InvalidIndex(usize)` is now a `PduError::InvalidIndex(u8)` as the EtherCAT index field
+  is itself onl a `u8`.
+
 ### Added
 
 - [#141](https://github.com/ethercrab-rs/ethercrab/pull/141) Added the `ethercat-wire` and

--- a/src/error.rs
+++ b/src/error.rs
@@ -200,7 +200,7 @@ pub enum PduError {
     /// Failed to create an Ethernet II frame.
     CreateFrame,
     /// A frame index was given that does not point to a frame.
-    InvalidIndex(usize),
+    InvalidIndex(u8),
     /// A received frame is invalid.
     Validation(PduValidationError),
     /// A frame is not ready to be reused.

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -69,7 +69,7 @@ impl<'sto> PduRx<'sto> {
         let mut frame = self
             .storage
             .claim_receiving(index)
-            .ok_or_else(|| PduError::InvalidIndex(usize::from(index)))?;
+            .ok_or(PduError::InvalidIndex(index))?;
 
         (|| {
             if frame.index() != index {


### PR DESCRIPTION
The field in the EtherCAT frame is a `u8` so it makes no sense for the reported error to be a `usize`.