### PR TITLE
Add a trait for cleaner timeouts

### DIFF
--- a/src/command/reads.rs
+++ b/src/command/reads.rs
@@ -2,6 +2,7 @@ use crate::{
     error::Error,
     fmt,
     pdu_loop::{CheckWorkingCounter, PduResponse, RxFrameDataBuf},
+    timer_factory::IntoTimeout,
     Client,
 };
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
@@ -97,7 +98,7 @@ impl<'client> WrappedRead<'client> {
                     .pdu_loop
                     .pdu_send(self.command.into(), (), Some(len))?;
 
-            match crate::timer_factory::timeout(self.client.timeouts.pdu, frame).await {
+            match frame.timeout(self.client.timeouts.pdu).await {
                 Ok(result) => return Ok(result.into_data()),
                 Err(Error::Timeout) => {
                     fmt::error!("Frame {} timed out", frame_idx);

--- a/src/command/writes.rs
+++ b/src/command/writes.rs
@@ -2,6 +2,7 @@ use crate::{
     error::{Error, PduError},
     fmt,
     pdu_loop::{CheckWorkingCounter, PduResponse, RxFrameDataBuf},
+    timer_factory::IntoTimeout,
     Client,
 };
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireWrite};
@@ -142,7 +143,7 @@ impl<'client> WrappedWrite<'client> {
                     .pdu_loop
                     .pdu_send(self.command.into(), &value, len_override)?;
 
-            match crate::timer_factory::timeout(self.client.timeouts.pdu, frame).await {
+            match frame.timeout(self.client.timeouts.pdu).await {
                 Ok(result) => return Ok(result.into_data()),
                 Err(Error::Timeout) => {
                     fmt::error!("Frame {} timed out", frame_idx);

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -183,6 +183,7 @@ mod tests {
             created_frame::CreatedFrame, sendable_frame::SendableFrame, FrameBox, FrameElement,
             FrameState,
         },
+        timer_factory::IntoTimeout,
         Command, Reads,
     };
     use core::{
@@ -199,22 +200,20 @@ mod tests {
         static STORAGE: PduStorage<1, 16> = PduStorage::new();
         let (_tx, _rx, pdu_loop) = STORAGE.try_split().unwrap();
 
-        let send_result = crate::timer_factory::timeout(
-            Duration::from_secs(0),
-            pdu_loop
-                .pdu_send(
-                    Reads::Brd {
-                        address: 0,
-                        register: 0,
-                    }
-                    .into(),
-                    (),
-                    Some(16),
-                )
-                .unwrap()
-                .0,
-        )
-        .await;
+        let send_result = pdu_loop
+            .pdu_send(
+                Reads::Brd {
+                    address: 0,
+                    register: 0,
+                }
+                .into(),
+                (),
+                Some(16),
+            )
+            .unwrap()
+            .0
+            .timeout(Duration::from_secs(0))
+            .await;
 
         // Just make sure the read timed out
         assert_eq!(send_result.unwrap_err(), Error::Timeout);

--- a/src/slave_group/mod.rs
+++ b/src/slave_group/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     fmt,
     pdi::PdiOffset,
     slave::{configuration::PdoDirection, pdi::SlavePdi, IoRanges, Slave, SlaveRef},
-    timer_factory::timeout,
+    timer_factory::IntoTimeout,
     Client, SlaveState,
 };
 use atomic_refcell::{AtomicRefCell, AtomicRefMut};
@@ -284,7 +284,7 @@ impl<const MAX_SLAVES: usize, const MAX_PDI: usize, S> SlaveGroup<MAX_SLAVES, MA
         client: &Client<'_>,
         desired_state: SlaveState,
     ) -> Result<(), Error> {
-        timeout(client.timeouts.state_transition, async {
+        async {
             loop {
                 let mut all_transitioned = true;
 
@@ -305,7 +305,8 @@ impl<const MAX_SLAVES: usize, const MAX_PDI: usize, S> SlaveGroup<MAX_SLAVES, MA
 
                 client.timeouts.loop_tick().await;
             }
-        })
+        }
+        .timeout(client.timeouts.state_transition)
         .await
     }
 


### PR DESCRIPTION
Slightly cleaner code around timing out futures.

Also reduces binary size which was the primary motivator for this PR.