### PR TITLE
Add some more DC sync experiment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,10 @@ tokio = { version = "1.33.0", features = [
 thread-priority = "0.16.0"
 ta = "0.5.0"
 cassette = "0.2.5"
+pid = "4.0.0"
+csv = "1.3.0"
+serde = { version = "1.0.190", default-features = false, features = ["derive"] }
+signal-hook = "0.3.17"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 core_affinity = "0.8.1"

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,21 @@
+# Plotting DC/OS time sync
+
+```gnuplot
+set datafile separator ','
+# set xdata time # tells gnuplot the x axis is time data
+# set ylabel "First Y " # label for the Y axis
+set autoscale fix
+set key top right outside autotitle columnhead
+set xlabel 'OS time (ns)' # label for the X axis
+
+set y2tics # enable second axis
+set ytics nomirror # dont show the tics on that side
+set y2label "OS/ECAT delta" # label for second axis
+
+# plot './dc-pi.csv' using 1:3 title "Difference" with lines, '' using 1:4 title "Offset" with lines, '' using 1:5 title "PI out" with lines
+plot './dc-pi.csv' using 1:4 title "Offset" with lines, '' using 1:3 title "OS/ECAT delta" with lines axis x1y2
+```
+
 # Optimising PDU reservation
 
 Problem


### PR DESCRIPTION
Also improves reliability of `smol`-based TX/RX task by spinning if a received frame's future isn't registered yet.

The added code tries to establish a reasonably close synchronisation between the OS and EtherCat system clock using a PI loop.

This isn't hugely useful because we need to figure out when a cycle starts, not what the current system time is, but I'll add it anyway because it might be useful down the line. If for nothing more than the PI loop boilerplate.