### PR TITLE
Upgrade Embassy example to stable crate versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ An EtherCAT master written in Rust.
 - [#151](https://github.com/ethercrab-rs/ethercrab/pull/151) Reduced overhead for EEPROM reads. Each
   chunk reader now only checks for and (attempt to) clear device errors once before reading a chunk
   of data, not for every chunk.
+- [#156](https://github.com/ethercrab-rs/ethercrab/pull/156) Update `embassy-time` from 0.2.0 to
+  0.3.0.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ atomic_refcell = "0.1.13"
 bitflags = "2.4.1"
 defmt = { version = "0.3.5", optional = true }
 embassy-futures = "0.1.0"
-embassy-time = "0.2.0"
+embassy-time = "0.3.0"
 embedded-io-async = { version = "0.6.0", default-features = false }
 futures-lite = { version = "2.0.0", default-features = false }
 heapless = "0.8.0"

--- a/examples/embassy-stm32/Cargo.toml
+++ b/examples/embassy-stm32/Cargo.toml
@@ -15,14 +15,14 @@ cortex-m = { version = "0.7.6", features = [
     "critical-section-single-core",
 ] }
 cortex-m-rt = "0.7.0"
-embedded-hal = "0.2.6"
+embedded-hal = "1.0.0"
 embedded-io = "0.6.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-static_cell = { version = "1.1", features = ["nightly"] }
+static_cell = { version = "2.0.0" }
 smoltcp = { version = "0.11.0", features = ["defmt"], default-features = false }
 
 embassy-sync = { version = "0.5.0", features = ["defmt"] }
-embassy-executor = { version = "0.4.0", features = [
+embassy-executor = { version = "0.5.0", features = [
     "arch-cortex-m",
     "executor-thread",
     "executor-interrupt",
@@ -32,7 +32,7 @@ embassy-executor = { version = "0.4.0", features = [
     # TODO: Use stable when type_alias_impl_trait is stabilised.
     "nightly",
 ] }
-embassy-time = { version = "0.2.0", features = [
+embassy-time = { version = "0.3.0", features = [
     "defmt",
     "defmt-timestamp-uptime",
     "tick-hz-1_000_000",
@@ -43,7 +43,7 @@ embassy-stm32 = { version = "0.1.0", features = [
     "memory-x",
     "time-driver-any",
 ] }
-embassy-net = { version = "0.2.1", features = [
+embassy-net = { version = "0.4.0", features = [
     "defmt",
     "tcp",
     "dhcpv4",
@@ -56,11 +56,3 @@ debug = 2
 opt-level = "z"
 lto = true
 codegen-units = 1
-
-[patch.crates-io]
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "eebfee189a592427423d3a3ad22132d59926a0e8" }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "eebfee189a592427423d3a3ad22132d59926a0e8" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "eebfee189a592427423d3a3ad22132d59926a0e8" }
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "eebfee189a592427423d3a3ad22132d59926a0e8" }
-embassy-net = { git = "https://github.com/embassy-rs/embassy.git", rev = "eebfee189a592427423d3a3ad22132d59926a0e8" }
-embassy-net-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "eebfee189a592427423d3a3ad22132d59926a0e8" }

--- a/examples/embassy-stm32/Cargo.toml
+++ b/examples/embassy-stm32/Cargo.toml
@@ -20,8 +20,6 @@ embedded-io = "0.6.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 static_cell = { version = "2.0.0" }
 smoltcp = { version = "0.11.0", features = ["defmt"], default-features = false }
-
-embassy-sync = { version = "0.5.0", features = ["defmt"] }
 embassy-executor = { version = "0.5.0", features = [
     "arch-cortex-m",
     "executor-thread",
@@ -29,8 +27,6 @@ embassy-executor = { version = "0.5.0", features = [
     "defmt",
     "integrated-timers",
     "arch-cortex-m",
-    # TODO: Use stable when type_alias_impl_trait is stabilised.
-    "nightly",
 ] }
 embassy-time = { version = "0.3.0", features = [
     "defmt",

--- a/examples/embassy-stm32/src/main.rs
+++ b/examples/embassy-stm32/src/main.rs
@@ -17,7 +17,7 @@ use embassy_stm32::{
 use embassy_time::{Duration, Instant, Timer};
 use ethercrab::{Client, ClientConfig, PduRx, PduStorage, PduTx, SendableFrame, Timeouts};
 use panic_probe as _;
-use static_cell::make_static;
+use static_cell::StaticCell;
 
 bind_interrupts!(struct Irqs {
     ETH => eth::InterruptHandler;
@@ -129,9 +129,10 @@ async fn main(spawner: Spawner) {
 
     let (tx, rx, pdu_loop) = defmt::unwrap!(PDU_STORAGE.try_split());
 
+    static PACKETS: StaticCell<PacketQueue<16, 16>> = StaticCell::new();
     let device = {
         let mut device = Ethernet::new(
-            make_static!(PacketQueue::<4, 4>::new()),
+            PACKETS.init(PacketQueue::<16, 16>::new()),
             p.ETH,
             Irqs,
             p.PA1,


### PR DESCRIPTION
`embassy` recently released stable versions of their crates, so we can remove the nightly patches.

The only ethercrab-specific change is a bump of `embassy-time` to 0.3.0.