### PR TITLE
Actually benchmark large struct ser/de

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -906,7 +906,7 @@ sudo setcap cap_net_raw=pe ./target/profiling/examples/<example name>
 sudo perf record --call-graph=dwarf -g ./target/profiling/examples/<example name> <example args>
 
 # To record benchmarks
-sudo perf record --call-graph=dwarf -g -o bench.data ./target/release/deps/pdu_loop-597b19205907e408 --baseline master --bench
+sudo perf record --call-graph=dwarf -g -o bench.data ./target/release/deps/pdu_loop-597b19205907e408 --bench --profile-time 5 'bench filter here'
 
 # Ctrl + C when you're done
 
@@ -915,7 +915,7 @@ sudo perf report -i perf.data
 
 # This won't show kernel symbols (possibly only when over SSH?)
 sudo chown $USER perf.data
-samply load perf.data
+samply import perf.data
 
 # Forward the port on a remote machine with
 ssh -L 3000:localhost:3000 ethercrab

--- a/ethercrab-wire-derive/benches/derive-large.rs
+++ b/ethercrab-wire-derive/benches/derive-large.rs
@@ -111,10 +111,10 @@ pub fn nested(c: &mut Criterion) {
     ];
 
     c.bench_function("nested struct unpack", |b| {
-        b.iter(|| NormalTypes::unpack_from_slice(black_box(&input_data)))
+        b.iter(|| LotsOfNesting::unpack_from_slice(black_box(&input_data)))
     });
 
-    let instance = NormalTypes::unpack_from_slice(&input_data).unwrap();
+    let instance = LotsOfNesting::unpack_from_slice(&input_data).unwrap();
 
     c.bench_function("nested struct pack array", |b| {
         b.iter(|| black_box(instance.pack()))


### PR DESCRIPTION
Previously, this benchmark was only running a subset of the defined types due to a copy paste error.