### PR TITLE
Zero out packing buffers before use

### DIFF
--- a/ethercrab-wire-derive/src/generate_enum.rs
+++ b/ethercrab-wire-derive/src/generate_enum.rs
@@ -52,6 +52,10 @@ pub fn generate_enum_write(
             fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
                 let mut buf = &mut buf[0..#size_bytes];
 
+                unsafe {
+                    buf.as_mut_ptr().write_bytes(0u8, #size_bytes);
+                }
+
                 #pack
 
                 buf
@@ -66,6 +70,7 @@ pub fn generate_enum_write(
             fn pack(&self) -> Self::Buffer {
                 let mut buf = [0u8; #size_bytes];
 
+                // Delegate to EtherCrabWireWrite impl above
                 <Self as ::ethercrab_wire::EtherCrabWireWrite>::pack_to_slice_unchecked(self, &mut buf);
 
                 buf

--- a/ethercrab-wire-derive/src/generate_struct.rs
+++ b/ethercrab-wire-derive/src/generate_struct.rs
@@ -64,6 +64,10 @@ pub fn generate_struct_write(
                     None => unreachable!()
                 };
 
+                unsafe {
+                    buf.as_mut_ptr().write_bytes(0u8, buf.len());
+                }
+
                 #(#fields_pack)*
 
                 buf

--- a/ethercrab-wire/src/impls.rs
+++ b/ethercrab-wire/src/impls.rs
@@ -167,6 +167,12 @@ impl<const N: usize> EtherCrabWireWrite for [u8; N] {
     fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
         let buf = &mut buf[0..N];
 
+        // SAFETY: Buffer will always be `N` bytes long at this point as the above line will panic
+        // if not.
+        unsafe {
+            buf.as_mut_ptr().write_bytes(0u8, N);
+        }
+
         buf.copy_from_slice(self);
 
         buf
@@ -180,6 +186,10 @@ impl<const N: usize> EtherCrabWireWrite for [u8; N] {
 impl EtherCrabWireWrite for &[u8] {
     fn pack_to_slice_unchecked<'buf>(&self, buf: &'buf mut [u8]) -> &'buf [u8] {
         let buf = &mut buf[0..self.len()];
+
+        unsafe {
+            buf.as_mut_ptr().write_bytes(0u8, buf.len());
+        }
 
         buf.copy_from_slice(self);
 

--- a/ethercrab-wire/tests/signed-enums.rs
+++ b/ethercrab-wire/tests/signed-enums.rs
@@ -1,4 +1,6 @@
-use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireReadWrite, EtherCrabWireWriteSized};
+use ethercrab_wire::{
+    EtherCrabWireRead, EtherCrabWireReadWrite, EtherCrabWireWrite, EtherCrabWireWriteSized,
+};
 
 #[test]
 fn signed_byte_enum() {
@@ -39,4 +41,81 @@ fn signed_enum_i32() {
         BigBoy::unpack_from_slice(&[0xdd, 0xcc, 0xbb, 0x00]),
         Ok(BigBoy::Foo)
     );
+}
+
+#[test]
+fn cia402_control_word() {
+    #[derive(ethercrab_wire::EtherCrabWireReadWrite, Debug, Eq, PartialEq)]
+    #[wire(bytes = 2)]
+    pub struct ControlWord {
+        /// bit 0, switch on
+        #[wire(bits = 1)]
+        pub so: bool,
+
+        /// bit 1, enable voltage
+        #[wire(bits = 1)]
+        pub ev: bool,
+
+        /// bit 2, quick stop
+        #[wire(bits = 1)]
+        pub qs: bool,
+
+        /// bit 3, enable operation
+        #[wire(bits = 1)]
+        pub eo: bool,
+
+        /// bit 4, operation mode specific
+        #[wire(bits = 1)]
+        pub oms_1: bool,
+
+        /// bit 5, operation mode specific
+        #[wire(bits = 1)]
+        pub oms_2: bool,
+
+        /// bit 6, operation mode specific
+        #[wire(bits = 1)]
+        pub oms_3: bool,
+
+        /// bit 7, fault reset
+        #[wire(bits = 1)]
+        pub fr: bool,
+
+        /// bit 8, immediate stop
+        #[wire(bits = 1)]
+        pub halt: bool,
+
+        /// bit 9, immediate stop
+        #[wire(bits = 1, post_skip = 6)]
+        pub oms_4: bool,
+    }
+
+    let mut cw = ControlWord {
+        so: true,
+        ev: true,
+        qs: true,
+        eo: true,
+        oms_1: true,
+        oms_2: false,
+        oms_3: false,
+        fr: true,
+        halt: false,
+        oms_4: false,
+    };
+
+    let mut buf = cw.pack();
+
+    assert_eq!(buf, [0b1001_1111, 0b0000_0000]);
+
+    // Change some flags, so when we pack to the buffer again we can make sure they're updated
+    // properly.
+    cw.so = false;
+    cw.ev = true;
+    cw.qs = true;
+    cw.fr = false;
+
+    cw.pack_to_slice(&mut buf).unwrap();
+
+    let cw2 = ControlWord::unpack_from_slice(&buf).unwrap();
+
+    assert_eq!(cw, cw2);
 }


### PR DESCRIPTION
This change makes for more expected behaviour when packing into existing non-zero buffers. It will be slightly slower and increase code size but is the safer way to go.

`ptr::write_bytes` is used instead of `slice::fill` as it does the same thing with a little less code according to [Godbolt](https://godbolt.org/z/4G888xsKb).