### PR TITLE
Fix overflowing subtraction when calculating DC cycle offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ An EtherCAT master written in Rust.
 - **(breaking)** [#230](https://github.com/ethercrab-rs/ethercrab/pull/230) Increase MSRV from 1.77
   to 1.79.
 
+### Fixed
+
+- [#229](https://github.com/ethercrab-rs/ethercrab/pull/229) Fix overflowing subtraction panic when
+  calculating DC cycle offset.
+
 ## [0.5.0] - 2024-07-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ atomic_enum = "0.3.0"
 atomic_refcell = "0.1.13"
 bitflags = "2.4.1"
 defmt = { version = "0.3.5", optional = true }
-embassy-time = "0.3.0"
+embassy-time = "0.3.2"
 embedded-io-async = { version = "0.6.0", default-features = false }
 futures-lite = { version = "2.0.0", default-features = false }
 heapless = "0.8.0"

--- a/src/subdevice_group/mod.rs
+++ b/src/subdevice_group/mod.rs
@@ -1131,7 +1131,7 @@ where
         let cycle_start_offset = time % self.dc_conf.sync0_period;
 
         let time_to_next_iter =
-            self.dc_conf.sync0_period + (self.dc_conf.sync0_shift - cycle_start_offset);
+            (self.dc_conf.sync0_period - cycle_start_offset) + self.dc_conf.sync0_shift;
 
         Ok((
             wkc,


### PR DESCRIPTION
This was originally fixed by @jabratn in [this commit on their fork](https://github.com/ethercrab-rs/ethercrab/commit/8a24b009dca6fedf90a9d69efff346d955d1e464). I hope you don't mind me taking the fix! I've added the `Co-Authored-By` header to give due credit.

Tested on my EK1100 setup which panics on overflow when on `master`, but doesn't on this branch (but still calculates the offset correctly).