### PR TITLE
Tweak dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ embedded-io-async = { version = "0.6.0", default-features = false }
 futures-lite = { version = "2.0.0", default-features = false }
 heapless = "0.8.0"
 log = { version = "0.4.20", optional = true, default-features = false }
-nom = { version = "7.1.3", default-features = false }
 sealed = "0.5.0"
 serde = { version = "1.0.190", features = ["derive"], optional = true }
 smlang = "0.6.0"
@@ -91,10 +90,10 @@ defmt = [
 ]
 log = ["dep:log"]
 std = [
-    "pnet_datalink",
-    "async-io",
+    "dep:pnet_datalink",
+    "dep:async-io",
     "smoltcp/phy-raw_socket",
-    "log",
+    "dep:log",
     "futures-lite/std",
     "embedded-io-async/std",
     "ethercrab-wire/std",


### PR DESCRIPTION
- Use newer optional dependency syntax
- Remove `nom` as it's no longer used anywhere in the code