### PR TITLE
Remove `smoltcp`, copy and strip down SmolTCP ethernet types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,6 @@ log = { version = "0.4.20", optional = true, default-features = false }
 sealed = "0.5.0"
 serde = { version = "1.0.190", features = ["derive"], optional = true }
 smlang = "0.6.0"
-smoltcp = { version = "0.11.0", default-features = false, features = [
-    "proto-ipv4",
-    "socket-raw",
-    "medium-ethernet",
-] }
 ethercrab-wire = { version = "0.1.4", path = "./ethercrab-wire" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -85,7 +80,6 @@ anyhow = "1.0.82"
 default = ["std"]
 defmt = [
     "dep:defmt",
-    "smoltcp/defmt",
     "embedded-io-async/defmt-03",
     "heapless/defmt-03",
     "ethercrab-wire/defmt-03",
@@ -94,7 +88,6 @@ log = ["dep:log"]
 std = [
     "dep:pnet_datalink",
     "dep:async-io",
-    "smoltcp/phy-raw_socket",
     "log",
     "futures-lite/std",
     "embedded-io-async/std",

--- a/src/error.rs
+++ b/src/error.rs
@@ -423,18 +423,6 @@ impl From<PduValidationError> for PduError {
     }
 }
 
-impl From<smoltcp::wire::Error> for PduError {
-    fn from(_: smoltcp::wire::Error) -> Self {
-        Self::Ethernet
-    }
-}
-
-impl From<smoltcp::wire::Error> for Error {
-    fn from(e: smoltcp::wire::Error) -> Self {
-        Self::Pdu(e.into())
-    }
-}
-
 impl From<TryFromIntError> for Error {
     fn from(_e: TryFromIntError) -> Self {
         fmt::error!("Integer conversion error");

--- a/src/ethernet.rs
+++ b/src/ethernet.rs
@@ -1,0 +1,209 @@
+//! Ethernet frame, copied from SmolTCP,
+//! [here](https://github.com/smoltcp-rs/smoltcp/blob/53caf70f640d5ccb3cd1492e1cb178bc7dfa3cdd/src/wire/ethernet.rs)
+//! at time of writing.
+//!
+//! Then drastically modified/stripped down to suit EtherCrab's needs.
+
+use core::fmt;
+
+use crate::error::{Error, PduError};
+
+/// A six-octet Ethernet II address.
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
+pub struct EthernetAddress(pub [u8; 6]);
+
+impl EthernetAddress {
+    /// The broadcast address.
+    pub const BROADCAST: EthernetAddress = EthernetAddress([0xff; 6]);
+
+    /// Construct an Ethernet address from a sequence of octets, in big-endian.
+    ///
+    /// # Panics
+    /// The function panics if `data` is not six octets long.
+    pub fn from_bytes(data: &[u8]) -> EthernetAddress {
+        let mut bytes = [0; 6];
+        bytes.copy_from_slice(data);
+        EthernetAddress(bytes)
+    }
+
+    /// Return an Ethernet address as a sequence of octets, in big-endian.
+    pub const fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl fmt::Display for EthernetAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let bytes = self.0;
+        write!(
+            f,
+            "{:02x}-{:02x}-{:02x}-{:02x}-{:02x}-{:02x}",
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5]
+        )
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for EthernetAddress {
+    fn format(&self, fmt: defmt::Formatter) {
+        let bytes = self.0;
+        defmt::write!(
+            fmt,
+            "{:02x}-{:02x}-{:02x}-{:02x}-{:02x}-{:02x}",
+            bytes[0],
+            bytes[1],
+            bytes[2],
+            bytes[3],
+            bytes[4],
+            bytes[5]
+        )
+    }
+}
+
+/// A read/write wrapper around an Ethernet II frame buffer.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct EthernetFrame<T: AsRef<[u8]>> {
+    buffer: T,
+}
+
+mod field {
+    use core::ops::{Range, RangeFrom};
+
+    pub const DESTINATION: Range<usize> = 0..6;
+    pub const SOURCE: Range<usize> = 6..12;
+    pub const ETHERTYPE: Range<usize> = 12..14;
+    pub const PAYLOAD: RangeFrom<usize> = 14..;
+}
+
+/// The Ethernet header length
+pub const ETHERNET_HEADER_LEN: usize = field::PAYLOAD.start;
+
+impl<T: AsRef<[u8]>> EthernetFrame<T> {
+    /// Imbue a raw octet buffer with Ethernet frame structure.
+    pub const fn new_unchecked(buffer: T) -> EthernetFrame<T> {
+        EthernetFrame { buffer }
+    }
+
+    /// Shorthand for a combination of [new_unchecked] and [check_len].
+    ///
+    /// [new_unchecked]: #method.new_unchecked
+    /// [check_len]: #method.check_len
+    pub fn new_checked(buffer: T) -> Result<EthernetFrame<T>, Error> {
+        let packet = Self::new_unchecked(buffer);
+        packet.check_len()?;
+        Ok(packet)
+    }
+
+    /// Ensure that no accessor method will panic if called.
+    /// Returns `Err(Error)` if the buffer is too short.
+    pub fn check_len(&self) -> Result<(), Error> {
+        let len = self.buffer.as_ref().len();
+        if len < ETHERNET_HEADER_LEN {
+            Err(Error::Pdu(PduError::Ethernet))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Consumes the frame, returning the underlying buffer.
+    pub fn into_inner(self) -> T {
+        self.buffer
+    }
+
+    /// Return the length of a frame header.
+    pub const fn header_len() -> usize {
+        ETHERNET_HEADER_LEN
+    }
+
+    /// Return the length of a buffer required to hold a packet with the payload
+    /// of a given length.
+    pub const fn buffer_len(payload_len: usize) -> usize {
+        ETHERNET_HEADER_LEN + payload_len
+    }
+
+    /// Return the destination address field.
+    #[inline]
+    pub fn dst_addr(&self) -> EthernetAddress {
+        let data = self.buffer.as_ref();
+        EthernetAddress::from_bytes(&data[field::DESTINATION])
+    }
+
+    /// Return the source address field.
+    #[inline]
+    pub fn src_addr(&self) -> EthernetAddress {
+        let data = self.buffer.as_ref();
+        EthernetAddress::from_bytes(&data[field::SOURCE])
+    }
+
+    /// Return the EtherType field, without checking for 802.1Q.
+    #[inline]
+    pub fn ethertype(&self) -> u16 {
+        let data = self.buffer.as_ref();
+
+        // Ethernet is big-endian
+        data.get(field::ETHERTYPE)
+            .map(|res| u16::from_be_bytes(res.try_into().unwrap()))
+            // EtherCrab only really cares whether the ethertype is 0x88a4, so defaulting to zero on
+            // unparseable ethertypes is fine here (imo, lol)
+            .unwrap_or(0)
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> EthernetFrame<&'a T> {
+    /// Return a pointer to the payload, without checking for 802.1Q.
+    #[inline]
+    pub fn payload(&self) -> &'a [u8] {
+        let data = self.buffer.as_ref();
+        &data[field::PAYLOAD]
+    }
+}
+
+impl<T: AsRef<[u8]> + AsMut<[u8]>> EthernetFrame<T> {
+    /// Set the destination address field.
+    #[inline]
+    pub fn set_dst_addr(&mut self, value: EthernetAddress) {
+        let data = self.buffer.as_mut();
+        data[field::DESTINATION].copy_from_slice(value.as_bytes())
+    }
+
+    /// Set the source address field.
+    #[inline]
+    pub fn set_src_addr(&mut self, value: EthernetAddress) {
+        let data = self.buffer.as_mut();
+        data[field::SOURCE].copy_from_slice(value.as_bytes())
+    }
+
+    /// Set the EtherType field.
+    #[inline]
+    pub fn set_ethertype(&mut self, value: u16) {
+        let data = self.buffer.as_mut();
+
+        data[field::ETHERTYPE].copy_from_slice(&value.to_be_bytes());
+    }
+
+    /// Return a mutable pointer to the payload.
+    #[inline]
+    pub fn payload_mut(&mut self) -> &mut [u8] {
+        let data = self.buffer.as_mut();
+        &mut data[field::PAYLOAD]
+    }
+}
+
+impl<T: AsRef<[u8]>> AsRef<[u8]> for EthernetFrame<T> {
+    fn as_ref(&self) -> &[u8] {
+        self.buffer.as_ref()
+    }
+}
+
+impl<T: AsRef<[u8]>> fmt::Display for EthernetFrame<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "EthernetII src={} dst={} type={}",
+            self.src_addr(),
+            self.dst_addr(),
+            self.ethertype()
+        )
+    }
+}

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -5,4 +5,5 @@
 pub use crate::eeprom::device_reader::DeviceEeprom;
 pub use crate::eeprom::ChunkReader;
 pub use crate::eeprom::EepromDataProvider;
+pub use crate::ethernet::{EthernetAddress, EthernetFrame};
 pub use crate::pdu_loop::{EthercatFrameHeader, PduHeader};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,7 @@ mod dl_status;
 pub mod ds402;
 mod eeprom;
 pub mod error;
+mod ethernet;
 mod fmmu;
 mod generate;
 mod mailbox;
@@ -195,8 +196,6 @@ pub mod internals;
 #[cfg(feature = "std")]
 pub mod std;
 
-use smoltcp::wire::{EthernetAddress, EthernetProtocol};
-
 pub use al_status_code::AlStatusCode;
 pub use client::Client;
 pub use client_config::{ClientConfig, RetryBehaviour};
@@ -206,6 +205,7 @@ pub use ethercrab_wire::{
     EtherCrabWireRead, EtherCrabWireReadSized, EtherCrabWireReadWrite, EtherCrabWireSized,
     EtherCrabWireWrite, EtherCrabWireWriteSized,
 };
+use ethernet::EthernetAddress;
 pub use pdu_loop::{PduLoop, PduRx, PduStorage, PduTx, SendableFrame};
 pub use register::{DcSupport, RegisterAddress};
 pub use slave::{DcSync, Slave, SlaveIdentity, SlavePdi, SlaveRef};
@@ -214,8 +214,7 @@ pub use slave_state::SlaveState;
 pub use timer_factory::Timeouts;
 
 const LEN_MASK: u16 = 0b0000_0111_1111_1111;
-const ETHERCAT_ETHERTYPE_RAW: u16 = 0x88a4;
-const ETHERCAT_ETHERTYPE: EthernetProtocol = EthernetProtocol::Unknown(ETHERCAT_ETHERTYPE_RAW);
+const ETHERCAT_ETHERTYPE: u16 = 0x88a4;
 const MASTER_ADDR: EthernetAddress = EthernetAddress([0x10, 0x10, 0x10, 0x10, 0x10, 0x10]);
 
 /// Starting address for discovered slaves.

--- a/src/pdu_loop/frame_element/frame_box.rs
+++ b/src/pdu_loop/frame_element/frame_box.rs
@@ -1,4 +1,5 @@
 use crate::{
+    ethernet::{EthernetAddress, EthernetFrame},
     pdu_loop::{
         frame_element::{FrameElement, FrameState},
         frame_header::EthercatFrameHeader,
@@ -14,7 +15,6 @@ use core::{
     task::Waker,
 };
 use ethercrab_wire::EtherCrabWireSized;
-use smoltcp::wire::{EthernetAddress, EthernetFrame};
 
 use super::FIRST_PDU_EMPTY;
 

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -4,14 +4,15 @@ pub mod received_frame;
 pub mod receiving_frame;
 pub mod sendable_frame;
 
-use crate::{error::PduError, fmt, pdu_loop::frame_header::EthercatFrameHeader};
+use crate::{
+    error::PduError, ethernet::EthernetFrame, fmt, pdu_loop::frame_header::EthercatFrameHeader,
+};
 use atomic_waker::AtomicWaker;
 use core::{
     ptr::{addr_of, addr_of_mut, NonNull},
     sync::atomic::{AtomicU16, Ordering},
 };
 use frame_box::FrameBox;
-use smoltcp::wire::EthernetFrame;
 
 /// A marker value for empty frames with no pushed PDUs.
 ///

--- a/src/pdu_loop/frame_element/receiving_frame.rs
+++ b/src/pdu_loop/frame_element/receiving_frame.rs
@@ -115,9 +115,8 @@ impl<'sto> ReceiveFrameFut<'sto> {
     /// Get entire frame buffer. Only really useful for assertions in tests.
     #[cfg(test)]
     pub fn buf(&self) -> &[u8] {
-        use crate::pdu_loop::frame_header::EthercatFrameHeader;
+        use crate::{ethernet::EthernetFrame, pdu_loop::frame_header::EthercatFrameHeader};
         use ethercrab_wire::EtherCrabWireSized;
-        use smoltcp::wire::EthernetFrame;
 
         let frame = self.frame.as_ref().unwrap();
 

--- a/src/pdu_loop/frame_element/sendable_frame.rs
+++ b/src/pdu_loop/frame_element/sendable_frame.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::Error,
+    ethernet::EthernetFrame,
     fmt,
     pdu_loop::{
         frame_element::{FrameBox, FrameElement, FrameState},
@@ -8,7 +9,6 @@ use crate::{
 };
 use core::{ptr::NonNull, sync::atomic::AtomicU8};
 use ethercrab_wire::EtherCrabWireSized;
-use smoltcp::wire::EthernetFrame;
 
 /// An EtherCAT frame that is ready to be sent over the network.
 ///

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -106,6 +106,7 @@ impl<'sto> PduLoop<'sto> {
 
 #[cfg(test)]
 mod tests {
+    use crate::ethernet::{EthernetAddress, EthernetFrame};
     use crate::{
         error::{Error, PduError},
         fmt,
@@ -116,7 +117,6 @@ mod tests {
     use cassette::Cassette;
     use core::{future::poll_fn, ops::Deref, pin::pin, task::Poll, time::Duration};
     use futures_lite::Future;
-    use smoltcp::wire::{EthernetAddress, EthernetFrame};
     use std::{sync::Arc, thread};
 
     #[test]

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -1,4 +1,5 @@
 use super::storage::PduStorageRef;
+use crate::ethernet::{EthernetAddress, EthernetFrame};
 use crate::{
     error::{Error, PduError},
     fmt,
@@ -6,7 +7,6 @@ use crate::{
     ETHERCAT_ETHERTYPE, MASTER_ADDR,
 };
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
-use smoltcp::wire::{EthernetAddress, EthernetFrame};
 
 /// EtherCAT frame receive adapter.
 pub struct PduRx<'sto> {

--- a/src/pdu_loop/storage.rs
+++ b/src/pdu_loop/storage.rs
@@ -1,4 +1,5 @@
 use super::{frame_header::EthercatFrameHeader, pdu_rx::PduRx, pdu_tx::PduTx};
+use crate::ethernet::EthernetFrame;
 use crate::{
     error::{Error, PduError},
     fmt,
@@ -20,7 +21,6 @@ use core::{
     sync::atomic::{AtomicBool, AtomicU8, Ordering},
 };
 use ethercrab_wire::EtherCrabWireSized;
-use smoltcp::wire::EthernetFrame;
 
 /// Smallest frame size with a data payload of 0 length
 const MIN_DATA: usize = EthernetFrame::<&[u8]>::buffer_len(

--- a/src/std/unix/bpf.rs
+++ b/src/std/unix/bpf.rs
@@ -4,11 +4,11 @@
 //! handling multiple frames. Thank you, SmolTCP maintainers!
 
 use crate::{
+    ethernet::{EthernetAddress, ETHERNET_HEADER_LEN},
     fmt,
     std::unix::{ifreq, ifreq_for},
 };
 use async_io::IoSafe;
-use smoltcp::wire::{EthernetAddress, ETHERNET_HEADER_LEN};
 use std::{
     io, mem,
     os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd},

--- a/src/std/unix/linux.rs
+++ b/src/std/unix/linux.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     std::unix::{ifreq, ifreq_for},
-    ETHERCAT_ETHERTYPE_RAW,
+    ETHERCAT_ETHERTYPE,
 };
 use async_io::IoSafe;
 use core::ptr::addr_of;
@@ -22,7 +22,7 @@ pub struct RawSocketDesc {
 
 impl RawSocketDesc {
     pub fn new(name: &str) -> io::Result<Self> {
-        let protocol = ETHERCAT_ETHERTYPE_RAW as i16;
+        let protocol = ETHERCAT_ETHERTYPE as i16;
 
         let lower = unsafe {
             let lower = libc::socket(
@@ -48,7 +48,7 @@ impl RawSocketDesc {
     }
 
     fn bind_interface(&mut self) -> io::Result<()> {
-        let protocol = ETHERCAT_ETHERTYPE_RAW as i16;
+        let protocol = ETHERCAT_ETHERTYPE as i16;
 
         let sockaddr = libc::sockaddr_ll {
             sll_family: libc::AF_PACKET as u16,

--- a/src/std/windows.rs
+++ b/src/std/windows.rs
@@ -1,12 +1,12 @@
 //! Items to use when not in `no_std` environments.
 
+use crate::ethernet::EthernetFrame;
 use crate::{
     error::Error,
     pdu_loop::{PduRx, PduTx},
 };
 use core::future::Future;
 use pnet_datalink::{self, channel, Channel, DataLinkReceiver, DataLinkSender};
-use smoltcp::wire::EthernetFrame;
 use std::{thread, time::SystemTime};
 
 /// Get a TX/RX pair.

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -2,13 +2,12 @@
 
 use ethercrab::{
     error::Error,
-    internals::{EthercatFrameHeader, PduHeader},
+    internals::{EthercatFrameHeader, EthernetAddress, EthernetFrame, PduHeader},
     std::tx_rx_task,
     PduRx, PduTx,
 };
 use ethercrab_wire::EtherCrabWireRead;
 use pcap_file::pcapng::{Block, PcapNgReader};
-use smoltcp::wire::{EthernetAddress, EthernetFrame};
 use std::{
     collections::{HashMap, VecDeque},
     fs::File,


### PR DESCRIPTION
I really like `smoltcp`, but it turns out I'm only using two types out of it, so it doesn't make much sense to include the whole dependency. This also frees up #162 to be merged, which is a nice bonus :)