### PR TITLE
Remove `embassy-futures` and last uses of it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ atomic_enum = "0.3.0"
 atomic_refcell = "0.1.13"
 bitflags = "2.4.1"
 defmt = { version = "0.3.5", optional = true }
-embassy-futures = "0.1.0"
 embassy-time = "0.3.0"
 embedded-io-async = { version = "0.6.0", default-features = false }
 futures-lite = { version = "2.0.0", default-features = false }

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -528,7 +528,7 @@ mod tests {
                 }
             };
 
-            embassy_futures::select::select(tx_task, rx_task).await;
+            futures_lite::future::race(tx_task, rx_task).await;
         };
 
         tokio::spawn(tx_rx_task);

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -749,12 +749,7 @@ impl<'a, S> SlaveRef<'a, S> {
             .read(RegisterAddress::AlStatusCode)
             .receive::<AlStatusCode>(self.client);
 
-        let (status, code) = embassy_futures::join::join(self.state(), code).await;
-
-        let status = status?;
-        let code = code?;
-
-        Ok((status, code))
+        futures_lite::future::try_zip(self.state(), code).await
     }
 
     fn eeprom(&self) -> SlaveEeprom<DeviceEeprom> {


### PR DESCRIPTION
`futures_lite` does the same thing and is also used by `smol`, so this shortens the dependency tree just a tiny bit