### PR TITLE
Remove a bunch of panicking indexing operations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ miri_steps: &miri_steps
         key: v8-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
 
     # Arbitrary nightly version - just the latest at time of writing. This can be changed freely.
-    - run: rustup toolchain add nightly-2024-03-08 --target $TARGET --component miri
+    - run: rustup toolchain add nightly-2024-07-13 --target $TARGET --component miri
     - run: |
         binaries=( "cargo-nextest" )
 
@@ -65,9 +65,8 @@ miri_steps: &miri_steps
           fi
         done
     - run: |
-        export MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation"
-
-        cargo +nightly-2024-03-08 miri nextest run --features '__internals' --target $TARGET --test-threads=num-cpus
+        MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation" \
+        cargo +nightly-2024-07-13 miri nextest run --features '__internals' --target $TARGET --test-threads=num-cpus
 
     - save_cache:
         key: v8-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}

--- a/ethercrab-wire-derive/src/generate_struct.rs
+++ b/ethercrab-wire-derive/src/generate_struct.rs
@@ -113,20 +113,20 @@ pub fn generate_struct_read(parsed: &StructMeta, input: &DeriveInput) -> proc_ma
 
             if ty_name == "bool" {
                 quote! {
-                    #name: ((buf[#byte_start] & #mask) >> #bit_start) > 0
+                    #name: ((buf.get(#byte_start).ok_or(::ethercrab_wire::WireError::ReadBufferTooShort)? & #mask) >> #bit_start) > 0
                 }
             }
             // Small optimisation
             else if ty_name == "u8" {
                 quote! {
-                    #name: (buf[#byte_start] & #mask) >> #bit_start
+                    #name: (buf.get(#byte_start).ok_or(::ethercrab_wire::WireError::ReadBufferTooShort)? & #mask) >> #bit_start
                 }
             }
             // Anything else will be a struct or an enum
             else {
                 quote! {
                     #name: {
-                        let masked = (buf[#byte_start] & #mask) >> #bit_start;
+                        let masked = (buf.get(#byte_start).ok_or(::ethercrab_wire::WireError::ReadBufferTooShort)? & #mask) >> #bit_start;
 
                         <#ty as ::ethercrab_wire::EtherCrabWireRead>::unpack_from_slice(&[masked])?
                     }
@@ -139,7 +139,7 @@ pub fn generate_struct_read(parsed: &StructMeta, input: &DeriveInput) -> proc_ma
             let end_byte = field.bytes.end;
 
             quote! {
-                #name: <#ty as ::ethercrab_wire::EtherCrabWireRead>::unpack_from_slice(&buf[#start_byte..#end_byte])?
+                #name: <#ty as ::ethercrab_wire::EtherCrabWireRead>::unpack_from_slice(buf.get(#start_byte..#end_byte).ok_or(::ethercrab_wire::WireError::ReadBufferTooShort)?)?
             }
         }
     });

--- a/ethercrab-wire/src/impls.rs
+++ b/ethercrab-wire/src/impls.rs
@@ -166,7 +166,7 @@ impl EtherCrabWireRead for bool {
     fn unpack_from_slice(buf: &[u8]) -> Result<Self, WireError> {
         // NOTE: ETG1000.6 5.2.2 states the truthy value is 0xff and false is 0. We'll just check
         // for greater than zero to be sure.
-        Ok(*buf.get(0).ok_or(WireError::ReadBufferTooShort)? > 0)
+        Ok(*buf.first().ok_or(WireError::ReadBufferTooShort)? > 0)
     }
 }
 

--- a/src/ds402.rs
+++ b/src/ds402.rs
@@ -13,6 +13,7 @@ use crate::{
     fmt,
     slave::{pdi::SlavePdi, SlaveRef},
 };
+use ethercrab_wire::EtherCrabWireRead;
 
 smlang::statemachine! {
     transitions: {
@@ -137,7 +138,7 @@ impl<'a> Ds402<'a> {
 
     /// Get the DS402 status word.
     pub fn status_word(&self) -> StatusWord {
-        let status = u16::from_le_bytes(fmt::unwrap!(self.slave.inputs_raw()[0..=1].try_into()));
+        let status = fmt::unwrap!(u16::unpack_from_slice(self.slave.inputs_raw()));
 
         StatusWord::from_bits_truncate(status)
     }

--- a/src/eeprom/mod.rs
+++ b/src/eeprom/mod.rs
@@ -102,7 +102,7 @@ where
         // Advance by one byte
         self.pos += 1;
 
-        res.get(skip).map(|res| *res).ok_or(Error::Internal)
+        res.get(skip).copied().ok_or(Error::Internal)
     }
 }
 

--- a/src/eeprom/mod.rs
+++ b/src/eeprom/mod.rs
@@ -102,7 +102,7 @@ where
         // Advance by one byte
         self.pos += 1;
 
-        Ok(res[skip])
+        res.get(skip).map(|res| *res).ok_or(Error::Internal)
     }
 }
 
@@ -126,7 +126,9 @@ where
 
         // We can't read past the end of the chunk, so clamp the buffer's length to the remaining
         // part of the chunk if necessary.
-        let mut buf = &mut buf[0..requested_read_len.min(max_read)];
+        let mut buf = buf
+            .get_mut(0..requested_read_len.min(max_read))
+            .ok_or(Error::Internal)?;
 
         self.reader.clear_errors().await?;
 
@@ -140,7 +142,7 @@ where
             let skip = usize::from(self.pos % 2);
 
             // Fix any odd addressing offsets
-            let chunk = &chunk[skip..];
+            let chunk = chunk.get(skip..).ok_or(Error::Internal)?;
 
             // Buffer is full after reading this chunk into it. We're done.
             if buf.len() < chunk.len() {

--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -707,7 +707,7 @@ impl EtherCrabWireSized for MailboxProtocols {
 impl EtherCrabWireRead for MailboxProtocols {
     fn unpack_from_slice(buf: &[u8]) -> Result<Self, ethercrab_wire::WireError> {
         // NOTE: Is actually a u16, but only the lower byte has any data in it
-        buf.get(0)
+        buf.first()
             .ok_or(ethercrab_wire::WireError::ReadBufferTooShort)
             .and_then(|res| Self::from_bits(*res).ok_or(ethercrab_wire::WireError::InvalidValue))
     }

--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -707,7 +707,9 @@ impl EtherCrabWireSized for MailboxProtocols {
 impl EtherCrabWireRead for MailboxProtocols {
     fn unpack_from_slice(buf: &[u8]) -> Result<Self, ethercrab_wire::WireError> {
         // NOTE: Is actually a u16, but only the lower byte has any data in it
-        Self::from_bits(buf[0]).ok_or(ethercrab_wire::WireError::InvalidValue)
+        buf.get(0)
+            .ok_or(ethercrab_wire::WireError::ReadBufferTooShort)
+            .and_then(|res| Self::from_bits(*res).ok_or(ethercrab_wire::WireError::InvalidValue))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,6 @@
 #![deny(trivial_casts)]
 #![deny(trivial_numeric_casts)]
 #![deny(unused_import_braces)]
-#![deny(unused_qualifications)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
 #![doc(

--- a/src/pdu_loop/frame_element/received_frame.rs
+++ b/src/pdu_loop/frame_element/received_frame.rs
@@ -44,11 +44,19 @@ impl<'sto> ReceivedFrame<'sto> {
             return Err(Error::Pdu(PduError::InvalidIndex(pdu_header.index)));
         }
 
-        let payload_ptr =
-            unsafe { NonNull::new_unchecked(buf[PduHeader::PACKED_LEN..].as_ptr().cast_mut()) };
+        let payload_ptr = unsafe {
+            NonNull::new_unchecked(
+                buf.get(PduHeader::PACKED_LEN..)
+                    .ok_or(Error::Internal)?
+                    .as_ptr()
+                    .cast_mut(),
+            )
+        };
 
-        let working_counter =
-            u16::unpack_from_slice(&buf[(PduHeader::PACKED_LEN + payload_len)..])?;
+        let working_counter = u16::unpack_from_slice(
+            buf.get((PduHeader::PACKED_LEN + payload_len)..)
+                .ok_or(Error::Internal)?,
+        )?;
 
         Ok(ReceivedPdu {
             data_start: payload_ptr,
@@ -71,7 +79,7 @@ impl<'sto> ReceivedFrame<'sto> {
             let this_pdu_len = PduHeader::PACKED_LEN + payload_len + 2;
 
             // Start buffer at beginning of next PDU
-            buf = &buf[this_pdu_len..];
+            buf = buf.get(this_pdu_len..).ok_or(Error::Internal)?;
         }
 
         // This checks for buffer min length
@@ -93,11 +101,19 @@ impl<'sto> ReceivedFrame<'sto> {
             return Err(Error::Pdu(PduError::TooLong));
         }
 
-        let payload_ptr =
-            unsafe { NonNull::new_unchecked(buf[PduHeader::PACKED_LEN..].as_ptr().cast_mut()) };
+        let payload_ptr = unsafe {
+            NonNull::new_unchecked(
+                buf.get(PduHeader::PACKED_LEN..)
+                    .ok_or(Error::Internal)?
+                    .as_ptr()
+                    .cast_mut(),
+            )
+        };
 
-        let working_counter =
-            u16::unpack_from_slice(&buf[(PduHeader::PACKED_LEN + payload_len)..])?;
+        let working_counter = u16::unpack_from_slice(
+            buf.get((PduHeader::PACKED_LEN + payload_len)..)
+                .ok_or(Error::Internal)?,
+        )?;
 
         Ok(ReceivedPdu {
             data_start: payload_ptr,

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -90,7 +90,7 @@ impl<'sto> PduLoop<'sto> {
             false,
         )?;
 
-        let frame = frame.mark_sendable(&self, timeout, retries);
+        let frame = frame.mark_sendable(self, timeout, retries);
 
         self.wake_sender();
 

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -73,7 +73,7 @@ impl<'sto> PduRx<'sto> {
         // their headers and payloads.
 
         // Second byte of first PDU header is the index
-        let pdu_idx = i[1];
+        let pdu_idx = *i.get(1).ok_or(Error::Internal)?;
 
         // We're assuming all PDUs in the returned frame have the same frame index, so we can just
         // use the first one.
@@ -97,7 +97,10 @@ impl<'sto> PduRx<'sto> {
 
         let frame_data = frame.buf_mut();
 
-        frame_data[0..i.len()].copy_from_slice(i);
+        frame_data
+            .get_mut(0..i.len())
+            .ok_or(Error::Internal)?
+            .copy_from_slice(i);
 
         frame.mark_received()?;
 

--- a/src/slave/eeprom.rs
+++ b/src/slave/eeprom.rs
@@ -310,14 +310,14 @@ where
             if string_len > N {
                 return Err(Error::StringTooLong {
                     max_length: N,
-                    string_length: string_len.into(),
+                    string_length: string_len,
                 });
             }
 
             let mut buf = heapless::Vec::<u8, N>::new();
 
             // SAFETY: We MUST ensure that `string_len` is less than `N`
-            unsafe { buf.set_len(usize::from(string_len)) }
+            unsafe { buf.set_len(string_len) }
 
             reader.read_exact(&mut buf).await?;
 

--- a/src/slave/eeprom.rs
+++ b/src/slave/eeprom.rs
@@ -166,7 +166,8 @@ where
             // Read entire category using its discovered length.
             let fmmus = reader.read(&mut buf).await?;
 
-            buf[0..fmmus]
+            buf.get(0..fmmus)
+                .ok_or(Error::Internal)?
                 .iter()
                 .map(|raw| {
                     FmmuUsage::try_from(*raw).map_err(|e| {

--- a/src/slave_group/mod.rs
+++ b/src/slave_group/mod.rs
@@ -758,14 +758,18 @@ where
         let inputs = if input_range.is_empty() {
             EMPTY_PDI_SLICE
         } else {
-            &i_data[input_range.bytes.clone()]
+            i_data
+                .get(input_range.bytes.clone())
+                .ok_or(Error::Internal)?
         };
 
         let outputs = if output_range.is_empty() {
             // SAFETY: Slice is empty so can never be mutated
             unsafe { slice::from_raw_parts_mut(EMPTY_PDI_SLICE.as_ptr().cast_mut(), 0) }
         } else {
-            &mut o_data[output_range.bytes.clone()]
+            o_data
+                .get_mut(output_range.bytes.clone())
+                .ok_or(Error::Internal)?
         };
 
         Ok(SlaveRef::new(
@@ -926,7 +930,10 @@ where
 
         let wkc = data.working_counter;
 
-        self.pdi_mut()[0..self.read_pdi_len].copy_from_slice(&data[0..self.read_pdi_len]);
+        self.pdi_mut()
+            .get_mut(0..self.read_pdi_len)
+            .ok_or(Error::Internal)?
+            .copy_from_slice(data.get(0..self.read_pdi_len).ok_or(Error::Internal)?);
 
         Ok(wkc)
     }

--- a/src/std/unix/mod.rs
+++ b/src/std/unix/mod.rs
@@ -77,7 +77,7 @@ impl Future for TxRxFut<'_> {
                 // is removed, PDU response frames are missed, causing timeout errors.
                 ctx.waker().wake_by_ref();
 
-                let packet = &buf[0..n];
+                let packet = buf.get(0..n).ok_or(Error::Internal)?;
 
                 if n == 0 {
                     fmt::warn!("Received zero bytes");


### PR DESCRIPTION
Discovered and fixed by temporarily adding `#![deny(clippy::indexing_slicing)]` (https://rust-lang.github.io/rust-clippy/master/index.html#/indexing_slicing). Allows more graceful error handling.

Slight binary size reduction:

`master`

```
   text    data     bss     dec     hex filename
  89768     112   57288  147168   23ee0 ethercrab-stm32-embassy
```

This branch:

```
   text    data     bss     dec     hex filename
  88800     112   57288  146200   23b18 ethercrab-stm32-embassy
```

Performance is unchanged.

Also added a few general clippy fixes to this PR.