### PR TITLE
Support `i*` types for enum discriminants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,12 @@ tokio = { version = "1.33.0", features = ["rt", "macros", "time"] }
 arbitrary = { version = "1.3.1", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 ctrlc = "3.4.1"
-env_logger = "0.10.0"
+env_logger = "0.11.1"
 hdrhistogram = "7.5.2"
 heckcheck = "2.0.1"
 pcap-file = "2.0.0"
 pretty_assertions = "1.4.0"
-smol = "1.3.0"
+smol = "2.0.0"
 tokio = { version = "1.33.0", features = [
     "rt-multi-thread",
     "macros",

--- a/ethercrab-wire-derive/src/generate_enum.rs
+++ b/ethercrab-wire-derive/src/generate_enum.rs
@@ -10,9 +10,10 @@ pub fn generate_enum_write(
     let name = input.ident.clone();
     let repr_type = parsed.repr_type;
     let size_bytes = match repr_type.to_string().as_str() {
-        "u8" => 1usize,
-        "u16" => 2,
-        "u32" => 4,
+        "u8" | "i8" => 1usize,
+        "u16" | "i16" => 2,
+        "u32" | "i32" => 4,
+        "u64" | "i64" => 8,
         invalid => unreachable!("Invalid repr {}", invalid),
     };
 
@@ -84,9 +85,10 @@ pub fn generate_enum_read(
     let name = input.ident.clone();
     let repr_type = parsed.repr_type;
     let size_bytes = match repr_type.to_string().as_str() {
-        "u8" => 1usize,
-        "u16" => 2,
-        "u32" => 4,
+        "u8" | "i8" => 1usize,
+        "u16" | "i16" => 2,
+        "u32" | "i32" => 4,
+        "u64" | "i64" => 8,
         invalid => unreachable!("Invalid repr {}", invalid),
     };
 

--- a/ethercrab-wire-derive/src/help.rs
+++ b/ethercrab-wire-derive/src/help.rs
@@ -166,7 +166,7 @@ pub fn enum_repr_ty(attrs: &[syn::Attribute], ident: &Ident) -> Result<Ident, sy
 }
 
 /// Look for 'alternatives = [1,2,3]` attribute on enum variant.
-pub fn variant_alternatives(attrs: &[syn::Attribute]) -> Result<Vec<u32>, syn::Error> {
+pub fn variant_alternatives(attrs: &[syn::Attribute]) -> Result<Vec<i128>, syn::Error> {
     for attr in my_attributes(attrs) {
         let Ok(nested) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
         else {
@@ -192,7 +192,7 @@ pub fn variant_alternatives(attrs: &[syn::Attribute]) -> Result<Vec<u32>, syn::E
                                     ));
                                 };
 
-                                lit.base10_parse::<u32>()
+                                lit.base10_parse::<i128>()
                             })
                             .collect::<Result<Vec<_>, _>>();
                     }

--- a/ethercrab-wire-derive/ui/enum-isize.rs
+++ b/ethercrab-wire-derive/ui/enum-isize.rs
@@ -1,0 +1,8 @@
+#[derive(ethercrab_wire::EtherCrabWireWrite)]
+#[repr(isize)]
+enum NoIsize {
+    Foo,
+    Bar,
+}
+
+fn main() {}

--- a/ethercrab-wire-derive/ui/enum-isize.stderr
+++ b/ethercrab-wire-derive/ui/enum-isize.stderr
@@ -1,0 +1,5 @@
+error: usize and isize may not be used as enum repr as these types can change size based on target platform. Use an i* or u* type instead.
+ --> ui/enum-isize.rs:2:8
+  |
+2 | #[repr(isize)]
+  |        ^^^^^

--- a/ethercrab-wire-derive/ui/enum-usize.rs
+++ b/ethercrab-wire-derive/ui/enum-usize.rs
@@ -1,0 +1,8 @@
+#[derive(ethercrab_wire::EtherCrabWireWrite)]
+#[repr(usize)]
+enum NoUsize {
+    Foo,
+    Bar,
+}
+
+fn main() {}

--- a/ethercrab-wire-derive/ui/enum-usize.stderr
+++ b/ethercrab-wire-derive/ui/enum-usize.stderr
@@ -1,0 +1,5 @@
+error: usize and isize may not be used as enum repr as these types can change size based on target platform. Use an i* or u* type instead.
+ --> ui/enum-usize.rs:2:8
+  |
+2 | #[repr(usize)]
+  |        ^^^^^

--- a/ethercrab-wire/tests/signed-enums.rs
+++ b/ethercrab-wire/tests/signed-enums.rs
@@ -1,0 +1,42 @@
+use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireReadWrite, EtherCrabWireWriteSized};
+
+#[test]
+fn signed_byte_enum() {
+    #[derive(Debug, Copy, Clone, EtherCrabWireReadWrite)]
+    #[repr(i8)]
+    enum SignedByte {
+        Foo = -10,
+        Bar,
+        Baz,
+    }
+
+    #[allow(unused)]
+    #[repr(i8)]
+    enum NotDerived {
+        Foo = -10,
+        Bar,
+        Baz,
+    }
+
+    assert_eq!(NotDerived::Bar as i8, -9);
+    assert_eq!(SignedByte::Bar.pack(), [-9i8 as u8]);
+    // Just sanity checking my self here
+    assert_eq!(SignedByte::Bar.pack(), [247u8]);
+}
+
+#[test]
+fn signed_enum_i32() {
+    #[derive(Debug, PartialEq, Copy, Clone, EtherCrabWireReadWrite)]
+    #[repr(i32)]
+    enum BigBoy {
+        Foo = 0x00bbccdd,
+        Bar = -2_147_483_648,
+        Baz = -1073741824,
+    }
+
+    assert_eq!(BigBoy::unpack_from_slice(&[0, 0, 0, 192]), Ok(BigBoy::Baz));
+    assert_eq!(
+        BigBoy::unpack_from_slice(&[0xdd, 0xcc, 0xbb, 0x00]),
+        Ok(BigBoy::Foo)
+    );
+}


### PR DESCRIPTION
- Add support for `i8`, `i16`, `i32` and `i64` enum discriminants.
- Add support for `u64` enum discriminant
- Explicitly mention that `isize` and `usize` are not supported as they can change width on different platforms.