### PR TITLE
Fix logging when `std` feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ std = [
     "dep:pnet_datalink",
     "dep:async-io",
     "smoltcp/phy-raw_socket",
-    "dep:log",
+    "log",
     "futures-lite/std",
     "embedded-io-async/std",
     "ethercrab-wire/std",


### PR DESCRIPTION
I've been pulling my hair out wondering why the logging wasn't working properly! The `std` feature should enable `log` by default.

Regression caused in #150.