### PR TITLE
Handle frame timeout logic in response future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- [#TODO](https://github.com/ethercrab-rs/ethercrab/pull/TODO) PDU retries now use the same PDU
+  index instead of allocating a new frame for every resend.
+
 ## [0.4.2] - 2024-05-27
 
 ### Added
@@ -377,8 +382,8 @@ An EtherCAT master written in Rust.
 - Initial release
 
 <!-- next-url -->
-[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.4.2...HEAD
 
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.4.2...HEAD
 [0.4.2]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.4.1...ethercrab-v0.4.2
 [0.4.1]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.4.0...ethercrab-v0.4.1
 [0.4.0]: https://github.com/ethercrab-rs/ethercrab/compare/v0.3.6...ethercrab-v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ An EtherCAT master written in Rust.
 
 ### Changed
 
-- [#TODO](https://github.com/ethercrab-rs/ethercrab/pull/TODO) PDU retries now use the same PDU
-  index instead of allocating a new frame for every resend.
+- [#216](https://github.com/ethercrab-rs/ethercrab/pull/216) PDU retries now use the same PDU index
+  instead of allocating a new frame for every resend.
 
 ## [0.4.2] - 2024-05-27
 

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -40,19 +40,21 @@ pub enum RetryBehaviour {
     /// [`Error::Timeout`](crate::error::Error::Timeout).
     Count(usize),
 
-    /// Attempt to resend the PDU forever.
+    /// Attempt to resend the PDU forever(*).
     ///
     /// Note that this can soft-lock a program if for example the EtherCAT network cable is removed
     /// as EtherCrab will attempt to resend the packet forever. It may be preferable to use
     /// [`RetryBehaviour::Count`] to set an upper bound on retries.
+    ///
+    /// (*) Forever in this case means a retry count of `usize::MAX`.
     Forever,
 }
 
 impl RetryBehaviour {
-    pub(crate) fn loop_counts(&self) -> usize {
+    pub(crate) fn retry_count(&self) -> usize {
         match self {
             // Try at least once when used in a range like `for _ in 0..<counts>`.
-            RetryBehaviour::None => 1,
+            RetryBehaviour::None => 0,
             RetryBehaviour::Count(n) => *n,
             RetryBehaviour::Forever => usize::MAX,
         }
@@ -64,9 +66,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn loop_counts_sanity_check() {
-        assert_eq!(RetryBehaviour::None.loop_counts(), 1);
-        assert_eq!(RetryBehaviour::Count(10).loop_counts(), 10);
-        assert_eq!(RetryBehaviour::Forever.loop_counts(), usize::MAX);
+    fn retry_count_sanity_check() {
+        assert_eq!(RetryBehaviour::None.retry_count(), 0);
+        assert_eq!(RetryBehaviour::Count(10).retry_count(), 10);
+        assert_eq!(RetryBehaviour::Forever.retry_count(), usize::MAX);
     }
 }

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -91,10 +91,17 @@ impl PduMarker {
     }
 
     pub fn init(&self) {
-        assert!(self
-            .frame_index
-            .compare_exchange(0, PDU_UNUSED_SENTINEL, Ordering::Relaxed, Ordering::Relaxed)
-            .is_ok());
+        // NOTE: Making this `debug_assert_eq` causes the frame to never be initialised. Maybe the
+        // compare_exchange gets optimised out completely?
+        assert_eq!(
+            self.frame_index.compare_exchange(
+                0,
+                PDU_UNUSED_SENTINEL,
+                Ordering::Relaxed,
+                Ordering::Relaxed
+            ),
+            Ok(0)
+        );
     }
 
     /// Reset this marker to unused if it belongs to the given frame index.

--- a/src/timer_factory.rs
+++ b/src/timer_factory.rs
@@ -2,19 +2,19 @@ use crate::error::Error;
 use core::{future::Future, pin::Pin, task::Poll, time::Duration};
 
 #[cfg(not(feature = "std"))]
-type Timer = embassy_time::Timer;
+pub(crate) type Timer = embassy_time::Timer;
 #[cfg(feature = "std")]
-type Timer = async_io::Timer;
+pub(crate) type Timer = async_io::Timer;
 
 #[cfg(not(feature = "std"))]
-fn timer(duration: Duration) -> Timer {
+pub(crate) fn timer(duration: Duration) -> Timer {
     embassy_time::Timer::after(embassy_time::Duration::from_micros(
         duration.as_micros() as u64
     ))
 }
 
 #[cfg(feature = "std")]
-fn timer(duration: Duration) -> Timer {
+pub(crate) fn timer(duration: Duration) -> Timer {
     async_io::Timer::after(duration)
 }
 


### PR DESCRIPTION
As opposed to using a `for` loop. This change results in a slight reduction in binary size which was the goal of the PR.

Master:

```
   text    data     bss     dec     hex filename
  99472     112   57800  157384   266c8 ethercrab-stm32-embassy
```

This commit:

```
   text    data     bss     dec     hex filename
  99316     112   57800  157228   2662c ethercrab-stm32-embassy
```

As well as a ~10% improvement in throughput in the `pdu_loop` benchmark as a nice bonus.