### PR TITLE
Correctly configure first SYNC0 pulse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Cargo.lock
 /examples/*.pcapng
 /npcap-sdk-*
 .vscode/
+# Debug output from examples
+*.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ An EtherCAT master written in Rust.
   (0x0980).
 - [#193](https://github.com/ethercrab-rs/ethercrab/pull/#193) Add
   `SlaveGroup::<PreOp>::request_into_op` to request all SubDevices in a group transition to OP, but
-  does not wait for them to transition. Also add `SlaveGroup::<Op>::is_op` to check if all
+  does not wait for them to transition. Also add `SlaveGroup::<Op>::all_op` to check if all
   SubDevices in the group have reached OP state.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ An EtherCAT master written in Rust.
 
 - [#195](https://github.com/ethercrab-rs/ethercrab/pull/#195) Add `Register::DcCyclicUnitControl`
   (0x0980).
+- [#193](https://github.com/ethercrab-rs/ethercrab/pull/#193) Add
+  `SlaveGroup::<PreOp>::request_into_op` to request all SubDevices in a group transition to OP, but
+  does not wait for them to transition. Also add `SlaveGroup::<Op>::is_op` to check if all
+  SubDevices in the group have reached OP state.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,7 @@ nix = { version = "0.28.0", features = ["net"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.149"
-rustix = { version = "0.38.21", default-features = false, features = [
-    "time",
-    "thread",
-] }
+rustix = { version = "0.38.21", default-features = false, features = ["time"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.6.3", features = ["io_safety"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,10 @@ nix = { version = "0.28.0", features = ["net"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.149"
-rustix = { version = "0.38.21", default-features = false, features = ["time"] }
+rustix = { version = "0.38.21", default-features = false, features = [
+    "time",
+    "thread",
+] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.6.3", features = ["io_safety"] }

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -428,8 +428,22 @@ fn main() -> Result<(), Error> {
 
                 process_stats.flush().ok();
 
-                break Ok(());
+                break;
             }
         }
+
+        let group = group.into_safe_op(&client).await.expect("OP -> SAFE-OP");
+
+        log::info!("OP -> SAFE-OP");
+
+        let group = group.into_pre_op(&client).await.expect("SAFE-OP -> PRE-OP");
+
+        log::info!("SAFE-OP -> PRE-OP");
+
+        let _group = group.into_init(&client).await.expect("PRE-OP -> INIT");
+
+        log::info!("PRE-OP -> INIT, shutdown complete");
+
+        Ok(())
     })
 }

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -408,9 +408,6 @@ fn main() -> Result<(), Error> {
                 // Round first pulse time to a whole number of cycles
                 let t = (device_time + first_pulse_delay) / true_cycle_time * true_cycle_time;
 
-                // Add one more cycle plus user-configured cycle shift
-                let t = t + true_cycle_time + cycle_shift;
-
                 log::info!("Computed DC sync start time: {}", t);
 
                 match slave

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -411,10 +411,12 @@ fn main() -> Result<(), Error> {
 
                         let first_pulse_delay = Duration::from_millis(100).as_nanos() as u64;
 
-                        let t = (device_time + first_pulse_delay) / true_cycle_time
-                            * true_cycle_time
-                            + true_cycle_time
-                            + cycle_shift;
+                        // Round first pulse delay to a whole number of cycles
+                        let t =
+                            (device_time + first_pulse_delay) / true_cycle_time * true_cycle_time;
+
+                        // Add one more cycle plus user-configured cycle shift
+                        let t = t + true_cycle_time + cycle_shift;
 
                         log::info!("Computed DC sync start time: {}", t);
 

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -378,6 +378,15 @@ fn main() -> Result<(), Error> {
                     Err(e) => return Err(e),
                 };
 
+                // Write access to EtherCAT
+                match slave
+                    .register_write(RegisterAddress::DcCyclicUnitControl, 0u8)
+                    .await
+                {
+                    Ok(_) | Err(Error::WorkingCounter { .. }) => (),
+                    Err(e) => return Err(e),
+                };
+
                 let device_time = match slave
                     .register_read::<u64>(RegisterAddress::DcSystemTime)
                     .await

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -378,7 +378,7 @@ fn main() -> Result<(), Error> {
         // Send PDI and check group state until all SubDevices enter OP state. At this point, we can
         // exit this loop and enter the main process data loop that does not have the state check
         // overhead present here.
-        while !group.is_op(&client).await? {
+        while !group.all_op(&client).await? {
             let now = Instant::now();
 
             // Note this method is experimental and currently hidden from the crate docs.

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -112,8 +112,6 @@ fn main() -> Result<(), Error> {
 
         for slave in group.iter(&client) {
             if slave.name() == "LAN9252-EVB-HBI" {
-                // log::info!("Found LAN9252 in {:?} state", slave.status().await.ok());
-
                 // Sync mode 02 = SYNC0
                 slave
                     .sdo_write(0x1c32, 1, 2u16)

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -461,7 +461,7 @@ fn main() -> Result<(), Error> {
         struct PiStat {
             ecat_time: u64,
             cycle_start_offset: u64,
-            next_iter_wait: i64,
+            next_iter_wait: u64,
         }
 
         let mut pi_stats = csv::Writer::from_writer(File::create("dc-pi.csv").expect("Open CSV"));
@@ -483,8 +483,7 @@ fn main() -> Result<(), Error> {
                 // time is rounded to a whole number of `sync0_cycle_time`-length cycles.
                 let cycle_start_offset = dc_time % sync0_cycle_time;
 
-                let time_to_next_iter =
-                    (sync0_cycle_time + (cycle_shift - cycle_start_offset)) as i64;
+                let time_to_next_iter = sync0_cycle_time + (cycle_shift - cycle_start_offset);
 
                 let stat = PiStat {
                     ecat_time: dc_time,
@@ -510,7 +509,7 @@ fn main() -> Result<(), Error> {
 
                 // Duration::from_nanos(dbg!(sync0_cycle_time as i64 + offset as i64) as u64)
                 // (sync0_cycle_time as i64 + offset as i64) as u64
-                time_to_next_iter as u64
+                time_to_next_iter
             } else {
                 sync0_cycle_time
             };

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -148,23 +148,23 @@ fn main() -> Result<(), Error> {
     let cycle_shift = (TICK_INTERVAL / 2).as_nanos() as u64;
     // let cycle_shift = 0;
 
-    // smol::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task")).detach();
-    thread_priority::ThreadBuilder::default()
-        .name("tx-rx-thread")
-        // Might need to set `<user> hard rtprio 99` and `<user> soft rtprio 99` in `/etc/security/limits.conf`
-        // Check limits with `ulimit -Hr` or `ulimit -Sr`
-        .priority(ThreadPriority::Crossplatform(
-            ThreadPriorityValue::try_from(49u8).unwrap(),
-        ))
-        // NOTE: Requires a realtime kernel
-        .policy(ThreadSchedulePolicy::Realtime(
-            RealtimeThreadSchedulePolicy::Fifo,
-        ))
-        .spawn(move |_| {
-            // Blocking io_uring
-            tx_rx_task_io_uring(&interface, tx, rx).expect("TX/RX task");
-        })
-        .unwrap();
+    smol::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task")).detach();
+    // thread_priority::ThreadBuilder::default()
+    //     .name("tx-rx-thread")
+    //     // Might need to set `<user> hard rtprio 99` and `<user> soft rtprio 99` in `/etc/security/limits.conf`
+    //     // Check limits with `ulimit -Hr` or `ulimit -Sr`
+    //     .priority(ThreadPriority::Crossplatform(
+    //         ThreadPriorityValue::try_from(49u8).unwrap(),
+    //     ))
+    //     // NOTE: Requires a realtime kernel
+    //     .policy(ThreadSchedulePolicy::Realtime(
+    //         RealtimeThreadSchedulePolicy::Fifo,
+    //     ))
+    //     .spawn(move |_| {
+    //         // Blocking io_uring
+    //         tx_rx_task_io_uring(&interface, tx, rx).expect("TX/RX task");
+    //     })
+    //     .unwrap();
 
     // Wait for TX/RX loop to start
     thread::sleep(Duration::from_millis(200));

--- a/src/slave_group/mod.rs
+++ b/src/slave_group/mod.rs
@@ -314,8 +314,6 @@ impl<const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroup<MAX_SLAVES, MAX_P
         mut self,
         client: &Client<'_>,
     ) -> Result<SlaveGroup<MAX_SLAVES, MAX_PDI, Op>, Error> {
-        // We're done configuring FMMUs, etc, now we can request all slaves in this group go into
-        // SAFE-OP
         for slave in self
             .inner
             .get_mut()

--- a/src/slave_group/mod.rs
+++ b/src/slave_group/mod.rs
@@ -308,7 +308,7 @@ impl<const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroup<MAX_SLAVES, MAX_P
     /// This allows the application process data loop to be started, so as to e.g. not time out
     /// watchdogs, or provide valid data to prevent DC sync errors.
     ///
-    /// If the SubDevice status is not mapped to the PDI, use [`is_op`](SlaveGroup::is_op) to
+    /// If the SubDevice status is not mapped to the PDI, use [`all_op`](SlaveGroup::all_op) to
     /// check if the group has reached OP state.
     pub async fn request_into_op(
         mut self,
@@ -347,7 +347,7 @@ impl<const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroup<MAX_SLAVES, MAX_P
     }
 
     /// Returns true if all SubDevices in the group are in OP state
-    pub async fn is_op(&self, client: &Client<'_>) -> Result<bool, Error> {
+    pub async fn all_op(&self, client: &Client<'_>) -> Result<bool, Error> {
         self.is_state(client, SlaveState::Op).await
     }
 }

--- a/src/slave_group/mod.rs
+++ b/src/slave_group/mod.rs
@@ -308,7 +308,7 @@ impl<const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroup<MAX_SLAVES, MAX_P
     /// This allows the application process data loop to be started, so as to e.g. not time out
     /// watchdogs, or provide valid data to prevent DC sync errors.
     ///
-    /// If the SubDevice status is not mapped to the PDI, use [`all_op`](SlaveGroup::all_op) to
+    /// If the SubDevice status is not mapped to the PDI, use [`is_op`](SlaveGroup::is_op) to
     /// check if the group has reached OP state.
     pub async fn request_into_op(
         mut self,

--- a/src/slave_group/mod.rs
+++ b/src/slave_group/mod.rs
@@ -301,16 +301,6 @@ impl<const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroup<MAX_SLAVES, MAX_P
     ) -> Result<SlaveGroup<MAX_SLAVES, MAX_PDI, PreOp>, Error> {
         self.transition_to(client, SlaveState::PreOp).await
     }
-}
-
-impl<const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroup<MAX_SLAVES, MAX_PDI, Op> {
-    /// Transition all slave devices in the group from OP to SAFE-OP.
-    pub async fn into_safe_op(
-        self,
-        client: &Client<'_>,
-    ) -> Result<SlaveGroup<MAX_SLAVES, MAX_PDI, SafeOp>, Error> {
-        self.transition_to(client, SlaveState::SafeOp).await
-    }
 
     /// DELETEME
     pub async fn into_op_nowait(
@@ -339,6 +329,16 @@ impl<const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroup<MAX_SLAVES, MAX_P
             inner: UnsafeCell::new(self.inner.into_inner()),
             _state: PhantomData,
         })
+    }
+}
+
+impl<const MAX_SLAVES: usize, const MAX_PDI: usize> SlaveGroup<MAX_SLAVES, MAX_PDI, Op> {
+    /// Transition all slave devices in the group from OP to SAFE-OP.
+    pub async fn into_safe_op(
+        self,
+        client: &Client<'_>,
+    ) -> Result<SlaveGroup<MAX_SLAVES, MAX_PDI, SafeOp>, Error> {
+        self.transition_to(client, SlaveState::SafeOp).await
     }
 }
 


### PR DESCRIPTION
This PR updates the `dc` example to correctly start distributed clock SYNC0 cycles at a point in the future so that the MainDevice can sync to the DC System Time and maintain a constant offset.

The example uses an offset of 50% on a 5ms cycle time, i.e. the process data is sent 2.5ms after the SYNC0 pulse. This has been checked against a LAN9252 dev board, looking at the SYNC0 and IRQ pins on an oscilloscope.

MainDevice jitter is also compensated for by adding a variable delay to the next process data cycle. This produces very consistent MainDevice cycle ticks - we're down into microseconds of jitter on my test system.