### PR TITLE
Split frame parsing up

### DIFF
--- a/src/internals.rs
+++ b/src/internals.rs
@@ -5,4 +5,4 @@
 pub use crate::eeprom::device_reader::DeviceEeprom;
 pub use crate::eeprom::ChunkReader;
 pub use crate::eeprom::EepromDataProvider;
-pub use crate::pdu_loop::FramePreamble;
+pub use crate::pdu_loop::{FrameHeader, PduHeader};

--- a/src/pdu_loop/frame_header.rs
+++ b/src/pdu_loop/frame_header.rs
@@ -1,5 +1,5 @@
 //! An EtherCAT frame header.
-//!
+
 use crate::LEN_MASK;
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized, EtherCrabWireWrite};
 
@@ -16,7 +16,7 @@ pub(crate) enum ProtocolType {
 
 /// An EtherCAT frame header.
 ///
-/// An EtherCAT frame can contain one or more PDUs, each starting with a
+/// An EtherCAT frame can contain one or more PDUs after this header, each starting with a
 /// [`PduHeader`](crate::pdu_loop::pdu_header).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FrameHeader {

--- a/src/pdu_loop/frame_header.rs
+++ b/src/pdu_loop/frame_header.rs
@@ -1,5 +1,5 @@
-//! An EtherCAT frame.
-
+//! An EtherCAT frame header.
+//!
 use crate::LEN_MASK;
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized, EtherCrabWireWrite};
 
@@ -14,6 +14,10 @@ pub(crate) enum ProtocolType {
     // Unknown(u8),
 }
 
+/// An EtherCAT frame header.
+///
+/// An EtherCAT frame can contain one or more PDUs, each starting with a
+/// [`PduHeader`](crate::pdu_loop::pdu_header).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct FrameHeader {
     pub(crate) payload_len: u16,

--- a/src/pdu_loop/frame_header.rs
+++ b/src/pdu_loop/frame_header.rs
@@ -3,7 +3,7 @@
 use crate::LEN_MASK;
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized, EtherCrabWireWrite};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, ethercrab_wire::EtherCrabWireRead)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, ethercrab_wire::EtherCrabWireRead)]
 #[repr(u8)]
 pub(crate) enum ProtocolType {
     DlPdu = 0x01u8,
@@ -18,7 +18,7 @@ pub(crate) enum ProtocolType {
 ///
 /// An EtherCAT frame can contain one or more PDUs, each starting with a
 /// [`PduHeader`](crate::pdu_loop::pdu_header).
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FrameHeader {
     pub(crate) payload_len: u16,
     pub(crate) protocol: ProtocolType,

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -1,6 +1,7 @@
 mod frame_element;
 mod frame_header;
 mod pdu_flags;
+mod pdu_header;
 mod pdu_rx;
 mod pdu_tx;
 // NOTE: Pub so doc links work
@@ -22,7 +23,7 @@ pub use storage::PduStorage;
 use self::frame_element::received_frame::ReceivedFrame;
 
 #[cfg(feature = "__internals")]
-pub use pdu_rx::FramePreamble;
+pub use pdu_rx::PduHeader;
 
 pub type PduResponse<T> = (T, u16);
 
@@ -525,8 +526,8 @@ mod tests {
     // Test the whole TX/RX loop with multiple threads
     #[tokio::test]
     async fn parallel() {
-        // let _ = env_logger::builder().is_test(true).try_init();
-        // env_logger::try_init().ok();
+        let _ = env_logger::builder().is_test(true).try_init();
+        env_logger::try_init().ok();
 
         static STORAGE: PduStorage<16, 128> = PduStorage::<16, 128>::new();
         let (mut tx, mut rx, pdu_loop) = STORAGE.try_split().unwrap();

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -23,7 +23,9 @@ pub use storage::PduStorage;
 use self::frame_element::received_frame::ReceivedFrame;
 
 #[cfg(feature = "__internals")]
-pub use pdu_rx::PduHeader;
+pub use frame_header::FrameHeader;
+#[cfg(feature = "__internals")]
+pub use pdu_header::PduHeader;
 
 pub type PduResponse<T> = (T, u16);
 

--- a/src/pdu_loop/pdu_header.rs
+++ b/src/pdu_loop/pdu_header.rs
@@ -9,15 +9,25 @@ use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
 #[derive(Debug, Copy, Clone, ethercrab_wire::EtherCrabWireRead)]
 #[wire(bytes = 10)]
 pub struct PduHeader {
-    // NOTE: The following fields are included in the header length field value.
+    /// Raw command  code.
     #[wire(bytes = 1)]
     pub command_code: u8,
+
+    /// EtherCAT frame index.
     #[wire(bytes = 1)]
     pub index: u8,
+
+    /// Raw command data.
+    ///
+    /// This represents 2x `u16` or 1x `u32` depending on the command.
     #[wire(bytes = 4)]
     pub command_raw: [u8; 4],
+
+    /// PDU flags.
     #[wire(bytes = 2)]
     pub flags: PduFlags,
+
+    /// IRQ.
     #[wire(bytes = 2)]
     pub irq: u16,
 }
@@ -44,6 +54,7 @@ impl PduHeader {
         Ok((data, wkc))
     }
 
+    /// Create a [`Command`] from the raw data in this header.
     pub fn command(&self) -> Result<Command, Error> {
         Command::parse_code_data(self.command_code, self.command_raw)
     }
@@ -90,7 +101,6 @@ impl PduHeader {
             command_raw.hash(state);
         }
 
-        // flags.hash(state);
         irq.hash(state);
     }
 }

--- a/src/pdu_loop/pdu_header.rs
+++ b/src/pdu_loop/pdu_header.rs
@@ -1,0 +1,299 @@
+use crate::{
+    command::Command,
+    error::{Error, PduError},
+    pdu_loop::pdu_flags::PduFlags,
+};
+use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
+
+/// A single PDU header, command, index, flags and IRQ.
+#[derive(Debug, Copy, Clone, ethercrab_wire::EtherCrabWireRead)]
+#[wire(bytes = 10)]
+pub struct PduHeader {
+    // NOTE: The following fields are included in the header length field value.
+    #[wire(bytes = 1)]
+    pub command_code: u8,
+    #[wire(bytes = 1)]
+    pub index: u8,
+    #[wire(bytes = 4)]
+    pub command_raw: [u8; 4],
+    #[wire(bytes = 2)]
+    pub flags: PduFlags,
+    #[wire(bytes = 2)]
+    pub irq: u16,
+}
+
+impl PduHeader {
+    /// Extract data and working counter from the given buffer.
+    ///
+    /// The buffer must contain the EtherCAT header this `PduHeader` instance was parsed from. It is
+    /// skipped over and the data after it returned.
+    pub fn data_wkc<'buf>(&self, buf: &'buf [u8]) -> Result<(&'buf [u8], u16), Error> {
+        // Jump past PDU header in the buffer
+        let header_offset = Self::PACKED_LEN;
+
+        // The length of the PDU data body. There are two bytes after this that hold the working
+        // counter, but are not counted as part of the PDU length from the header.
+        let data_end = header_offset + usize::from(self.flags.len());
+
+        let data = buf.get(header_offset..data_end).ok_or(PduError::Decode)?;
+        let wkc = buf
+            .get(data_end..)
+            .ok_or(Error::Pdu(PduError::Decode))
+            .and_then(|raw| Ok(u16::unpack_from_slice(raw)?))?;
+
+        Ok((data, wkc))
+    }
+
+    pub fn command(&self) -> Result<Command, Error> {
+        Command::parse_code_data(self.command_code, self.command_raw)
+    }
+
+    /// A hacked equality check used for replay tests only.
+    ///
+    /// It treats `command_raw` specially as this can change in responses.
+    ///
+    /// Please do not use outside the replay tests.
+    #[doc(hidden)]
+    #[allow(unused)]
+    pub fn test_only_hacked_equal(&self, other: &Self) -> bool {
+        self.command_code == other.command_code
+            && self.index == other.index
+            && if matches!(self.command_code, 4 | 5) {
+                self.command_raw == other.command_raw
+            } else {
+                true
+            }
+            // && self.flags == other.flags
+            && self.irq == other.irq
+    }
+
+    /// Similar to [`test_only_hacked_equal`].
+    ///
+    /// Please do not use outside replay tests.
+    #[doc(hidden)]
+    #[allow(unused)]
+    pub fn test_only_hacked_hash(&self, state: &mut impl core::hash::Hasher) {
+        use core::hash::Hash;
+
+        let PduHeader {
+            command_code,
+            index,
+            command_raw,
+            flags: _,
+            irq,
+        } = *self;
+
+        command_code.hash(state);
+        index.hash(state);
+
+        if matches!(command_code, 4 | 5) {
+            command_raw.hash(state);
+        }
+
+        // flags.hash(state);
+        irq.hash(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::hash::{Hash, Hasher};
+    use std::collections::{hash_map::DefaultHasher, HashMap};
+
+    // These shouldn't be derived for general use, just for testing
+    impl Eq for PduHeader {}
+    impl PartialEq for PduHeader {
+        fn eq(&self, other: &Self) -> bool {
+            self.test_only_hacked_equal(&other)
+        }
+    }
+    impl Hash for PduHeader {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.test_only_hacked_hash(state);
+        }
+    }
+
+    #[test]
+    fn decode() {
+        // FPRD reg 0x900, 16 bytes
+        let packet_bytes = [
+            0x04, 0x12, 0x00, 0x10, 0x00, 0x09, 0x10, 0x00, 0x00, 0x00, 0x0a, 0xc9, 0x83, 0xcc,
+            0x9c, 0xcd, 0x83, 0xcc, 0x00, 0x00, 0x00, 0x00, 0x56, 0x65, 0x72, 0x6c, 0x01, 0x00,
+        ];
+
+        let header = PduHeader::unpack_from_slice(&packet_bytes);
+
+        assert_eq!(
+            header,
+            Ok(PduHeader {
+                command_code: 0x04,
+                index: 0x12,
+                command_raw: [0x00, 0x10, 0x00, 0x09],
+                flags: PduFlags {
+                    length: 16,
+                    circulated: false,
+                    is_not_last: false
+                },
+                irq: 0
+            })
+        );
+
+        let header = header.unwrap();
+
+        let (data, wkc) = header.data_wkc(&packet_bytes).expect("Data/wkc");
+
+        assert_eq!(
+            data,
+            &[
+                0x0a, 0xc9, 0x83, 0xcc, 0x9c, 0xcd, 0x83, 0xcc, 0x00, 0x00, 0x00, 0x00, 0x56, 0x65,
+                0x72, 0x6c
+            ]
+        );
+        assert_eq!(wkc, 1);
+    }
+
+    // Just a sanity check...
+    #[test]
+    fn preamble_eq() {
+        let a = PduHeader {
+            command_code: 2,
+            index: 0,
+            command_raw: [0, 0, 0, 0],
+            flags: PduFlags {
+                length: 1,
+                circulated: false,
+                is_not_last: false,
+            },
+            irq: 0,
+        };
+
+        let b = PduHeader {
+            command_code: 2,
+            index: 0,
+            command_raw: [0, 0, 0, 0],
+            flags: PduFlags {
+                length: 1,
+                circulated: false,
+                is_not_last: false,
+            },
+            irq: 0,
+        };
+
+        assert_eq!(a, b);
+
+        let mut state = DefaultHasher::new();
+
+        assert_eq!(a.hash(&mut state), b.hash(&mut state));
+    }
+
+    #[test]
+    fn preamble_brd_eq() {
+        let a = PduHeader {
+            command_code: 7,
+            index: 0,
+            command_raw: [0, 0, 0, 0],
+            flags: PduFlags {
+                length: 1,
+                circulated: false,
+                is_not_last: false,
+            },
+            irq: 0,
+        };
+
+        let b = PduHeader {
+            command_code: 7,
+            index: 0,
+            command_raw: [1, 0, 0, 0],
+            flags: PduFlags {
+                length: 1,
+                circulated: false,
+                is_not_last: false,
+            },
+            irq: 0,
+        };
+
+        // Different `command_raw` but `command_code` is BRD so the equality should still hold.
+        assert_eq!(a, b);
+
+        let mut state_a = DefaultHasher::new();
+        let mut state_b = DefaultHasher::new();
+
+        a.hash(&mut state_a);
+        b.hash(&mut state_b);
+
+        // Hashes remain equal because we look up by sent preamble, not the potentially modified
+        // receive.
+        assert_eq!(state_a.finish(), state_b.finish());
+    }
+
+    #[test]
+    fn find_brd() {
+        let mut map = HashMap::new();
+
+        map.insert(
+            PduHeader {
+                command_code: 7,
+                index: 0,
+                command_raw: [3, 0, 0, 0],
+                flags: PduFlags {
+                    length: 1,
+                    circulated: false,
+                    is_not_last: false,
+                },
+                irq: 0,
+            },
+            1234usize,
+        );
+
+        assert_eq!(
+            map.get(&PduHeader {
+                command_code: 7,
+                index: 0,
+                command_raw: [0, 0, 0, 0],
+                flags: PduFlags {
+                    length: 1,
+                    circulated: false,
+                    is_not_last: false,
+                },
+                irq: 0,
+            }),
+            Some(&1234usize)
+        );
+    }
+
+    #[test]
+    fn find_bwr() {
+        let mut map = HashMap::new();
+
+        map.insert(
+            PduHeader {
+                command_code: 8,
+                index: 1,
+                command_raw: [3, 0, 32, 1],
+                flags: PduFlags {
+                    length: 2,
+                    circulated: false,
+                    is_not_last: false,
+                },
+                irq: 0,
+            },
+            1234usize,
+        );
+
+        assert_eq!(
+            map.get(&PduHeader {
+                command_code: 8,
+                index: 1,
+                command_raw: [0, 0, 32, 1],
+                flags: PduFlags {
+                    length: 2,
+                    circulated: false,
+                    is_not_last: false,
+                },
+                irq: 0,
+            }),
+            Some(&1234usize)
+        );
+    }
+}

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -1,9 +1,8 @@
 use super::storage::PduStorageRef;
 use crate::{
-    command::Command,
     error::{Error, PduError, PduValidationError},
     fmt,
-    pdu_loop::{frame_header::FrameHeader, pdu_flags::PduFlags},
+    pdu_loop::{frame_header::FrameHeader, pdu_header::PduHeader},
     ETHERCAT_ETHERTYPE, MASTER_ADDR,
 };
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
@@ -52,23 +51,39 @@ impl<'sto> PduRx<'sto> {
 
         let i = raw_packet.payload();
 
-        let header = FramePreamble::unpack_from_slice(i).map_err(|e| {
+        let frame_header = FrameHeader::unpack_from_slice(i).map_err(|e| {
             fmt::error!("Failed to parse frame header: {}", e);
 
             e
         })?;
 
-        let (data, working_counter) = header.data_wkc(i).map_err(|e| {
+        let i = i
+            // Strip EtherCAT frame header...
+            .get(FrameHeader::PACKED_LEN..)
+            // ...then take as much as we're supposed to
+            .and_then(|i| i.get(0..usize::from(frame_header.payload_len)))
+            .ok_or_else(|| {
+                fmt::error!("Received frame is too short");
+
+                Error::ReceiveFrame
+            })?;
+
+        // `i` now contains a complete PDU including header
+
+        // Only support a single PDU per frame for now
+        let pdu_header = PduHeader::unpack_from_slice(i)?;
+
+        let (data, working_counter) = pdu_header.data_wkc(i).map_err(|e| {
             fmt::error!("Could not get frame data/wkc: {}", e);
 
             e
         })?;
 
-        let command = header.command()?;
+        let command = pdu_header.command()?;
 
-        let FramePreamble {
+        let PduHeader {
             index, flags, irq, ..
-        } = header;
+        } = pdu_header;
 
         fmt::trace!(
             "Received frame with index {} ({:#04x}), WKC {}",
@@ -109,295 +124,5 @@ impl<'sto> PduRx<'sto> {
         frame.mark_received(flags, irq, working_counter)?;
 
         Ok(())
-    }
-}
-
-/// PDU frame header, command, index, flags and IRQ.
-#[derive(Debug, Copy, Clone, ethercrab_wire::EtherCrabWireRead)]
-#[wire(bytes = 12)]
-pub struct FramePreamble {
-    #[wire(bytes = 2)]
-    header: FrameHeader,
-
-    // NOTE: The following fields are included in the header length field value.
-    #[wire(bytes = 1)]
-    command_code: u8,
-    #[wire(bytes = 1)]
-    index: u8,
-    #[wire(bytes = 4)]
-    command_raw: [u8; 4],
-    #[wire(bytes = 2)]
-    flags: PduFlags,
-    #[wire(bytes = 2)]
-    irq: u16,
-}
-
-impl FramePreamble {
-    fn data_wkc<'buf>(&self, buf: &'buf [u8]) -> Result<(&'buf [u8], u16), Error> {
-        // Jump past header in the buffer
-        let header_offset = FramePreamble::PACKED_LEN;
-
-        // The length of the PDU data body. There are two bytes after this that hold the working
-        // counter, but are not counted as part of the PDU length from the header.
-        let data_end = usize::from(self.header.payload_len);
-
-        let data = buf.get(header_offset..data_end).ok_or(PduError::Decode)?;
-        let wkc = buf
-            .get(data_end..)
-            .ok_or(Error::Pdu(PduError::Decode))
-            .and_then(|raw| Ok(u16::unpack_from_slice(raw)?))?;
-
-        Ok((data, wkc))
-    }
-
-    fn command(&self) -> Result<Command, Error> {
-        Command::parse_code_data(self.command_code, self.command_raw)
-    }
-
-    /// A hacked equality check used for replay tests only.
-    ///
-    /// It treats `command_raw` specially as this can change in responses.
-    ///
-    /// Please do not use outside the replay tests.
-    #[doc(hidden)]
-    #[allow(unused)]
-    pub fn test_only_hacked_equal(&self, other: &Self) -> bool {
-        self.command_code == other.command_code
-            && self.index == other.index
-            && if matches!(self.command_code, 4 | 5) {
-                self.command_raw == other.command_raw &&
-                self.header == other.header
-            } else {
-                true
-            }
-            // && self.flags == other.flags
-            && self.irq == other.irq
-    }
-
-    /// Similar to [`test_only_hacked_equal`].
-    ///
-    /// Please do not use outside replay tests.
-    #[doc(hidden)]
-    #[allow(unused)]
-    pub fn test_only_hacked_hash(&self, state: &mut impl core::hash::Hasher) {
-        use core::hash::Hash;
-
-        let FramePreamble {
-            header,
-            command_code,
-            index,
-            command_raw,
-            flags: _,
-            irq,
-        } = *self;
-
-        // header.hash(state);
-        command_code.hash(state);
-        index.hash(state);
-
-        if matches!(command_code, 4 | 5) {
-            header.payload_len.hash(state);
-            command_raw.hash(state);
-        }
-
-        // flags.hash(state);
-        irq.hash(state);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::pdu_loop::frame_header::ProtocolType::DlPdu;
-    use core::hash::{Hash, Hasher};
-    use std::collections::{hash_map::DefaultHasher, HashMap};
-
-    // These shouldn't be derived for general use, just for testing
-    impl Eq for FramePreamble {}
-    impl PartialEq for FramePreamble {
-        fn eq(&self, other: &Self) -> bool {
-            self.test_only_hacked_equal(&other)
-        }
-    }
-    impl Hash for FramePreamble {
-        fn hash<H: Hasher>(&self, state: &mut H) {
-            self.test_only_hacked_hash(state);
-        }
-    }
-
-    // Just a sanity check...
-    #[test]
-    fn preamble_eq() {
-        let a = FramePreamble {
-            header: FrameHeader {
-                payload_len: 13,
-                protocol: DlPdu,
-            },
-            command_code: 2,
-            index: 0,
-            command_raw: [0, 0, 0, 0],
-            flags: PduFlags {
-                length: 1,
-                circulated: false,
-                is_not_last: false,
-            },
-            irq: 0,
-        };
-
-        let b = FramePreamble {
-            header: FrameHeader {
-                payload_len: 13,
-                protocol: DlPdu,
-            },
-            command_code: 2,
-            index: 0,
-            command_raw: [0, 0, 0, 0],
-            flags: PduFlags {
-                length: 1,
-                circulated: false,
-                is_not_last: false,
-            },
-            irq: 0,
-        };
-
-        assert_eq!(a, b);
-
-        let mut state = DefaultHasher::new();
-
-        assert_eq!(a.hash(&mut state), b.hash(&mut state));
-    }
-
-    #[test]
-    fn preamble_brd_eq() {
-        let a = FramePreamble {
-            header: FrameHeader {
-                payload_len: 13,
-                protocol: DlPdu,
-            },
-            command_code: 7,
-            index: 0,
-            command_raw: [0, 0, 0, 0],
-            flags: PduFlags {
-                length: 1,
-                circulated: false,
-                is_not_last: false,
-            },
-            irq: 0,
-        };
-
-        let b = FramePreamble {
-            header: FrameHeader {
-                payload_len: 13,
-                protocol: DlPdu,
-            },
-            command_code: 7,
-            index: 0,
-            command_raw: [1, 0, 0, 0],
-            flags: PduFlags {
-                length: 1,
-                circulated: false,
-                is_not_last: false,
-            },
-            irq: 0,
-        };
-
-        // Different `command_raw` but `command_code` is BRD so the equality should still hold.
-        assert_eq!(a, b);
-
-        let mut state_a = DefaultHasher::new();
-        let mut state_b = DefaultHasher::new();
-
-        a.hash(&mut state_a);
-        b.hash(&mut state_b);
-
-        // Hashes remain equal because we look up by sent preamble, not the potentially modified
-        // receive.
-        assert_eq!(state_a.finish(), state_b.finish());
-    }
-
-    #[test]
-    fn find_brd() {
-        let mut map = HashMap::new();
-
-        map.insert(
-            FramePreamble {
-                header: FrameHeader {
-                    payload_len: 13,
-                    protocol: DlPdu,
-                },
-                command_code: 7,
-                index: 0,
-                command_raw: [3, 0, 0, 0],
-                flags: PduFlags {
-                    length: 1,
-                    circulated: false,
-                    is_not_last: false,
-                },
-                irq: 0,
-            },
-            1234usize,
-        );
-
-        assert_eq!(
-            map.get(&FramePreamble {
-                header: FrameHeader {
-                    payload_len: 13,
-                    protocol: DlPdu,
-                },
-                command_code: 7,
-                index: 0,
-                command_raw: [0, 0, 0, 0],
-                flags: PduFlags {
-                    length: 1,
-                    circulated: false,
-                    is_not_last: false,
-                },
-                irq: 0,
-            }),
-            Some(&1234usize)
-        );
-    }
-
-    #[test]
-    fn find_bwr() {
-        let mut map = HashMap::new();
-
-        map.insert(
-            FramePreamble {
-                header: FrameHeader {
-                    payload_len: 14,
-                    protocol: DlPdu,
-                },
-                command_code: 8,
-                index: 1,
-                command_raw: [3, 0, 32, 1],
-                flags: PduFlags {
-                    length: 2,
-                    circulated: false,
-                    is_not_last: false,
-                },
-                irq: 0,
-            },
-            1234usize,
-        );
-
-        assert_eq!(
-            map.get(&FramePreamble {
-                header: FrameHeader {
-                    payload_len: 14,
-                    protocol: DlPdu,
-                },
-                command_code: 8,
-                index: 1,
-                command_raw: [0, 0, 32, 1],
-                flags: PduFlags {
-                    length: 2,
-                    circulated: false,
-                    is_not_last: false,
-                },
-                irq: 0,
-            }),
-            Some(&1234usize)
-        );
     }
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,6 +1,11 @@
 //! Utilities to replay Wireshark captures as part of regression/integration tests.
 
-use ethercrab::{error::Error, internals::FramePreamble, std::tx_rx_task, PduRx, PduTx};
+use ethercrab::{
+    error::Error,
+    internals::{FrameHeader, PduHeader},
+    std::tx_rx_task,
+    PduRx, PduTx,
+};
 use ethercrab_wire::EtherCrabWireRead;
 use pcap_file::pcapng::{Block, PcapNgReader};
 use smoltcp::wire::{EthernetAddress, EthernetFrame};
@@ -12,6 +17,17 @@ use std::{
     pin::Pin,
     task::Poll,
 };
+
+/// PDU frame header, command, index, flags and IRQ.
+#[derive(Debug, Copy, Clone, ethercrab_wire::EtherCrabWireRead)]
+#[wire(bytes = 12)]
+pub struct FramePreamble {
+    #[wire(bytes = 2)]
+    header: FrameHeader,
+
+    #[wire(bytes = 10)]
+    pdu_header: PduHeader,
+}
 
 pub fn spawn_tx_rx(capture_file_path: &str, tx: PduTx<'static>, rx: PduRx<'static>) {
     let interface = std::env::var("INTERFACE");
@@ -40,13 +56,17 @@ impl Eq for PreambleHash {}
 
 impl PartialEq for PreambleHash {
     fn eq(&self, other: &Self) -> bool {
-        self.0.test_only_hacked_equal(&other.0)
+        self.0
+            .pdu_header
+            .test_only_hacked_equal(&other.0.pdu_header)
+            && self.0.header == other.0.header
     }
 }
 
 impl core::hash::Hash for PreambleHash {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.test_only_hacked_hash(state);
+        self.0.pdu_header.test_only_hacked_hash(state);
+        self.0.header.hash(state);
     }
 }
 

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -18,7 +18,9 @@ use std::{
     task::Poll,
 };
 
-/// PDU frame header, command, index, flags and IRQ.
+/// Combined EtherCAT and PDU headers.
+///
+/// Only supports a PDU per EtherCAT frame.
 #[derive(Debug, Copy, Clone, ethercrab_wire::EtherCrabWireRead)]
 #[wire(bytes = 12)]
 pub struct FramePreamble {


### PR DESCRIPTION
This is some precursory work to support multiple PDUs per Ethernet frame.

The EtherCAT header is now split from the PDU frame header, more easily allowing for multiple PDU frames in the future.