### PR TITLE
Use hex format for all frame logging

### DIFF
--- a/src/command/reads.rs
+++ b/src/command/reads.rs
@@ -101,7 +101,7 @@ impl<'client> WrappedRead<'client> {
             match frame.timeout(self.client.timeouts.pdu).await {
                 Ok(result) => return Ok(result.into_data()),
                 Err(Error::Timeout) => {
-                    fmt::error!("Frame {} timed out", frame_idx);
+                    fmt::error!("Frame {:#04x} timed out", frame_idx);
 
                     // NOTE: The `Drop` impl of `ReceiveFrameFut` frees the frame by setting its
                     // state to `None`, ready for reuse.

--- a/src/command/writes.rs
+++ b/src/command/writes.rs
@@ -146,7 +146,7 @@ impl<'client> WrappedWrite<'client> {
             match frame.timeout(self.client.timeouts.pdu).await {
                 Ok(result) => return Ok(result.into_data()),
                 Err(Error::Timeout) => {
-                    fmt::error!("Frame {} timed out", frame_idx);
+                    fmt::error!("Frame {:#04x} timed out", frame_idx);
 
                     // NOTE: The `Drop` impl of `ReceiveFrameFut` frees the frame by setting its
                     // state to `None`, ready for reuse.

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -161,7 +161,7 @@ impl<const N: usize> FrameElement<N> {
         Self::swap_state(this, FrameState::Sent, FrameState::RxBusy)
             .map_err(|actual_state| {
                 fmt::error!(
-                    "Failed to claim receiving frame #{}: expected state {:?}, but got {:?}",
+                    "Failed to claim receiving frame {:#04x}: expected state {:?}, but got {:?}",
                     (*addr_of_mut!((*this.as_ptr()).frame.index)),
                     FrameState::Sent,
                     actual_state

--- a/src/pdu_loop/frame_element/received_frame.rs
+++ b/src/pdu_loop/frame_element/received_frame.rs
@@ -61,7 +61,7 @@ impl<'sto> ReceivedFrame<'sto> {
 
 impl<'sto> Drop for ReceivedFrame<'sto> {
     fn drop(&mut self) {
-        fmt::trace!("Drop frame element idx {}", self.frame().index);
+        fmt::trace!("Drop frame {:#04x}", self.frame().index);
 
         unsafe {
             // Invariant: the frame can only be in `RxProcessing` at this point, so if this swap

--- a/src/pdu_loop/frame_element/receiving_frame.rs
+++ b/src/pdu_loop/frame_element/receiving_frame.rs
@@ -46,7 +46,7 @@ impl<'sto> ReceivingFrame<'sto> {
                 .map(|_| {})
                 .map_err(|bad| {
                     fmt::error!(
-                        "Failed to set frame #{} state from RxBusy -> RxDone, got {:?}",
+                        "Failed to set frame {:#04x} state from RxBusy -> RxDone, got {:?}",
                         self.index(),
                         bad
                     );
@@ -58,7 +58,7 @@ impl<'sto> ReceivingFrame<'sto> {
         // If the wake fails, release the receiving claim so the frame receive can possibly be
         // reattempted at a later time.
         if let Err(()) = unsafe { self.inner.wake() } {
-            fmt::trace!("Failed to wake frame #{}: no waker", self.index());
+            fmt::trace!("Failed to wake frame {:#04x}: no waker", self.index());
 
             unsafe {
                 // Restore frame state to `Sent`, which is what `PduStorageRef::claim_receiving`
@@ -88,7 +88,7 @@ impl<'sto> ReceivingFrame<'sto> {
                     }
                     Err(bad_state) => {
                         fmt::error!(
-                            "Failed to set frame #{} state from RxDone -> Sent, got {:?}",
+                            "Failed to set frame {:#04x} state from RxDone -> Sent, got {:?}",
                             self.index(),
                             bad_state
                         );
@@ -167,14 +167,14 @@ impl<'sto> Future for ReceiveFrameFut<'sto> {
 
         let was = match swappy {
             Ok(_frame_element) => {
-                fmt::trace!("Frame #{} is ready", idx);
+                fmt::trace!("frame {:#04x} is ready", idx);
 
                 return Poll::Ready(Ok(ReceivedFrame { inner: rxin }));
             }
             Err(e) => e,
         };
 
-        fmt::trace!("Frame #{} not ready yet ({:?})", idx, was);
+        fmt::trace!("frame {:#04x} not ready yet ({:?})", idx, was);
 
         match was {
             FrameState::Sendable | FrameState::Sending | FrameState::Sent | FrameState::RxBusy => {

--- a/src/pdu_loop/frame_element/sendable_frame.rs
+++ b/src/pdu_loop/frame_element/sendable_frame.rs
@@ -64,7 +64,7 @@ impl<'sto> SendableFrame<'sto> {
 
     /// The frame has been sent by the network driver.
     pub(crate) fn mark_sent(self) {
-        fmt::trace!("Frame #{} is sent", unsafe { self.inner.frame() }.index);
+        fmt::trace!("frame {:#04x} is sent", unsafe { self.inner.frame() }.index);
 
         unsafe {
             FrameElement::set_state(self.inner.frame, FrameState::Sent);

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -85,12 +85,7 @@ impl<'sto> PduRx<'sto> {
             index, flags, irq, ..
         } = pdu_header;
 
-        fmt::trace!(
-            "Received frame with index {} ({:#04x}), WKC {}",
-            index,
-            index,
-            working_counter,
-        );
+        fmt::trace!("Received frame {:#04x}, WKC {}", index, working_counter,);
 
         let mut frame = self
             .storage

--- a/src/pdu_loop/storage.rs
+++ b/src/pdu_loop/storage.rs
@@ -133,7 +133,7 @@ impl<'sto> PduStorageRef<'sto> {
 
             let idx = usize::from(idx_u8);
 
-            fmt::trace!("Try to allocate frame #{}", idx);
+            fmt::trace!("Try to allocate frame {:#04x}", idx);
 
             // Claim frame so it is no longer free and can be used. It must be claimed before
             // initialisation to avoid race conditions with other threads potentially claiming the
@@ -194,7 +194,7 @@ impl<'sto> PduStorageRef<'sto> {
             return None;
         }
 
-        fmt::trace!("--> Claim receiving #{}", idx);
+        fmt::trace!("--> Claim receiving {:#04x}", idx);
 
         let frame = unsafe { NonNull::new_unchecked(self.frame_at_index(idx)) };
         let frame = unsafe { FrameElement::claim_receiving(frame)? };

--- a/src/slave/configuration.rs
+++ b/src/slave/configuration.rs
@@ -357,7 +357,12 @@ where
                     .sdo_read_expedited::<u8>(pdo, SubIndex::Index(0))
                     .await?;
 
-                fmt::trace!("--> #{} data: {:#06x} ({} mappings):", i, pdo, num_mappings);
+                fmt::trace!(
+                    "--> {:#04x} data: {:#06x} ({} mappings):",
+                    i,
+                    pdo,
+                    num_mappings
+                );
 
                 for i in 1..=num_mappings {
                     /// Defined in ETG1000.6 Table 74/Table 75 Receive PDO Mapping.

--- a/src/std/io_uring.rs
+++ b/src/std/io_uring.rs
@@ -138,7 +138,7 @@ pub fn tx_rx_task_io_uring<'sto>(
             .user_data(rx_key as u64);
 
             fmt::trace!(
-                "Insert frame TX #{}, key {}, RX key {}",
+                "Insert frame TX {:#04x}, key {}, RX key {}",
                 idx,
                 tx_key,
                 rx_key
@@ -221,7 +221,7 @@ pub fn tx_rx_task_io_uring<'sto>(
                 let frame_index = frame[0x11];
 
                 fmt::trace!(
-                    "Raw frame #{} result {} buffer key {}",
+                    "Raw frame {:#04x} result {} buffer key {}",
                     frame_index,
                     recv.result(),
                     key,
@@ -232,7 +232,7 @@ pub fn tx_rx_task_io_uring<'sto>(
                         Ok(_) => break,
                         Err(Error::Pdu(PduError::NoWaker)) => {
                             fmt::trace!(
-                                "No waker for received frame #{}, retrying receive",
+                                "No waker for received frame {:#04x}, retrying receive",
                                 frame_index
                             );
 

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -182,7 +182,10 @@ pub fn dummy_tx_rx_task(
                 (f, preamble)
             }
             Block::InterfaceDescription(_) | Block::InterfaceStatistics(_) => continue,
-            other => panic!("Frame {} is not correct type: {:?}", packet_number, other),
+            other => panic!(
+                "Frame {:#04x} is not correct type: {:?}",
+                packet_number, other
+            ),
         };
 
         if raw.src_addr() == MASTER_ADDR {
@@ -197,7 +200,7 @@ pub fn dummy_tx_rx_task(
                 .push_back((raw, packet_number));
         } else {
             panic!(
-                "Frame {} does not have EtherCAT address (has {:?} instead)",
+                "Frame {:#04x} does not have EtherCAT address (has {:?} instead)",
                 packet_number,
                 raw.src_addr()
             );


### PR DESCRIPTION
Just a lil PR to make it easier to match up against Wireshark/`tshark` logs and improve consistency in the codebase/log output.