### PR TITLE
More housekeeping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tokio = { version = "1.33.0", features = [
 ] }
 thread-priority = "0.16.0"
 ta = "0.5.0"
-cassette = "0.2.5"
+cassette = "0.3.0"
 csv = "1.3.0"
 serde = { version = "1.0.190", default-features = false, features = ["derive"] }
 signal-hook = "0.3.17"

--- a/src/pdu_loop/frame_element/created_frame.rs
+++ b/src/pdu_loop/frame_element/created_frame.rs
@@ -180,7 +180,6 @@ mod tests {
             waker: AtomicWaker::default(),
             ethernet_frame: [0u8; BUF_LEN],
             pdu_payload_len: 0,
-            pdu_count: 0,
             first_pdu: None,
         }]);
 

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -73,9 +73,6 @@ pub struct FrameElement<const N: usize> {
     waker: AtomicWaker,
     pdu_payload_len: usize,
 
-    /// Number of PDUs inserted into this frame element
-    pdu_count: u8,
-
     // Atomic as we iterate over all `FrameElement`s and read this field when receiving a frame.
     /// Stores the PDU index of the first PDU written into this frame (if any).
     ///
@@ -95,7 +92,6 @@ impl<const N: usize> Default for FrameElement<N> {
             ethernet_frame: [0; N],
             frame_index: 0,
             pdu_payload_len: 0,
-            pdu_count: 0,
             first_pdu: None,
             waker: AtomicWaker::default(),
         }
@@ -175,7 +171,6 @@ impl<const N: usize> FrameElement<N> {
 
         (*addr_of_mut!((*this.as_ptr()).frame_index)) = frame_index;
         (*addr_of_mut!((*this.as_ptr()).pdu_payload_len)) = 0;
-        (*addr_of_mut!((*this.as_ptr()).pdu_count)) = 0;
 
         Ok(this)
     }


### PR DESCRIPTION
- Remove unused field from `FrameElement`, saving a few bytes in the resulting binary
- Change `pdu_loop` benchmark to measure Ethernet frame throughput. Previously this was only measuring payload throughput, but IMO the total throughput is what matters when considering performance for e.g. EtherCAT G (1Gbit)

  Benchmarking on an M1 MacBook Air sees 73MiB/sec or ~600mbit. Still a ways to go if somebody wants to saturate gigabit Ethernet, but decently close.