### PR TITLE
Massively simplify frame/PDU code

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -490,11 +490,11 @@ impl<'sto> Client<'sto> {
         len_override: Option<u16>,
     ) -> Result<ReceivedPdu<'sto>, Error> {
         // Using a block to reduce future's stack size
-        let (frame, frame_idx) = {
+        let (frame, frame_idx, handle) = {
             let mut frame = self.pdu_loop.alloc_frame()?;
             let frame_idx = frame.frame_index();
 
-            frame.push_pdu(command, data, len_override, false)?;
+            let handle = frame.push_pdu(command, data, len_override, false)?;
 
             let frame = frame.mark_sendable(
                 &self.pdu_loop,
@@ -504,7 +504,7 @@ impl<'sto> Client<'sto> {
 
             self.pdu_loop.wake_sender();
 
-            (frame, frame_idx)
+            (frame, frame_idx, handle)
         };
 
         let received = match frame.await {
@@ -517,7 +517,7 @@ impl<'sto> Client<'sto> {
             Err(e) => return Err(e),
         };
 
-        received.first_pdu()
+        received.first_pdu(handle)
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,10 +3,10 @@ use crate::{
     al_status_code::AlStatusCode,
     command::Command,
     dc,
-    error::{Error, Item, PduError},
+    error::{Error, Item},
     fmt,
     pdi::PdiOffset,
-    pdu_loop::{CreatedFrame, PduLoop, ReceivedFrame, ReceivedPdu, SimpleReceivedPdu},
+    pdu_loop::{PduLoop, ReceivedPdu},
     register::RegisterAddress,
     slave::Slave,
     slave_group::{self, SlaveGroupHandle},
@@ -482,50 +482,13 @@ impl<'sto> Client<'sto> {
         self.pdu_loop.max_frame_data()
     }
 
-    /// Send one or more PDUs in a frame.
-    pub(crate) async fn multi_pdu<T, H>(
-        &self,
-        send: impl Fn(&mut CreatedFrame) -> Result<H, PduError>,
-        take: impl Fn(ReceivedFrame<'_>, H) -> Result<T, Error>,
-    ) -> Result<T, Error> {
-        // Using a block to reduce future's stack size
-        let (frame, frame_idx, handles) = {
-            let mut frame = self.pdu_loop.alloc_frame()?;
-            let frame_idx = frame.frame_index();
-
-            let handles = send(&mut frame)?;
-
-            let frame = frame.mark_sendable(
-                &self.pdu_loop,
-                self.timeouts.pdu,
-                self.config.retry_behaviour.retry_count(),
-            );
-
-            self.pdu_loop.wake_sender();
-
-            (frame, frame_idx, handles)
-        };
-
-        let received = match frame.await {
-            Ok(received) => received,
-            Err(Error::Timeout) => {
-                fmt::error!("Frame index {} timed out", frame_idx);
-
-                return Err(Error::Timeout);
-            }
-            Err(e) => return Err(e),
-        };
-
-        take(received, handles)
-    }
-
     /// Send a single PDU in a frame.
     pub(crate) async fn single_pdu(
         &'sto self,
         command: Command,
         data: impl EtherCrabWireWrite,
         len_override: Option<u16>,
-    ) -> Result<SimpleReceivedPdu<'sto>, Error> {
+    ) -> Result<ReceivedPdu<'sto>, Error> {
         // Using a block to reduce future's stack size
         let (frame, frame_idx) = {
             let mut frame = self.pdu_loop.alloc_frame()?;

--- a/src/command/reads.rs
+++ b/src/command/reads.rs
@@ -1,4 +1,8 @@
-use crate::{error::Error, pdu_loop::ReceivedPdu, Client};
+use crate::{
+    error::Error,
+    pdu_loop::{ReceivedPdu, SimpleReceivedPdu},
+    Client,
+};
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
 
 /// Read commands that send no data.
@@ -100,7 +104,7 @@ impl WrappedRead {
         self,
         client: &'client Client<'client>,
         len: u16,
-    ) -> Result<ReceivedPdu<'client, ()>, Error> {
+    ) -> Result<SimpleReceivedPdu<'client>, Error> {
         self.common(client, len).await?.maybe_wkc(self.wkc)
     }
 
@@ -124,14 +128,11 @@ impl WrappedRead {
     }
 
     // Some manual monomorphisation
-    async fn common<'client, 'frame>(
+    async fn common<'client>(
         &self,
         client: &'client Client<'client>,
         len: u16,
-    ) -> Result<ReceivedPdu<'client, ()>, Error>
-    where
-        'client: 'frame,
-    {
+    ) -> Result<SimpleReceivedPdu<'client>, Error> {
         client.single_pdu(self.command.into(), (), Some(len)).await
     }
 }

--- a/src/command/reads.rs
+++ b/src/command/reads.rs
@@ -1,8 +1,4 @@
-use crate::{
-    error::Error,
-    pdu_loop::{ReceivedPdu, SimpleReceivedPdu},
-    Client,
-};
+use crate::{error::Error, pdu_loop::ReceivedPdu, Client};
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
 
 /// Read commands that send no data.
@@ -104,7 +100,7 @@ impl WrappedRead {
         self,
         client: &'client Client<'client>,
         len: u16,
-    ) -> Result<SimpleReceivedPdu<'client>, Error> {
+    ) -> Result<ReceivedPdu<'client>, Error> {
         self.common(client, len).await?.maybe_wkc(self.wkc)
     }
 
@@ -132,7 +128,7 @@ impl WrappedRead {
         &self,
         client: &'client Client<'client>,
         len: u16,
-    ) -> Result<SimpleReceivedPdu<'client>, Error> {
+    ) -> Result<ReceivedPdu<'client>, Error> {
         client.single_pdu(self.command.into(), (), Some(len)).await
     }
 }

--- a/src/command/writes.rs
+++ b/src/command/writes.rs
@@ -1,4 +1,4 @@
-use crate::{error::Error, pdu_loop::SimpleReceivedPdu, Client};
+use crate::{error::Error, pdu_loop::ReceivedPdu, Client};
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireWrite};
 
 /// Write commands.
@@ -120,7 +120,7 @@ impl WrappedWrite {
         self,
         client: &'client Client<'client>,
         value: impl EtherCrabWireWrite,
-    ) -> Result<SimpleReceivedPdu<'client>, Error> {
+    ) -> Result<ReceivedPdu<'client>, Error> {
         self.common(client, value, None).await?.maybe_wkc(self.wkc)
     }
 
@@ -130,7 +130,7 @@ impl WrappedWrite {
         client: &'client Client<'client>,
         value: impl EtherCrabWireWrite,
         len_override: Option<u16>,
-    ) -> Result<SimpleReceivedPdu<'client>, Error> {
+    ) -> Result<ReceivedPdu<'client>, Error> {
         client
             .single_pdu(self.command.into(), &value, len_override)
             .await

--- a/src/command/writes.rs
+++ b/src/command/writes.rs
@@ -1,4 +1,4 @@
-use crate::{error::Error, pdu_loop::ReceivedPdu, Client};
+use crate::{error::Error, pdu_loop::SimpleReceivedPdu, Client};
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireWrite};
 
 /// Write commands.
@@ -116,14 +116,11 @@ impl WrappedWrite {
     }
 
     /// Similar to [`send_receive`](WrappedWrite::send_receive) but returns a slice.
-    pub async fn send_receive_slice<'data, 'client>(
+    pub async fn send_receive_slice<'client>(
         self,
         client: &'client Client<'client>,
         value: impl EtherCrabWireWrite,
-    ) -> Result<ReceivedPdu<'data, ()>, Error>
-    where
-        'client: 'data,
-    {
+    ) -> Result<SimpleReceivedPdu<'client>, Error> {
         self.common(client, value, None).await?.maybe_wkc(self.wkc)
     }
 
@@ -133,7 +130,7 @@ impl WrappedWrite {
         client: &'client Client<'client>,
         value: impl EtherCrabWireWrite,
         len_override: Option<u16>,
-    ) -> Result<ReceivedPdu<'client, ()>, Error> {
+    ) -> Result<SimpleReceivedPdu<'client>, Error> {
         client
             .single_pdu(self.command.into(), &value, len_override)
             .await

--- a/src/pdu_loop/frame_element/created_frame.rs
+++ b/src/pdu_loop/frame_element/created_frame.rs
@@ -122,7 +122,7 @@ impl<'sto> CreatedFrame<'sto> {
         // zero-initialised) so there's nothing to do.
 
         // Don't need to check length here as we do that with `pdu_buf_mut().get_mut()` above.
-        self.inner.add_pdu(alloc_size);
+        self.inner.add_pdu(alloc_size, pdu_idx);
 
         Ok(PduResponseHandle {
             _ty: PhantomData,
@@ -182,6 +182,7 @@ mod tests {
             pdu_payload_len: 0,
             marker_count: 0,
             pdu_count: 0,
+            first_pdu: None,
         }]);
 
         let mut created = CreatedFrame::claim_created(

--- a/src/pdu_loop/frame_element/created_frame.rs
+++ b/src/pdu_loop/frame_element/created_frame.rs
@@ -66,13 +66,13 @@ impl<'sto> CreatedFrame<'sto> {
         }
     }
 
-    pub fn push_pdu<RX>(
+    pub fn push_pdu(
         &mut self,
         command: Command,
         data: impl EtherCrabWireWrite,
         len_override: Option<u16>,
         more_follows: bool,
-    ) -> Result<PduResponseHandle<RX>, PduError> {
+    ) -> Result<PduResponseHandle<()>, PduError> {
         let data_length_usize =
             len_override.map_or(data.packed_len(), |l| usize::from(l).max(data.packed_len()));
 
@@ -194,7 +194,7 @@ mod tests {
         )
         .expect("Claim created");
 
-        let handle = created.push_pdu::<u32>(
+        let handle = created.push_pdu(
             Command::fpwr(0x1000, 0x0918).into(),
             [0xffu8; 9],
             None,

--- a/src/pdu_loop/frame_element/created_frame.rs
+++ b/src/pdu_loop/frame_element/created_frame.rs
@@ -3,9 +3,7 @@ use crate::{
     fmt,
     generate::write_packed,
     pdu_loop::{
-        frame_element::{
-            receiving_frame::ReceiveFrameFut, FrameBox, FrameElement, FrameState, PduMarker,
-        },
+        frame_element::{receiving_frame::ReceiveFrameFut, FrameBox, FrameElement, FrameState},
         frame_header::EthercatFrameHeader,
         pdu_flags::PduFlags,
         pdu_header::PduHeader,
@@ -164,9 +162,9 @@ pub struct PduResponseHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pdu_loop::frame_element::{AtomicFrameState, FrameElement, PduMarker};
+    use crate::pdu_loop::frame_element::{AtomicFrameState, FrameElement};
     use atomic_waker::AtomicWaker;
-    use core::{cell::UnsafeCell, mem::MaybeUninit, ptr::NonNull, sync::atomic::AtomicU8};
+    use core::{cell::UnsafeCell, ptr::NonNull, sync::atomic::AtomicU8};
 
     #[test]
     fn too_long() {
@@ -176,16 +174,12 @@ mod tests {
 
         let pdu_idx = AtomicU8::new(0);
 
-        let mut pdu_markers: [PduMarker; 1] = unsafe { MaybeUninit::zeroed().assume_init() };
-        pdu_markers[0].init();
-
         let frames = UnsafeCell::new([FrameElement {
             frame_index: 0xab,
             status: AtomicFrameState::new(FrameState::None),
             waker: AtomicWaker::default(),
             ethernet_frame: [0u8; BUF_LEN],
             pdu_payload_len: 0,
-            marker_count: 0,
             pdu_count: 0,
             first_pdu: None,
         }]);

--- a/src/pdu_loop/frame_element/frame_box.rs
+++ b/src/pdu_loop/frame_element/frame_box.rs
@@ -127,7 +127,8 @@ impl<'sto> FrameBox<'sto> {
         unsafe { core::slice::from_raw_parts_mut(ptr.as_ptr(), self.max_len - pdu_payload_start) }
     }
 
-    /// Get frame payload area.
+    /// Get frame payload area. This contains one or more PDUs and is located after the EtherCAT
+    /// frame header.
     pub fn pdu_buf(&self) -> &[u8] {
         let ptr = unsafe { FrameElement::<0>::ethercat_payload_ptr(self.frame) };
 

--- a/src/pdu_loop/frame_element/frame_box.rs
+++ b/src/pdu_loop/frame_element/frame_box.rs
@@ -199,34 +199,12 @@ impl<'sto> FrameBox<'sto> {
         Ok(pdu_idx)
     }
 
-    pub fn pdu_marker_at(&self, index: u8) -> &PduMarker {
-        unsafe {
-            let base_ptr = self.pdu_markers.as_ptr();
-
-            let layout = Layout::array::<PduMarker>(PDU_SLOTS).unwrap();
-
-            let stride = layout.size() / PDU_SLOTS;
-
-            let this_marker = base_ptr.byte_add(usize::from(index) * stride);
-
-            &*this_marker
-        }
-    }
-
     pub fn set_state(&self, to: FrameState) {
         unsafe { FrameElement::set_state(self.frame, to) };
     }
 
     pub fn swap_state(&self, from: FrameState, to: FrameState) -> Result<(), FrameState> {
         unsafe { FrameElement::swap_state(self.frame, from, to) }.map(|_| ())
-    }
-
-    pub fn inc_refcount(&self) {
-        unsafe { FrameElement::<0>::inc_refcount(self.frame) };
-    }
-
-    pub fn dec_refcount(&self) -> u8 {
-        unsafe { FrameElement::<0>::dec_refcount(self.frame) }
     }
 
     pub fn add_pdu(&mut self, alloc_size: usize, pdu_idx: u8) {

--- a/src/pdu_loop/frame_element/frame_box.rs
+++ b/src/pdu_loop/frame_element/frame_box.rs
@@ -65,6 +65,7 @@ impl<'sto> FrameBox<'sto> {
     pub fn init(&mut self) {
         unsafe {
             addr_of_mut!((*self.frame.as_ptr()).waker).write(AtomicWaker::new());
+            addr_of_mut!((*self.frame.as_ptr()).first_pdu).write(None);
         }
 
         let mut ethernet_frame = self.ethernet_frame_mut();
@@ -227,9 +228,10 @@ impl<'sto> FrameBox<'sto> {
         unsafe { FrameElement::<0>::dec_refcount(self.frame) }
     }
 
-    pub fn add_pdu(&mut self, alloc_size: usize) {
+    pub fn add_pdu(&mut self, alloc_size: usize, pdu_idx: u8) {
         unsafe { *addr_of_mut!((*self.frame.as_ptr()).pdu_payload_len) += alloc_size };
 
         unsafe { FrameElement::<0>::inc_pdu_count(self.frame) };
+        unsafe { FrameElement::<0>::set_first_pdu(self.frame, pdu_idx) };
     }
 }

--- a/src/pdu_loop/frame_element/frame_box.rs
+++ b/src/pdu_loop/frame_element/frame_box.rs
@@ -1,16 +1,12 @@
 use crate::{
-    error::PduError,
-    fmt,
     pdu_loop::{
-        frame_element::{FrameElement, FrameState, PduMarker},
+        frame_element::{FrameElement, FrameState},
         frame_header::EthercatFrameHeader,
-        PDU_SLOTS,
     },
     ETHERCAT_ETHERTYPE, MASTER_ADDR,
 };
 use atomic_waker::AtomicWaker;
 use core::{
-    alloc::Layout,
     fmt::Debug,
     marker::PhantomData,
     ptr::{addr_of, addr_of_mut, NonNull},

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -4,15 +4,11 @@ pub mod received_frame;
 pub mod receiving_frame;
 pub mod sendable_frame;
 
-use crate::{
-    error::PduError,
-    fmt,
-    pdu_loop::{frame_header::EthercatFrameHeader, PDU_UNUSED_SENTINEL},
-};
+use crate::{error::PduError, fmt, pdu_loop::frame_header::EthercatFrameHeader};
 use atomic_waker::AtomicWaker;
 use core::{
     ptr::{addr_of, addr_of_mut, NonNull},
-    sync::atomic::{AtomicU16, AtomicU8, Ordering},
+    sync::atomic::{AtomicU8, Ordering},
 };
 use frame_box::FrameBox;
 use smoltcp::wire::EthernetFrame;
@@ -46,62 +42,6 @@ pub enum FrameState {
     RxProcessing = 7,
 }
 
-#[derive(Debug)]
-#[repr(transparent)]
-pub struct PduMarker {
-    /// Ethernet frame index (`u8`) plus marker to indicate if this PDU is in flight (uses `u16`
-    /// high bits).
-    ///
-    /// The marker value is defined by [`PDU_UNUSED_SENTINEL`].
-    frame_index: AtomicU16,
-}
-
-impl PduMarker {
-    /// Try to reserve this PDU for use in a TX/RX.
-    ///
-    /// If the given index is already reserved, an error will be returned.
-    fn reserve(&self, frame_idx: u8) -> Result<(), PduError> {
-        // Try to reserve the frame by switching the flag state from unused to the frame
-        if let Err(bad_state) = self.frame_index.compare_exchange(
-            PDU_UNUSED_SENTINEL,
-            u16::from(frame_idx),
-            Ordering::Acquire,
-            Ordering::Relaxed,
-        ) {
-            fmt::error!(
-                "Bad PDU marker state: points to existing frame index {}, expecting sentinel {}, new frame index {}",
-                bad_state,
-                PDU_UNUSED_SENTINEL,
-                frame_idx
-            );
-
-            // TODO: Maybe a unique error variant here?
-            return Err(PduError::InvalidFrameState);
-        }
-
-        Ok(())
-    }
-
-    pub fn init(&self) {
-        // NOTE: Making this `debug_assert_eq` causes the frame to never be initialised. Maybe the
-        // compare_exchange gets optimised out completely?
-        assert_eq!(
-            self.frame_index.compare_exchange(
-                0,
-                PDU_UNUSED_SENTINEL,
-                Ordering::Relaxed,
-                Ordering::Relaxed
-            ),
-            Ok(0)
-        );
-    }
-
-    fn release(&self) {
-        self.frame_index
-            .store(PDU_UNUSED_SENTINEL, Ordering::Release);
-    }
-}
-
 /// An individual frame state, PDU header config, and data buffer.
 ///
 /// # A frame's journey
@@ -132,10 +72,6 @@ pub struct FrameElement<const N: usize> {
     status: AtomicFrameState,
     waker: AtomicWaker,
     pdu_payload_len: usize,
-    /// The number of PDU handles held by this frame.
-    ///
-    /// Used to drop the whole frame only when all PDUs have been consumed from it.
-    marker_count: u8,
 
     /// Number of PDUs inserted into this frame element
     pdu_count: u8,
@@ -159,7 +95,6 @@ impl<const N: usize> Default for FrameElement<N> {
             ethernet_frame: [0; N],
             frame_index: 0,
             pdu_payload_len: 0,
-            marker_count: 0,
             pdu_count: 0,
             first_pdu: None,
             waker: AtomicWaker::default(),
@@ -240,7 +175,6 @@ impl<const N: usize> FrameElement<N> {
 
         (*addr_of_mut!((*this.as_ptr()).frame_index)) = frame_index;
         (*addr_of_mut!((*this.as_ptr()).pdu_payload_len)) = 0;
-        (*addr_of_mut!((*this.as_ptr()).marker_count)) = 0;
         (*addr_of_mut!((*this.as_ptr()).pdu_count)) = 0;
 
         Ok(this)
@@ -261,16 +195,6 @@ impl<const N: usize> FrameElement<N> {
                 );
             })
             .ok()
-    }
-
-    unsafe fn inc_pdu_count(this: NonNull<FrameElement<0>>) {
-        let value = &mut *addr_of_mut!((*this.as_ptr()).pdu_count);
-
-        *value += 1;
-    }
-
-    unsafe fn pdu_count(this: NonNull<FrameElement<0>>) -> u8 {
-        *addr_of!((*this.as_ptr()).pdu_count)
     }
 
     unsafe fn frame_index(this: NonNull<FrameElement<0>>) -> u8 {

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -96,14 +96,6 @@ impl PduMarker {
         );
     }
 
-    /// Reset this marker to unused if it belongs to the given frame index.
-    fn release_for_frame(&self, frame_index: u16) {
-        // This is much more performant than `compare_exchange`, even though it's a bit messier :(
-        if self.frame_index.load(Ordering::Relaxed) == frame_index {
-            self.release();
-        }
-    }
-
     fn release(&self) {
         self.frame_index
             .store(PDU_UNUSED_SENTINEL, Ordering::Release);
@@ -114,7 +106,7 @@ impl PduMarker {
 ///
 /// # A frame's journey
 ///
-/// TODO: Update this journey! The current docs are out of date!
+// TODO: Update this journey! The current docs are out of date!
 // The following flowchart describes a `FrameElement`'s state changes during its use:
 //
 // <img alt="A flowchart showing the different state transitions of FrameElement" src="https://mermaid.ink/svg/pako:eNqdUztv2zAQ_isHTgngtLuGDLVadGkQ2E7bQYBxEc82YYoU-LBsJPnvPVLMy_JULaR05PfS3ZNorSRRiY22Q7tDF2BVNwb4-eGwo2XAQFV1Zw3Bzc3tcyNQa9uuN6l4dd00Jh8D5cHYAejY6ujVgfQJrrYRHZpAJOHxBBhsp1rwCfAa8IBK46MmCBZaxlRmC0lKI54_Mc8d8Sqnkkohq-ptHzW_wX39wChdh0bOQGLA_wBrRDb3pUO3X3syMsnMVlc_v9_x8gf3BKu_oK3tz-Uuy_kpxWslc5TbkOA92AM5MBQG6_ZTuJTMZbhUGRUvCp6jljh9D9nCLCfroZdx7Y7Zwlyj6koZ0JcLDHRuZHH8Fv1pyjt-L7S_UStOWVnztXe2Je_H39j1mgIx3eIVPkNUVc60iJRZUA5zlDPw1k111Nx7l3TU7z05gsQQXSKdf2gnTsDkzoye2KzvreFN6owp0f2bhUt079VC-omG-18mPYMKu9HOm3uSxbx0tmfPZ7xptMRMdOQ6VJIn8SmxNyLsiEFExVvJqTWiMS98DmOwy5NpRRVcpJmIPZuhWuGWMUW1Qe35K0kVrPs1jnae8Jd_545fZQ" style="background: white; max-height: 800px" />
@@ -269,20 +261,6 @@ impl<const N: usize> FrameElement<N> {
                 );
             })
             .ok()
-    }
-
-    unsafe fn inc_refcount(this: NonNull<FrameElement<0>>) {
-        let value = &mut *addr_of_mut!((*this.as_ptr()).marker_count);
-
-        *value += 1;
-    }
-
-    unsafe fn dec_refcount(this: NonNull<FrameElement<0>>) -> u8 {
-        let value = &mut *addr_of_mut!((*this.as_ptr()).marker_count);
-
-        *value -= 1;
-
-        *value
     }
 
     unsafe fn inc_pdu_count(this: NonNull<FrameElement<0>>) {

--- a/src/pdu_loop/frame_element/received_frame.rs
+++ b/src/pdu_loop/frame_element/received_frame.rs
@@ -6,7 +6,7 @@ use crate::{
         pdu_header::PduHeader,
     },
 };
-use core::{cell::Cell, marker::PhantomData, ops::Deref, ptr::NonNull};
+use core::{marker::PhantomData, ops::Deref, ptr::NonNull};
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
 
 /// A frame element where response data has been received from the EtherCAT network.
@@ -16,18 +16,11 @@ use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
 #[derive(Debug)]
 pub struct ReceivedFrame<'sto> {
     pub(in crate::pdu_loop::frame_element) inner: FrameBox<'sto>,
-    /// Whether any PDU handles were `take()`n. If this is false, the frame was used in a send-only
-    /// capacity, and no [`ReceivedPdu`]s are held. This means `ReceivedFrame` must be responsible
-    /// for clearing all the PDU claims normally freed by `ReceivedPdu`'s drop impl.
-    unread: Cell<bool>,
 }
 
 impl<'sto> ReceivedFrame<'sto> {
     pub(in crate::pdu_loop) fn new(inner: FrameBox<'sto>) -> ReceivedFrame<'sto> {
-        Self {
-            inner,
-            unread: Cell::new(true),
-        }
+        Self { inner }
     }
 
     pub fn first_pdu(self, handle: PduResponseHandle) -> Result<ReceivedPdu<'sto>, Error> {

--- a/src/pdu_loop/frame_element/received_frame.rs
+++ b/src/pdu_loop/frame_element/received_frame.rs
@@ -54,7 +54,7 @@ impl<'sto> ReceivedFrame<'sto> {
         Ok(ReceivedPdu {
             data_start: payload_ptr,
             len: payload_len,
-            working_counter: working_counter,
+            working_counter,
             _storage: PhantomData,
         })
     }
@@ -103,7 +103,7 @@ impl<'sto> ReceivedFrame<'sto> {
         Ok(ReceivedPdu {
             data_start: payload_ptr,
             len: payload_len,
-            working_counter: working_counter,
+            working_counter,
             _storage: PhantomData,
         })
     }

--- a/src/pdu_loop/frame_element/received_frame.rs
+++ b/src/pdu_loop/frame_element/received_frame.rs
@@ -117,23 +117,11 @@ impl<'sto> ReceivedFrame<'sto> {
 
 impl<'sto> Drop for ReceivedFrame<'sto> {
     fn drop(&mut self) {
-        // No PDU results where `take()`n so we have to free the frame here, instead of relying on
-        // `ReceivedPdu::drop`.
-        if self.unread.get() {
-            fmt::trace!(
-                "Frame index {} was untouched, freeing",
-                self.inner.frame_index()
-            );
-
-            self.inner.release_pdu_claims();
-
-            // Invariant: the frame can only be in `RxProcessing` at this point, so if this
-            // swap fails there's either a logic bug, or we should panic anyway because the
-            // hardware failed.
-            fmt::unwrap!(self
-                .inner
-                .swap_state(FrameState::RxProcessing, FrameState::None));
-        }
+        // Invariant: the frame can only be in `RxProcessing` at this point, so if this swap fails
+        // there's either a logic bug, or we should panic anyway because the hardware failed.
+        fmt::unwrap!(self
+            .inner
+            .swap_state(FrameState::RxProcessing, FrameState::None));
     }
 }
 

--- a/src/pdu_loop/frame_element/received_frame.rs
+++ b/src/pdu_loop/frame_element/received_frame.rs
@@ -32,74 +32,7 @@ impl<'sto> ReceivedFrame<'sto> {
         }
     }
 
-    pub fn take<'frame, T>(
-        &'sto self,
-        // SAFETY: Consumes handle so it cannot be retrieved again. If this invariant is relaxed, we
-        // could hold multiple references to the same section of response data. This isn't hugely
-        // bad on its own as all we ever do is read it, but semantically it makes sense.
-        #[allow(clippy::needless_pass_by_value)] handle: PduResponseHandle<T>,
-    ) -> Result<ReceivedPdu<'frame, T>, Error> {
-        // Offset relative to end of EtherCAT header
-        let pdu_start_offset = handle.buf_start;
-
-        let this_pdu = &self.inner.pdu_buf()[pdu_start_offset..];
-
-        let pdu_header = PduHeader::unpack_from_slice(this_pdu)?;
-
-        let payload_len = usize::from(pdu_header.flags.len());
-
-        // SAFETY: The memory behind `this_pdu` was initialised by Rust so is always valid
-        let payload_ptr = unsafe {
-            NonNull::new_unchecked(this_pdu[PduHeader::PACKED_LEN..].as_ptr().cast_mut())
-        };
-
-        let working_counter =
-            u16::unpack_from_slice(&this_pdu[(PduHeader::PACKED_LEN + payload_len)..])?;
-
-        self.inner.inc_refcount();
-
-        if pdu_header.index != handle.pdu_idx {
-            fmt::error!(
-                "Expected PDU index {:#04x}, got {:#04x}",
-                handle.pdu_idx,
-                pdu_header.index
-            );
-
-            return Err(Error::Pdu(PduError::InvalidIndex(pdu_header.index)));
-        }
-
-        if pdu_header.command_code != handle.command_code {
-            fmt::error!(
-                "PDU {:#04x} response has incorrect command received {:#04x}, expected {:#04x}",
-                pdu_header.index,
-                pdu_header.command_code,
-                handle.command_code
-            );
-
-            return Err(Error::Pdu(PduError::Decode));
-        }
-
-        self.unread.replace(false);
-
-        Ok(ReceivedPdu {
-            data_start: payload_ptr,
-            len: payload_len,
-            // SAFETY: 'sto must always live longer than 'frame or we risk reading into uninit
-            // memory.
-            frame: unsafe { core::mem::transmute::<FrameBox<'sto>, FrameBox<'frame>>(self.inner) },
-            pdu_marker: unsafe {
-                core::mem::transmute::<&'sto PduMarker, &'frame PduMarker>(
-                    self.inner.pdu_marker_at(pdu_header.index),
-                )
-            },
-            working_counter,
-            _ty: PhantomData,
-            _storage: PhantomData,
-            pdu_idx: pdu_header.index,
-        })
-    }
-
-    pub fn first_pdu(self) -> Result<SimpleReceivedPdu<'sto>, Error> {
+    pub fn first_pdu(self) -> Result<ReceivedPdu<'sto>, Error> {
         let mut buf = self.inner.pdu_buf();
 
         let pdu_header = PduHeader::unpack_from_slice(buf)?;
@@ -118,7 +51,7 @@ impl<'sto> ReceivedFrame<'sto> {
         let working_counter =
             u16::unpack_from_slice(&buf[(PduHeader::PACKED_LEN + payload_len)..])?;
 
-        Ok(SimpleReceivedPdu {
+        Ok(ReceivedPdu {
             data_start: payload_ptr,
             len: payload_len,
             working_counter: working_counter,
@@ -126,7 +59,7 @@ impl<'sto> ReceivedFrame<'sto> {
         })
     }
 
-    pub fn pdu<'pdu>(&'sto self, index: u8) -> Result<SimpleReceivedPdu<'pdu>, Error>
+    pub fn pdu<'pdu>(&'sto self, index: u8) -> Result<ReceivedPdu<'pdu>, Error>
     where
         'sto: 'pdu,
     {
@@ -159,7 +92,7 @@ impl<'sto> ReceivedFrame<'sto> {
         let working_counter =
             u16::unpack_from_slice(&buf[(PduHeader::PACKED_LEN + payload_len)..])?;
 
-        Ok(SimpleReceivedPdu {
+        Ok(ReceivedPdu {
             data_start: payload_ptr,
             len: payload_len,
             working_counter: working_counter,
@@ -191,118 +124,14 @@ impl<'sto> Drop for ReceivedFrame<'sto> {
 }
 
 #[derive(Debug)]
-pub struct ReceivedPdu<'sto, T> {
-    pdu_marker: &'sto PduMarker,
-    frame: FrameBox<'sto>,
-    data_start: NonNull<u8>,
-    len: usize,
-    pub(crate) working_counter: u16,
-    _ty: PhantomData<T>,
-    _storage: PhantomData<&'sto ()>,
-    pdu_idx: u8,
-}
-
-impl<'sto, T> ReceivedPdu<'sto, T> {
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    pub fn trim_front(&mut self, ct: usize) {
-        let ct = ct.min(self.len());
-
-        self.data_start = unsafe { NonNull::new_unchecked(self.data_start.as_ptr().add(ct)) };
-    }
-
-    pub fn wkc(self, expected: u16) -> Result<Self, Error> {
-        if self.working_counter == expected {
-            Ok(self)
-        } else {
-            Err(Error::WorkingCounter {
-                expected,
-                received: self.working_counter,
-            })
-        }
-    }
-
-    pub fn maybe_wkc(self, expected: Option<u16>) -> Result<Self, Error> {
-        match expected {
-            Some(expected) => self.wkc(expected),
-            None => Ok(self),
-        }
-    }
-}
-
-// Free up PDU marker for reuse. The frame may still be in use by other PDU handles, so it is not
-// dropped here.
-//
-// The `ReceivedFrame` behind this `ReceivedPdu` can also be dropped, however it does not hold any
-// data referenced by `ReceivedPdu` - that is stored in the backing store. The backing store's
-// `FrameElement` must remain reserved until all `ReceivedPdu`s are dropped so as to not overwrite
-// any referenced data.
-impl<'sto, T> Drop for ReceivedPdu<'sto, T> {
-    fn drop(&mut self) {
-        let frame_idx = u16::from(self.frame.frame_index());
-
-        self.pdu_marker.release_for_frame(frame_idx);
-
-        let count = self.frame.dec_refcount();
-
-        fmt::trace!(
-            "Drop received PDU marker {:#04x}, points to frame index {}, refcount {}",
-            self.pdu_idx,
-            frame_idx,
-            count
-        );
-
-        // We've just dropped the last handle to the backing store. It can now be released.
-        if count == 0 {
-            fmt::trace!(
-                "All PDU handles dropped, freeing frame element {}",
-                self.frame.frame_index()
-            );
-
-            // Invariant: the frame can only be in `RxProcessing` at this point, so if this swap
-            // fails there's either a logic bug, or we should panic anyway because the hardware
-            // failed.
-            fmt::unwrap!(self
-                .frame
-                .swap_state(FrameState::RxProcessing, FrameState::None));
-        }
-
-        // dbg!(self.frame.refcount.fetch_sub(1, Ordering::Release));
-    }
-}
-
-// SAFETY: This is ok because we respect the lifetime of the underlying data by carrying the 'sto
-// lifetime.
-unsafe impl<'sto, T> Send for ReceivedPdu<'sto, T> {}
-
-impl<'sto, T> Deref for ReceivedPdu<'sto, T> {
-    type Target = [u8];
-
-    // Temporally shorter borrow: This ref is the lifetime of ReceivedPdu, not 'sto. This is the
-    // magic.
-    fn deref(&self) -> &Self::Target {
-        let len = self.len();
-
-        unsafe { core::slice::from_raw_parts(self.data_start.as_ptr(), len) }
-    }
-}
-
-// ---
-// ---
-// ---
-// ---
-
-#[derive(Debug)]
-pub struct SimpleReceivedPdu<'sto> {
+pub struct ReceivedPdu<'sto> {
     data_start: NonNull<u8>,
     len: usize,
     pub(crate) working_counter: u16,
     _storage: PhantomData<&'sto ()>,
 }
 
-impl<'sto> SimpleReceivedPdu<'sto> {
+impl<'sto> ReceivedPdu<'sto> {
     pub fn len(&self) -> usize {
         self.len
     }
@@ -334,9 +163,9 @@ impl<'sto> SimpleReceivedPdu<'sto> {
 
 // SAFETY: This is ok because we respect the lifetime of the underlying data by carrying the 'sto
 // lifetime.
-unsafe impl<'sto> Send for SimpleReceivedPdu<'sto> {}
+unsafe impl<'sto> Send for ReceivedPdu<'sto> {}
 
-impl<'sto> Deref for SimpleReceivedPdu<'sto> {
+impl<'sto> Deref for ReceivedPdu<'sto> {
     type Target = [u8];
 
     // Temporally shorter borrow: This ref is the lifetime of SimpleReceivedPdu, not 'sto. This is

--- a/src/pdu_loop/frame_element/receiving_frame.rs
+++ b/src/pdu_loop/frame_element/receiving_frame.rs
@@ -20,14 +20,13 @@ pub struct ReceivingFrame<'sto> {
 impl<'sto> ReceivingFrame<'sto> {
     pub(in crate::pdu_loop) fn claim_receiving(
         frame: NonNull<FrameElement<0>>,
-        pdu_markers: NonNull<PduMarker>,
         pdu_idx: &'sto AtomicU8,
         frame_data_len: usize,
     ) -> Option<Self> {
         let frame = unsafe { FrameElement::claim_receiving(frame)? };
 
         Some(Self {
-            inner: FrameBox::new(frame, pdu_markers, pdu_idx, frame_data_len),
+            inner: FrameBox::new(frame, pdu_idx, frame_data_len),
         })
     }
 
@@ -133,8 +132,6 @@ impl<'sto> ReceiveFrameFut<'sto> {
     }
 
     fn release(r: FrameBox<'sto>) {
-        r.release_pdu_claims();
-
         // Make frame available for reuse if this future is dropped.
         r.set_state(FrameState::None);
     }

--- a/src/pdu_loop/frame_element/receiving_frame.rs
+++ b/src/pdu_loop/frame_element/receiving_frame.rs
@@ -1,9 +1,7 @@
 use crate::{
     error::{Error, PduError},
     fmt,
-    pdu_loop::frame_element::{
-        received_frame::ReceivedFrame, FrameBox, FrameElement, FrameState, PduMarker,
-    },
+    pdu_loop::frame_element::{received_frame::ReceivedFrame, FrameBox, FrameElement, FrameState},
     PduLoop,
 };
 use core::{future::Future, ptr::NonNull, sync::atomic::AtomicU8, task::Poll, time::Duration};

--- a/src/pdu_loop/frame_element/sendable_frame.rs
+++ b/src/pdu_loop/frame_element/sendable_frame.rs
@@ -2,7 +2,7 @@ use crate::{
     error::Error,
     fmt,
     pdu_loop::{
-        frame_element::{FrameBox, FrameElement, FrameState, PduMarker},
+        frame_element::{FrameBox, FrameElement, FrameState},
         frame_header::EthercatFrameHeader,
     },
 };

--- a/src/pdu_loop/frame_element/sendable_frame.rs
+++ b/src/pdu_loop/frame_element/sendable_frame.rs
@@ -57,14 +57,13 @@ unsafe impl<'sto> Send for SendableFrame<'sto> {}
 impl<'sto> SendableFrame<'sto> {
     pub(crate) fn claim_sending(
         frame: NonNull<FrameElement<0>>,
-        pdu_markers: NonNull<PduMarker>,
         pdu_idx: &'sto AtomicU8,
         frame_data_len: usize,
     ) -> Option<Self> {
         let frame = unsafe { FrameElement::claim_sending(frame)? };
 
         Some(Self {
-            inner: FrameBox::new(frame, pdu_markers, pdu_idx, frame_data_len),
+            inner: FrameBox::new(frame, pdu_idx, frame_data_len),
         })
     }
 

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -271,7 +271,7 @@ mod tests {
             // from
             match frame_fut.poll(ctx) {
                 Poll::Ready(Ok(frame)) => {
-                    let response = frame.first_pdu().expect("Handle");
+                    let response = frame.first_pdu(handle).expect("Handle");
 
                     assert_eq!(response.deref(), &data);
                 }
@@ -403,7 +403,7 @@ mod tests {
             // from
             match frame_fut.poll(ctx) {
                 Poll::Ready(Ok(frame)) => {
-                    assert_eq!(frame.first_pdu().unwrap().deref(), &data_bytes);
+                    assert_eq!(frame.first_pdu(handle).unwrap().deref(), &data_bytes);
                 }
                 Poll::Ready(other) => panic!("Expected Ready(Ok()), got {:?}", other),
                 Poll::Pending => panic!("frame future still pending"),
@@ -484,7 +484,7 @@ mod tests {
                 .await
                 .expect("Future");
 
-            let received_data = result.first_pdu().expect("Take");
+            let received_data = result.first_pdu(handle).expect("Take");
 
             assert_eq!(&*received_data, &data);
         }
@@ -597,7 +597,7 @@ mod tests {
                     }
                     .expect("Future");
 
-                    let received_data = result.first_pdu().expect("Take");
+                    let received_data = result.first_pdu(handle).expect("Take");
 
                     assert_eq!(&*received_data, &data);
                 });

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -15,7 +15,7 @@ pub use storage::PduStorage;
 
 pub(crate) use self::frame_element::created_frame::CreatedFrame;
 pub(crate) use self::frame_element::received_frame::ReceivedFrame;
-pub(crate) use frame_element::received_frame::ReceivedPdu;
+pub(crate) use frame_element::received_frame::{ReceivedPdu, SimpleReceivedPdu};
 
 pub use frame_element::sendable_frame::SendableFrame;
 
@@ -92,7 +92,7 @@ impl<'sto> PduLoop<'sto> {
     ) -> Result<(), Error> {
         let mut frame = self.storage.alloc_frame()?;
 
-        frame.push_pdu::<()>(
+        frame.push_pdu(
             Command::bwr(register).into(),
             (),
             Some(payload_length),
@@ -137,7 +137,7 @@ mod tests {
         let mut frame = pdu_loop.storage.alloc_frame().expect("Alloc");
 
         frame
-            .push_pdu::<()>(
+            .push_pdu(
                 Reads::Brd {
                     address: 0,
                     register: 0,
@@ -179,7 +179,7 @@ mod tests {
         let mut frame = pdu_loop.storage.alloc_frame().unwrap();
 
         let _handle = frame
-            .push_pdu::<()>(Command::fpwr(0x5678, 0x1234).into(), data, None, false)
+            .push_pdu(Command::fpwr(0x5678, 0x1234).into(), data, None, false)
             .expect("Push");
 
         let frame = frame.mark_sendable(&pdu_loop, Duration::MAX, usize::MAX);
@@ -223,7 +223,7 @@ mod tests {
             let mut frame = pdu_loop.storage.alloc_frame().expect("Frame alloc");
 
             let handle = frame
-                .push_pdu::<()>(Command::fpwr(0x5678, 0x1234).into(), &data, None, false)
+                .push_pdu(Command::fpwr(0x5678, 0x1234).into(), &data, None, false)
                 .expect("Push PDU");
 
             let mut frame_fut = pin!(frame.mark_sendable(&pdu_loop, Duration::MAX, usize::MAX));
@@ -301,7 +301,7 @@ mod tests {
         let mut frame = pdu_loop.storage.alloc_frame().unwrap();
 
         let _handle = frame
-            .push_pdu::<()>(Command::fpwr(0x5678, 0x1234).into(), data, None, false)
+            .push_pdu(Command::fpwr(0x5678, 0x1234).into(), data, None, false)
             .expect("Push PDU");
 
         // Drop frame future to reset its state to `FrameState::None`
@@ -314,7 +314,7 @@ mod tests {
         let mut frame = pdu_loop.storage.alloc_frame().unwrap();
 
         let _handle = frame
-            .push_pdu::<()>(Command::fpwr(0x6789, 0x1234).into(), data, None, false)
+            .push_pdu(Command::fpwr(0x6789, 0x1234).into(), data, None, false)
             .expect("Push second PDU");
 
         let frame = frame.mark_sendable(&pdu_loop, Duration::MAX, usize::MAX);
@@ -371,7 +371,7 @@ mod tests {
             let mut frame = pdu_loop.storage.alloc_frame().unwrap();
 
             let handle = frame
-                .push_pdu::<()>(
+                .push_pdu(
                     Command::fpwr(0x6789, 0x1234).into(),
                     &data_bytes,
                     None,
@@ -476,7 +476,7 @@ mod tests {
             let mut frame = pdu_loop.storage.alloc_frame().expect("Frame alloc");
 
             let handle = frame
-                .push_pdu::<()>(Command::fpwr(0x1000, 0x980).into(), data, None, false)
+                .push_pdu(Command::fpwr(0x1000, 0x980).into(), data, None, false)
                 .expect("Push PDU");
 
             let result = frame
@@ -580,7 +580,7 @@ mod tests {
                     let mut frame = pdu_loop.storage.alloc_frame().expect("Frame alloc");
 
                     let handle = frame
-                        .push_pdu::<()>(Command::fpwr(0x1000, 0x980).into(), data, None, false)
+                        .push_pdu(Command::fpwr(0x1000, 0x980).into(), data, None, false)
                         .expect("Push PDU");
 
                     let mut x =

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -15,7 +15,7 @@ pub use storage::PduStorage;
 
 pub(crate) use self::frame_element::created_frame::CreatedFrame;
 pub(crate) use self::frame_element::received_frame::ReceivedFrame;
-pub(crate) use frame_element::received_frame::{ReceivedPdu, SimpleReceivedPdu};
+pub(crate) use frame_element::received_frame::ReceivedPdu;
 
 pub use frame_element::sendable_frame::SendableFrame;
 
@@ -271,7 +271,7 @@ mod tests {
             // from
             match frame_fut.poll(ctx) {
                 Poll::Ready(Ok(frame)) => {
-                    let response = frame.take(handle).expect("Handle");
+                    let response = frame.first_pdu().expect("Handle");
 
                     assert_eq!(response.deref(), &data);
                 }
@@ -403,7 +403,7 @@ mod tests {
             // from
             match frame_fut.poll(ctx) {
                 Poll::Ready(Ok(frame)) => {
-                    assert_eq!(frame.take(handle).unwrap().deref(), &data_bytes);
+                    assert_eq!(frame.first_pdu().unwrap().deref(), &data_bytes);
                 }
                 Poll::Ready(other) => panic!("Expected Ready(Ok()), got {:?}", other),
                 Poll::Pending => panic!("frame future still pending"),
@@ -484,7 +484,7 @@ mod tests {
                 .await
                 .expect("Future");
 
-            let received_data = result.take(handle).expect("Take");
+            let received_data = result.first_pdu().expect("Take");
 
             assert_eq!(&*received_data, &data);
         }
@@ -597,7 +597,7 @@ mod tests {
                     }
                     .expect("Future");
 
-                    let received_data = result.take(handle).expect("Take");
+                    let received_data = result.first_pdu().expect("Take");
 
                     assert_eq!(&*received_data, &data);
                 });

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -14,7 +14,6 @@ pub use pdu_tx::PduTx;
 pub use storage::PduStorage;
 
 pub(crate) use self::frame_element::created_frame::CreatedFrame;
-pub(crate) use self::frame_element::received_frame::ReceivedFrame;
 pub(crate) use frame_element::received_frame::ReceivedPdu;
 
 pub use frame_element::sendable_frame::SendableFrame;
@@ -23,14 +22,6 @@ pub use frame_element::sendable_frame::SendableFrame;
 pub use frame_header::EthercatFrameHeader;
 #[cfg(feature = "__internals")]
 pub use pdu_header::PduHeader;
-
-/// Unused PDU marker.
-///
-/// The value this is set to should be larger than `u8::MAX` to ensure no valid frame index can
-/// equal it.
-const PDU_UNUSED_SENTINEL: u16 = u16::MAX;
-
-const PDU_SLOTS: usize = 256;
 
 /// The core EtherCrab network communications driver.
 ///

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -79,7 +79,10 @@ impl<'sto> PduRx<'sto> {
         // use the first one.
 
         // PDU has its own EtherCAT index. This needs mapping back to the original frame.
-        let frame_index = self.storage.marker_at_index(pdu_idx).frame_index();
+        let frame_index = self
+            .storage
+            .frame_index_by_first_pdu_index(pdu_idx)
+            .ok_or(Error::Pdu(PduError::Decode))?;
 
         fmt::trace!(
             "Receiving frame index {} (found from PDU {:#04x})",

--- a/src/pdu_loop/pdu_tx.rs
+++ b/src/pdu_loop/pdu_tx.rs
@@ -24,7 +24,6 @@ impl<'sto> PduTx<'sto> {
 
             let Some(sending) = SendableFrame::claim_sending(
                 frame,
-                self.storage.pdu_markers,
                 self.storage.pdu_idx,
                 self.storage.frame_data_len,
             ) else {

--- a/src/pdu_loop/storage.rs
+++ b/src/pdu_loop/storage.rs
@@ -318,7 +318,7 @@ mod tests {
         let mut frame = pdu_loop.alloc_frame().expect("Allocate first frame");
 
         frame
-            .push_pdu::<()>(
+            .push_pdu(
                 Command::bwr(0x1000).into(),
                 [0xaa, 0xbb, 0xcc, 0xdd],
                 None,
@@ -334,7 +334,7 @@ mod tests {
         const LEN: usize = 8;
 
         frame
-            .push_pdu::<()>(Command::Nop, (), Some(LEN as u16), false)
+            .push_pdu(Command::Nop, (), Some(LEN as u16), false)
             .unwrap();
 
         let pdu_start = EthernetFrame::<&[u8]>::header_len()

--- a/src/pdu_loop/storage.rs
+++ b/src/pdu_loop/storage.rs
@@ -212,13 +212,8 @@ impl<'sto> PduStorageRef<'sto> {
             // variable in the frame, and the atomic index counter above.
             let frame = self.frame_at_index(usize::from(frame_idx));
 
-            let frame = CreatedFrame::claim_created(
-                frame,
-                frame_idx,
-                self.pdu_markers,
-                self.pdu_idx,
-                self.frame_data_len,
-            );
+            let frame =
+                CreatedFrame::claim_created(frame, frame_idx, self.pdu_idx, self.frame_data_len);
 
             if let Ok(f) = frame {
                 return Ok(f);
@@ -248,7 +243,6 @@ impl<'sto> PduStorageRef<'sto> {
 
         ReceivingFrame::claim_receiving(
             self.frame_at_index(frame_idx),
-            self.pdu_markers,
             self.pdu_idx,
             self.frame_data_len,
         )

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     error::{Error, MailboxError, PduError},
     fmt,
     mailbox::{MailboxHeader, MailboxType},
-    pdu_loop::ReceivedPdu,
+    pdu_loop::{ReceivedPdu, SimpleReceivedPdu},
     register::{DcSupport, RegisterAddress, SupportFlags},
     slave::{ports::Ports, types::SlaveConfig},
     slave_state::SlaveState,
@@ -456,7 +456,7 @@ where
     }
 
     /// Wait for a mailbox response
-    async fn coe_response(&self, read_mailbox: &Mailbox) -> Result<ReceivedPdu<'_, ()>, Error> {
+    async fn coe_response(&self, read_mailbox: &Mailbox) -> Result<SimpleReceivedPdu, Error> {
         let mailbox_read_sm = RegisterAddress::sync_manager_status(read_mailbox.sync_manager);
 
         // Wait for slave OUT mailbox to be ready
@@ -499,7 +499,7 @@ where
 
     /// Send a mailbox request, wait for response mailbox to be ready, read response from mailbox
     /// and return as a slice.
-    async fn send_coe_service<R>(&'a self, request: R) -> Result<(R, ReceivedPdu<'_, ()>), Error>
+    async fn send_coe_service<R>(&'a self, request: R) -> Result<(R, SimpleReceivedPdu), Error>
     where
         R: CoeServiceRequest + Debug,
     {

--- a/src/slave/mod.rs
+++ b/src/slave/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     error::{Error, MailboxError, PduError},
     fmt,
     mailbox::{MailboxHeader, MailboxType},
-    pdu_loop::{ReceivedPdu, SimpleReceivedPdu},
+    pdu_loop::ReceivedPdu,
     register::{DcSupport, RegisterAddress, SupportFlags},
     slave::{ports::Ports, types::SlaveConfig},
     slave_state::SlaveState,
@@ -456,7 +456,7 @@ where
     }
 
     /// Wait for a mailbox response
-    async fn coe_response(&self, read_mailbox: &Mailbox) -> Result<SimpleReceivedPdu, Error> {
+    async fn coe_response(&self, read_mailbox: &Mailbox) -> Result<ReceivedPdu, Error> {
         let mailbox_read_sm = RegisterAddress::sync_manager_status(read_mailbox.sync_manager);
 
         // Wait for slave OUT mailbox to be ready
@@ -499,7 +499,7 @@ where
 
     /// Send a mailbox request, wait for response mailbox to be ready, read response from mailbox
     /// and return as a slice.
-    async fn send_coe_service<R>(&'a self, request: R) -> Result<(R, SimpleReceivedPdu), Error>
+    async fn send_coe_service<R>(&'a self, request: R) -> Result<(R, ReceivedPdu), Error>
     where
         R: CoeServiceRequest + Debug,
     {

--- a/src/slave_group/mod.rs
+++ b/src/slave_group/mod.rs
@@ -937,8 +937,8 @@ where
 
     fn process_pdi_response_with_time(
         &self,
-        dc: &crate::pdu_loop::SimpleReceivedPdu,
-        data: &crate::pdu_loop::SimpleReceivedPdu,
+        dc: &crate::pdu_loop::ReceivedPdu,
+        data: &crate::pdu_loop::ReceivedPdu,
     ) -> Result<(u64, u16), Error> {
         let time = u64::unpack_from_slice(dc)?;
 
@@ -948,10 +948,7 @@ where
     /// Take a received PDI and copy its inputs into the group's memory.
     ///
     /// Returns working counter on success.
-    fn process_pdi_response(
-        &self,
-        data: &crate::pdu_loop::SimpleReceivedPdu,
-    ) -> Result<u16, Error> {
+    fn process_pdi_response(&self, data: &crate::pdu_loop::ReceivedPdu) -> Result<u16, Error> {
         if data.len() != self.pdi().len() {
             fmt::error!(
                 "Data length {} does not match value length {}",

--- a/src/slave_group/mod.rs
+++ b/src/slave_group/mod.rs
@@ -863,33 +863,71 @@ where
         );
 
         if let Some(dc_ref) = client.dc_ref_address() {
-            let (time, wkc) = client
-                .multi_pdu(
-                    |frame| {
-                        let dc_handle = frame.push_pdu::<u64>(
-                            Command::frmw(dc_ref, RegisterAddress::DcSystemTime.into()).into(),
-                            0u64,
-                            None,
-                            true,
-                        )?;
+            // let (time, wkc) = client
+            //     .multi_pdu(
+            //         |frame| {
+            //             let dc_handle = frame.push_pdu::<u64>(
+            //                 Command::frmw(dc_ref, RegisterAddress::DcSystemTime.into()).into(),
+            //                 0u64,
+            //                 None,
+            //                 true,
+            //             )?;
 
-                        let pdu_handle = frame.push_pdu::<()>(
-                            Command::lrw(self.inner().pdi_start.start_address).into(),
-                            self.pdi(),
-                            None,
-                            false,
-                        )?;
+            //             let pdu_handle = frame.push_pdu::<()>(
+            //                 Command::lrw(self.inner().pdi_start.start_address).into(),
+            //                 self.pdi(),
+            //                 None,
+            //                 false,
+            //             )?;
 
-                        Ok((dc_handle, pdu_handle))
-                    },
-                    |received, (dc, data)| {
-                        self.process_pdi_response_with_time(
-                            &received.take(dc)?,
-                            &received.take(data)?,
-                        )
-                    },
-                )
-                .await?;
+            //             Ok((dc_handle, pdu_handle))
+            //         },
+            //         |received, (dc, data)| {
+            //             self.process_pdi_response_with_time(
+            //                 &received.take(dc)?,
+            //                 &received.take(data)?,
+            //             )
+            //         },
+            //     )
+            //     .await?;
+
+            let mut frame = client.pdu_loop.alloc_frame()?;
+            let frame_idx = frame.frame_index();
+
+            frame.push_pdu(
+                Command::frmw(dc_ref, RegisterAddress::DcSystemTime.into()).into(),
+                0u64,
+                None,
+                true,
+            )?;
+
+            frame.push_pdu(
+                Command::lrw(self.inner().pdi_start.start_address).into(),
+                self.pdi(),
+                None,
+                false,
+            )?;
+
+            let frame = frame.mark_sendable(
+                &client.pdu_loop,
+                client.timeouts.pdu,
+                client.config.retry_behaviour.retry_count(),
+            );
+
+            client.pdu_loop.wake_sender();
+
+            let received = match frame.await {
+                Ok(received) => received,
+                Err(Error::Timeout) => {
+                    fmt::error!("Frame index {} timed out", frame_idx);
+
+                    return Err(Error::Timeout);
+                }
+                Err(e) => return Err(e),
+            };
+
+            let (time, wkc) =
+                self.process_pdi_response_with_time(&received.pdu(0)?, &received.pdu(1)?)?;
 
             Ok((wkc, Some(time)))
         } else {
@@ -899,8 +937,8 @@ where
 
     fn process_pdi_response_with_time(
         &self,
-        dc: &crate::pdu_loop::ReceivedPdu<'_, u64>,
-        data: &crate::pdu_loop::ReceivedPdu<'_, ()>,
+        dc: &crate::pdu_loop::SimpleReceivedPdu,
+        data: &crate::pdu_loop::SimpleReceivedPdu,
     ) -> Result<(u64, u16), Error> {
         let time = u64::unpack_from_slice(dc)?;
 
@@ -912,7 +950,7 @@ where
     /// Returns working counter on success.
     fn process_pdi_response(
         &self,
-        data: &crate::pdu_loop::ReceivedPdu<'_, ()>,
+        data: &crate::pdu_loop::SimpleReceivedPdu,
     ) -> Result<u16, Error> {
         if data.len() != self.pdi().len() {
             fmt::error!(
@@ -1062,31 +1100,69 @@ where
             self.read_pdi_len
         );
 
-        let (time, wkc) = client
-            .multi_pdu(
-                |frame| {
-                    let dc_handle = frame.push_pdu::<u64>(
-                        Command::frmw(self.dc_conf.reference, RegisterAddress::DcSystemTime.into())
-                            .into(),
-                        0u64,
-                        None,
-                        true,
-                    )?;
+        // let (time, wkc) = client
+        //     .multi_pdu(
+        //         |frame| {
+        //             let dc_handle = frame.push_pdu::<u64>(
+        //                 Command::frmw(self.dc_conf.reference, RegisterAddress::DcSystemTime.into())
+        //                     .into(),
+        //                 0u64,
+        //                 None,
+        //                 true,
+        //             )?;
 
-                    let pdu_handle = frame.push_pdu::<()>(
-                        Command::lrw(self.inner().pdi_start.start_address).into(),
-                        self.pdi(),
-                        None,
-                        false,
-                    )?;
+        //             let pdu_handle = frame.push_pdu::<()>(
+        //                 Command::lrw(self.inner().pdi_start.start_address).into(),
+        //                 self.pdi(),
+        //                 None,
+        //                 false,
+        //             )?;
 
-                    Ok((dc_handle, pdu_handle))
-                },
-                |received, (dc, data)| {
-                    self.process_pdi_response_with_time(&received.take(dc)?, &received.take(data)?)
-                },
-            )
-            .await?;
+        //             Ok((dc_handle, pdu_handle))
+        //         },
+        //         |received, (dc, data)| {
+        //             self.process_pdi_response_with_time(&received.take(dc)?, &received.take(data)?)
+        //         },
+        //     )
+        //     .await?;
+
+        let mut frame = client.pdu_loop.alloc_frame()?;
+        let frame_idx = frame.frame_index();
+
+        frame.push_pdu(
+            Command::frmw(self.dc_conf.reference, RegisterAddress::DcSystemTime.into()).into(),
+            0u64,
+            None,
+            true,
+        )?;
+
+        frame.push_pdu(
+            Command::lrw(self.inner().pdi_start.start_address).into(),
+            self.pdi(),
+            None,
+            false,
+        )?;
+
+        let frame = frame.mark_sendable(
+            &client.pdu_loop,
+            client.timeouts.pdu,
+            client.config.retry_behaviour.retry_count(),
+        );
+
+        client.pdu_loop.wake_sender();
+
+        let received = match frame.await {
+            Ok(received) => received,
+            Err(Error::Timeout) => {
+                fmt::error!("Frame index {} timed out", frame_idx);
+
+                return Err(Error::Timeout);
+            }
+            Err(e) => return Err(e),
+        };
+
+        let (time, wkc) =
+            self.process_pdi_response_with_time(&received.pdu(0)?, &received.pdu(1)?)?;
 
         // Nanoseconds from the start of the cycle. This works because the first SYNC0 pulse
         // time is rounded to a whole number of `sync0_period`-length cycles.


### PR DESCRIPTION
`PduMarker` became unnecessary and was removed, which is a huge relief as that whole set of code was a horrible hack I was never happy with. Received EtherCAT frames are now matched up to their backing data by parsing out the first PDU index in the frame and doing a linear search over the (up to) 256 frame slots. Benchmark performance improved by ~4% and embedded binary size reduced a lot too:

`master`:

```
   text    data     bss     dec     hex filename
  96576     112   57800  154488   25b78 ethercrab-stm32-embassy
```

This PR:

```
   text    data     bss     dec     hex filename
  92216     112   57288  149616   24870 ethercrab-stm32-embassy
```