### PR TITLE
Remove `SlaveGroupState` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,9 @@ An EtherCAT master written in Rust.
   instead.
 - **(breaking)** [#181](https://github.com/ethercrab-rs/ethercrab/pull/181) Remove async
   `SendableFrame::send`. Use `SendableFrame::send_blocking` instead.
+- [#197](https://github.com/ethercrab-rs/ethercrab/pull/197) Remove `SlaveGroupState` trait. It is
+  no longer required, but the same methods are available so migration should be as simple as just
+  removing the import.
 
 ## [0.3.7] - 2024-03-12
 

--- a/examples/akd.rs
+++ b/examples/akd.rs
@@ -4,7 +4,7 @@ use env_logger::Env;
 use ethercrab::{
     error::{Error, MailboxError},
     std::{ethercat_now, tx_rx_task},
-    Client, ClientConfig, PduStorage, SlaveGroupState, Timeouts,
+    Client, ClientConfig, PduStorage, Timeouts,
 };
 use std::{sync::Arc, time::Duration};
 use tokio::time::MissedTickBehavior;

--- a/examples/dump-eeprom.rs
+++ b/examples/dump-eeprom.rs
@@ -10,7 +10,7 @@ use ethercrab::{
     error::Error,
     internals::{ChunkReader, DeviceEeprom},
     std::{ethercat_now, tx_rx_task},
-    Client, ClientConfig, PduStorage, SlaveGroupState, Timeouts,
+    Client, ClientConfig, PduStorage, Timeouts,
 };
 
 /// Maximum number of slaves that can be stored. This must be a power of 2 greater than 1.

--- a/examples/ec400.rs
+++ b/examples/ec400.rs
@@ -12,7 +12,7 @@ use ethercrab::{
     ds402::{Ds402, Ds402Sm},
     error::Error,
     std::{ethercat_now, tx_rx_task},
-    Client, ClientConfig, PduStorage, SlaveGroupState, Timeouts,
+    Client, ClientConfig, PduStorage, Timeouts,
 };
 use std::{
     sync::{

--- a/examples/io-uring.rs
+++ b/examples/io-uring.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), ethercrab::error::Error> {
     use ethercrab::{
         error::Error,
         std::{ethercat_now, tx_rx_task_io_uring},
-        Client, ClientConfig, PduStorage, SlaveGroup, SlaveGroupState, Timeouts,
+        Client, ClientConfig, PduStorage, SlaveGroup, Timeouts,
     };
     use std::{
         sync::Arc,

--- a/examples/multiple-groups.rs
+++ b/examples/multiple-groups.rs
@@ -10,7 +10,7 @@ use env_logger::Env;
 use ethercrab::{
     error::Error,
     std::{ethercat_now, tx_rx_task},
-    Client, ClientConfig, PduStorage, SlaveGroup, SlaveGroupState, Timeouts,
+    Client, ClientConfig, PduStorage, SlaveGroup, Timeouts,
 };
 use std::{
     sync::Arc,

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), ethercrab::error::Error> {
     use ethercrab::{
         error::Error,
         std::{ethercat_now, tx_rx_task},
-        Client, ClientConfig, PduStorage, SlaveGroup, SlaveGroupState, Timeouts,
+        Client, ClientConfig, PduStorage, SlaveGroup, Timeouts,
     };
     use smol::LocalExecutor;
     use std::{

--- a/examples/smol-io-uring.rs
+++ b/examples/smol-io-uring.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), ethercrab::error::Error> {
     use ethercrab::{
         error::Error,
         std::{ethercat_now, tx_rx_task_io_uring},
-        Client, ClientConfig, PduStorage, SlaveGroup, SlaveGroupState, Timeouts,
+        Client, ClientConfig, PduStorage, SlaveGroup, Timeouts,
     };
     use futures_lite::StreamExt;
     use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ pub use ethercrab_wire::{
 pub use pdu_loop::{PduLoop, PduRx, PduStorage, PduTx, SendableFrame};
 pub use register::RegisterAddress;
 pub use slave::{Slave, SlaveIdentity, SlavePdi, SlaveRef};
-pub use slave_group::{GroupId, GroupSlaveIterator, SlaveGroup, SlaveGroupHandle, SlaveGroupState};
+pub use slave_group::{GroupId, GroupSlaveIterator, SlaveGroup, SlaveGroupHandle};
 pub use slave_state::SlaveState;
 pub use timer_factory::Timeouts;
 

--- a/src/slave_group/iterator.rs
+++ b/src/slave_group/iterator.rs
@@ -1,10 +1,12 @@
-use crate::{fmt, Client, SlaveGroupState, SlaveRef};
+use super::{HasPdi, PreOp};
+use crate::{fmt, Client, Slave, SlaveGroup, SlavePdi, SlaveRef};
+use atomic_refcell::AtomicRefMut;
 
 /// An iterator over all slaves in a group.
 ///
 /// Created by calling [`SlaveGroup::iter`](crate::slave_group::SlaveGroup::iter).
 pub struct GroupSlaveIterator<'group, 'client, const MAX_SLAVES: usize, const MAX_PDI: usize, S> {
-    group: &'group S,
+    group: &'group SlaveGroup<MAX_SLAVES, MAX_PDI, S>,
     idx: usize,
     client: &'client Client<'client>,
 }
@@ -12,7 +14,10 @@ pub struct GroupSlaveIterator<'group, 'client, const MAX_SLAVES: usize, const MA
 impl<'group, 'client, const MAX_SLAVES: usize, const MAX_PDI: usize, S>
     GroupSlaveIterator<'group, 'client, MAX_SLAVES, MAX_PDI, S>
 {
-    pub(in crate::slave_group) fn new(client: &'client Client<'client>, group: &'group S) -> Self {
+    pub(in crate::slave_group) fn new(
+        client: &'client Client<'client>,
+        group: &'group SlaveGroup<MAX_SLAVES, MAX_PDI, S>,
+    ) -> Self {
         Self {
             group,
             idx: 0,
@@ -21,20 +26,44 @@ impl<'group, 'client, const MAX_SLAVES: usize, const MAX_PDI: usize, S>
     }
 }
 
-impl<'group, 'client, const MAX_SLAVES: usize, const MAX_PDI: usize, S> Iterator
-    for GroupSlaveIterator<'group, 'client, MAX_SLAVES, MAX_PDI, S>
+impl<'group, 'client, const MAX_SLAVES: usize, const MAX_PDI: usize> Iterator
+    for GroupSlaveIterator<'group, 'client, MAX_SLAVES, MAX_PDI, PreOp>
 where
     'client: 'group,
-    S: SlaveGroupState,
 {
-    type Item = SlaveRef<'group, S::RefType<'group>>;
+    type Item = SlaveRef<'group, AtomicRefMut<'group, Slave>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.idx >= self.group.len() {
             return None;
         }
 
-        let slave = fmt::unwrap!( self.group.slave(self.client, self.idx).map_err(|e| {
+        let slave = fmt::unwrap!(self.group.slave(self.client, self.idx).map_err(|e| {
+            fmt::error!("Failed to get slave at index {} from group with {} slaves: {}. This is very wrong. Please open an issue.", self.idx, self.group.len(), e);
+
+            e
+        }));
+
+        self.idx += 1;
+
+        Some(slave)
+    }
+}
+
+impl<'group, 'client, const MAX_SLAVES: usize, const MAX_PDI: usize, S> Iterator
+    for GroupSlaveIterator<'group, 'client, MAX_SLAVES, MAX_PDI, S>
+where
+    'client: 'group,
+    S: HasPdi,
+{
+    type Item = SlaveRef<'group, SlavePdi<'group>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.group.len() {
+            return None;
+        }
+
+        let slave = fmt::unwrap!(self.group.slave(self.client, self.idx).map_err(|e| {
             fmt::error!("Failed to get slave at index {} from group with {} slaves: {}. This is very wrong. Please open an issue.", self.idx, self.group.len(), e);
 
             e

--- a/tests/replay-ek1100-el2828-el2889-no-reborrow.rs
+++ b/tests/replay-ek1100-el2828-el2889-no-reborrow.rs
@@ -10,8 +10,7 @@
 mod util;
 
 use ethercrab::{
-    error::Error, slave_group, Client, ClientConfig, PduStorage, SlaveGroup, SlaveGroupState,
-    Timeouts,
+    error::Error, slave_group, Client, ClientConfig, PduStorage, SlaveGroup, Timeouts,
 };
 use std::{path::PathBuf, time::Duration};
 use tokio::time::MissedTickBehavior;

--- a/tests/replay-ek1100-el2828-el2889.rs
+++ b/tests/replay-ek1100-el2828-el2889.rs
@@ -10,8 +10,7 @@ mod util;
 
 use env_logger::Env;
 use ethercrab::{
-    error::Error, slave_group, Client, ClientConfig, PduStorage, SlaveGroup, SlaveGroupState,
-    Timeouts,
+    error::Error, slave_group, Client, ClientConfig, PduStorage, SlaveGroup, Timeouts,
 };
 use std::{path::PathBuf, time::Duration};
 use tokio::time::MissedTickBehavior;

--- a/tests/replay-ek1914-el3004-mailbox.rs
+++ b/tests/replay-ek1914-el3004-mailbox.rs
@@ -6,7 +6,7 @@
 mod util;
 
 use env_logger::Env;
-use ethercrab::{error::Error, Client, ClientConfig, PduStorage, SlaveGroupState, Timeouts};
+use ethercrab::{error::Error, Client, ClientConfig, PduStorage, Timeouts};
 use std::path::PathBuf;
 
 const MAX_SLAVES: usize = 16;

--- a/tests/replay-ek1914-no-complete-access.rs
+++ b/tests/replay-ek1914-no-complete-access.rs
@@ -6,9 +6,7 @@
 
 mod util;
 
-use ethercrab::{
-    error::Error, Client, ClientConfig, PduStorage, RetryBehaviour, SlaveGroupState, Timeouts,
-};
+use ethercrab::{error::Error, Client, ClientConfig, PduStorage, RetryBehaviour, Timeouts};
 use std::{path::PathBuf, time::Duration};
 
 const MAX_SLAVES: usize = 16;

--- a/tests/replay-ek1914-segmented-upload.rs
+++ b/tests/replay-ek1914-segmented-upload.rs
@@ -5,7 +5,7 @@
 mod util;
 
 use env_logger::Env;
-use ethercrab::{error::Error, Client, ClientConfig, PduStorage, SlaveGroupState, Timeouts};
+use ethercrab::{error::Error, Client, ClientConfig, PduStorage, Timeouts};
 use std::path::PathBuf;
 
 const MAX_SLAVES: usize = 16;


### PR DESCRIPTION
Turns out this trait isn't really necessary as long as we don't mind a little bit of "manual monomorphisation" for `GroupSlaveIterator`. No user visible changes. Simplified internals.