### PR TITLE
Support reading/writing `f32`, `f64` and `bool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ An EtherCAT master written in Rust.
 
 ### Added
 
-- [#167](https://github.com/ethercrab-rs/ethercrab/pull/167) Add support for reading/writing `f32`
-  and `f64`. Note that `f64` cannot currently be written using `sdo_write` as only 4 byte expedited
-  transfers are currently supported.
+- [#167](https://github.com/ethercrab-rs/ethercrab/pull/167) Add support for reading/writing `f32`,
+  `f64` and `bool`. Note that `f64` cannot currently be written using `sdo_write` as only 4 byte
+  expedited transfers are currently supported.
 
 ## [0.3.5] - 2023-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#167](https://github.com/ethercrab-rs/ethercrab/pull/167) Add support for reading/writing `f32`
+  and `f64`. Note that `f64` cannot currently be written using `sdo_write` as only 4 byte expedited
+  transfers are currently supported.
+
 ## [0.3.5] - 2023-12-22
 
 ### Changed
@@ -244,8 +250,8 @@ An EtherCAT master written in Rust.
 - Initial release
 
 <!-- next-url -->
-[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.5...HEAD
 
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.5...HEAD
 [0.3.5]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.2...v0.3.3

--- a/src/pdu_data.rs
+++ b/src/pdu_data.rs
@@ -88,6 +88,25 @@ impl_pdudata!(i64);
 impl_float_pdudata!(f32, 4);
 impl_float_pdudata!(f64, 8);
 
+impl PduRead for bool {
+    const LEN: u16 = 1;
+
+    type Error = ();
+
+    fn try_from_slice(slice: &[u8]) -> Result<Self, Self::Error> {
+        Ok(*slice.get(0).ok_or(())? > 0)
+    }
+}
+
+impl PduData for bool {
+    fn as_slice(&self) -> &[u8] {
+        unsafe {
+            #[allow(trivial_casts)]
+            core::slice::from_raw_parts(self as *const _ as *const u8, 1)
+        }
+    }
+}
+
 impl PduRead for () {
     const LEN: u16 = 0;
 

--- a/src/pdu_data.rs
+++ b/src/pdu_data.rs
@@ -88,6 +88,10 @@ impl_pdudata!(i64);
 impl_float_pdudata!(f32, 4);
 impl_float_pdudata!(f64, 8);
 
+// ETG1000.6 5.2.2 states the truthy value is 0xff and false is 0
+static BOOL_FALSE: &[u8] = &[0x00u8];
+static BOOL_TRUE: &[u8] = &[0xffu8];
+
 impl PduRead for bool {
     const LEN: u16 = 1;
 
@@ -100,9 +104,10 @@ impl PduRead for bool {
 
 impl PduData for bool {
     fn as_slice(&self) -> &[u8] {
-        unsafe {
-            #[allow(trivial_casts)]
-            core::slice::from_raw_parts(self as *const _ as *const u8, 1)
+        if *self {
+            BOOL_TRUE
+        } else {
+            BOOL_FALSE
         }
     }
 }

--- a/src/pdu_data.rs
+++ b/src/pdu_data.rs
@@ -51,6 +51,31 @@ macro_rules! impl_pdudata {
     };
 }
 
+macro_rules! impl_float_pdudata {
+    ($ty:ty, $size:expr) => {
+        impl PduRead for $ty {
+            const LEN: u16 = $size;
+            type Error = TryFromSliceError;
+
+            fn try_from_slice(slice: &[u8]) -> Result<Self, Self::Error> {
+                Ok(Self::from_le_bytes(slice.try_into()?))
+            }
+        }
+
+        impl PduData for $ty {
+            fn as_slice(&self) -> &[u8] {
+                unsafe {
+                    #[allow(trivial_casts)]
+                    core::slice::from_raw_parts(self as *const _ as *const u8, $size)
+                }
+
+                // Above is equivalent to the following, but without the dependency
+                // safe_transmute::to_bytes::transmute_one_to_bytes(self)
+            }
+        }
+    };
+}
+
 impl_pdudata!(u8);
 impl_pdudata!(u16);
 impl_pdudata!(u32);
@@ -59,6 +84,9 @@ impl_pdudata!(i8);
 impl_pdudata!(i16);
 impl_pdudata!(i32);
 impl_pdudata!(i64);
+
+impl_float_pdudata!(f32, 4);
+impl_float_pdudata!(f64, 8);
 
 impl PduRead for () {
     const LEN: u16 = 0;


### PR DESCRIPTION
Note that `f64`s cannot currently be passed to `sdo_write` as it only supports 4 byte expedited transfers currently.