### PR TITLE
Remove `context` from `Error::WorkingCounter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ An EtherCAT master written in Rust.
   in name `AlStatusCode::ApplicationControllerAvailableI` ->
   `AlStatusCode::ApplicationControllerAvailable`
 
+### Removed
+
+- **(breaking)** [#145](https://github.com/ethercrab-rs/ethercrab/pull/145) Remove the `context`
+  field from `Error::WorkingCounter`. The output from EtherCrab's error logging should be used
+  instead.
+
 ## [0.3.5] - 2023-12-22
 
 ### Changed

--- a/src/client.rs
+++ b/src/client.rs
@@ -221,7 +221,7 @@ impl<'sto> Client<'sto> {
             Command::apwr(slave_idx, RegisterAddress::ConfiguredStationAddress.into())
                 .send(self, configured_address)
                 .await?
-                .wkc(1, "set station address")?;
+                .wkc(1)?;
 
             let slave = Slave::new(self, usize::from(slave_idx), configured_address).await?;
 
@@ -393,7 +393,7 @@ impl<'sto> Client<'sto> {
                 let status = Command::brd(RegisterAddress::AlStatus.into())
                     .receive::<AlControl>(self)
                     .await?
-                    .wkc(num_slaves, "read all slaves state")?;
+                    .wkc(num_slaves)?;
 
                 fmt::trace!("Global AL status {:?}", status);
 

--- a/src/dc.rs
+++ b/src/dc.rs
@@ -21,7 +21,7 @@ async fn latch_dc_times(client: &Client<'_>, slaves: &mut [Slave]) -> Result<(),
     Command::bwr(RegisterAddress::DcTimePort0.into())
         .send_receive(client, 0u32)
         .await?
-        .wkc(num_slaves_with_dc as u16, "Broadcast time")?;
+        .wkc(num_slaves_with_dc as u16)?;
 
     // Read receive times for all slaves and store on slave structs
     for slave in slaves.iter_mut().filter(|slave| slave.flags.dc_supported) {
@@ -39,7 +39,6 @@ async fn latch_dc_times(client: &Client<'_>, slaves: &mut [Slave]) -> Result<(),
                 RegisterAddress::DcTimePort0.into(),
                 // 4 u32
                 4 * 4,
-                "Port receive times",
             )
             .await
             .map(|slice| {

--- a/src/eeprom/device_reader.rs
+++ b/src/eeprom/device_reader.rs
@@ -36,7 +36,7 @@ impl<'slave> EepromDataProvider for DeviceEeprom<'slave> {
     ) -> Result<impl core::ops::Deref<Target = [u8]>, Error> {
         let status = self
             .client
-            .read::<SiiControl>(RegisterAddress::SiiControl.into(), "Read SII control")
+            .read::<SiiControl>(RegisterAddress::SiiControl.into())
             .await?;
 
         // Clear errors
@@ -47,7 +47,6 @@ impl<'slave> EepromDataProvider for DeviceEeprom<'slave> {
                 .write_slice(
                     RegisterAddress::SiiControl.into(),
                     &status.error_reset().pack(),
-                    "Reset errors",
                 )
                 .await?;
         }
@@ -59,7 +58,6 @@ impl<'slave> EepromDataProvider for DeviceEeprom<'slave> {
             .write_slice(
                 RegisterAddress::SiiControl.into(),
                 &SiiRequest::read(start_word).pack(),
-                "SII read setup",
             )
             .await?;
 
@@ -69,7 +67,6 @@ impl<'slave> EepromDataProvider for DeviceEeprom<'slave> {
             .read_slice(
                 RegisterAddress::SiiData.into(),
                 status.read_size.chunk_len(),
-                "SII data",
             )
             .await
             .map(|data| {
@@ -88,7 +85,7 @@ async fn wait(slave: &SlaveClient<'_>) -> Result<(), Error> {
     crate::timer_factory::timeout(slave.timeouts().eeprom, async {
         loop {
             let control = slave
-                .read::<SiiControl>(RegisterAddress::SiiControl.into(), "SII busy wait")
+                .read::<SiiControl>(RegisterAddress::SiiControl.into())
                 .await?;
 
             if !control.busy {

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,8 +16,6 @@ pub enum Error {
         expected: u16,
         /// The actual value received.
         received: u16,
-        /// Optional context for debugging.
-        context: Option<&'static str>,
     },
     /// Failed to borrow an item. This likely points to a race condition.
     Borrow,
@@ -100,17 +98,9 @@ impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::Pdu(e) => write!(f, "pdu: {}", e),
-            Error::WorkingCounter {
-                expected,
-                received,
-                context,
-            } => write!(
-                f,
-                "working counter expected {}, got {} ({})",
-                expected,
-                received,
-                context.unwrap_or("[no context provided]")
-            ),
+            Error::WorkingCounter { expected, received } => {
+                write!(f, "working counter expected {}, got {}", expected, received)
+            }
             Error::Borrow => f.write_str("already borrowed"),
             Error::Timeout => f.write_str("timeout"),
             Error::Eeprom(e) => write!(f, "eeprom: {}", e),

--- a/src/pdu_loop/frame_element/received_frame.rs
+++ b/src/pdu_loop/frame_element/received_frame.rs
@@ -25,7 +25,7 @@ impl<'sto> ReceivedFrame<'sto> {
     ///
     /// If the working counter of the received frame does not match the given expected value, this
     /// method will return an [`Error::WorkingCounter`] error.
-    pub fn wkc(self, expected: u16, context: &'static str) -> Result<RxFrameDataBuf<'sto>, Error> {
+    pub fn wkc(self, expected: u16) -> Result<RxFrameDataBuf<'sto>, Error> {
         let frame = self.frame();
         let act_wc = frame.working_counter;
 
@@ -35,7 +35,6 @@ impl<'sto> ReceivedFrame<'sto> {
             Err(Error::WorkingCounter {
                 expected,
                 received: act_wc,
-                context: Some(context),
             })
         }
     }

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -28,18 +28,17 @@ use self::frame_element::received_frame::ReceivedFrame;
 pub type PduResponse<T> = (T, u16);
 
 pub trait CheckWorkingCounter<T> {
-    fn wkc(self, expected: u16, context: &'static str) -> Result<T, Error>;
+    fn wkc(self, expected: u16) -> Result<T, Error>;
 }
 
 impl<T> CheckWorkingCounter<T> for PduResponse<T> {
-    fn wkc(self, expected: u16, context: &'static str) -> Result<T, Error> {
+    fn wkc(self, expected: u16) -> Result<T, Error> {
         if self.1 == expected {
             Ok(self.0)
         } else {
             Err(Error::WorkingCounter {
                 expected,
                 received: self.1,
-                context: Some(context),
             })
         }
     }
@@ -619,7 +618,7 @@ mod tests {
                 )
                 .await
                 .unwrap()
-                .wkc(0, "testing")
+                .wkc(0)
                 .unwrap();
 
             assert_eq!(&*result, &data);

--- a/src/slave/configuration.rs
+++ b/src/slave/configuration.rs
@@ -238,7 +238,6 @@ where
             .write_slice(
                 RegisterAddress::sync_manager(sync_manager_index).into(),
                 &sm_config.pack(),
-                "SM config",
             )
             .await?;
 
@@ -472,11 +471,7 @@ where
         // Multiple SMs may use the same FMMU, so we'll read the existing config from the slave
         let mut fmmu_config = self
             .client
-            .read_slice(
-                RegisterAddress::fmmu(fmmu_index as u8).into(),
-                16,
-                "read FMMU config",
-            )
+            .read_slice(RegisterAddress::fmmu(fmmu_index as u8).into(), 16)
             .await
             .and_then(|raw| Fmmu::unpack_from_slice(&raw).map_err(|_| Error::Internal))?;
 
@@ -506,7 +501,6 @@ where
             .write_slice(
                 RegisterAddress::fmmu(fmmu_index as u8).into(),
                 &fmmu_config.pack(),
-                "PDI FMMU",
             )
             .await?;
         fmt::debug!(

--- a/src/slave/slave_client.rs
+++ b/src/slave/slave_client.rs
@@ -54,14 +54,14 @@ impl<'client> SlaveClient<'client> {
     }
 
     #[inline(always)]
-    pub(crate) async fn read<T>(&self, register: u16, context: &'static str) -> Result<T, Error>
+    pub(crate) async fn read<T>(&self, register: u16) -> Result<T, Error>
     where
         T: EtherCrabWireReadSized,
     {
         Command::fprd(self.configured_address, register)
             .receive(self.client)
             .await?
-            .wkc(1, context)
+            .wkc(1)
     }
 
     #[inline(always)]
@@ -69,12 +69,11 @@ impl<'client> SlaveClient<'client> {
         &self,
         register: u16,
         len: u16,
-        context: &'static str,
     ) -> Result<RxFrameDataBuf<'client>, Error> {
         Command::fprd(self.configured_address, register)
             .receive_slice(self.client, len)
             .await?
-            .wkc(1, context)
+            .wkc(1)
     }
 
     #[inline(always)]
@@ -82,28 +81,22 @@ impl<'client> SlaveClient<'client> {
         &self,
         register: u16,
         value: &[u8],
-        context: &'static str,
     ) -> Result<RxFrameDataBuf<'_>, Error> {
         Command::fpwr(self.configured_address, register)
             .send_receive_slice(self.client, value)
             .await?
-            .wkc(1, context)
+            .wkc(1)
     }
 
     /// A wrapper around an FPWR service to this slave's configured address, ignoring any response.
     #[inline(always)]
-    pub(crate) async fn write<T>(
-        &self,
-        register: u16,
-        value: T,
-        context: &'static str,
-    ) -> Result<(), Error>
+    pub(crate) async fn write<T>(&self, register: u16, value: T) -> Result<(), Error>
     where
         T: EtherCrabWireWrite,
     {
         Command::fpwr(self.configured_address, register)
             .send(self.client, value)
             .await?
-            .wkc(1, context)
+            .wkc(1)
     }
 }


### PR DESCRIPTION
It's not particularly useful for troubleshooting, and doesn't really provide anything that a normal error log and a Wireshark capture can't, beyond adding bloat the resulting binary which is important for embedded systems.