### PR TITLE
Bump Rust MSRV to 1.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- **(breaking)** [#230](https://github.com/ethercrab-rs/ethercrab/pull/230) Increase MSRV from 1.77
+  to 1.79.
+
 ## [0.5.0] - 2024-07-28
 
 ### Changed
@@ -421,8 +426,8 @@ An EtherCAT master written in Rust.
 - Initial release
 
 <!-- next-url -->
-[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.5.0...HEAD
 
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.5.0...HEAD
 [0.5.0]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.4.2...ethercrab-v0.5.0
 [0.4.2]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.4.1...ethercrab-v0.4.2
 [0.4.1]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.4.0...ethercrab-v0.4.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "An EtherCAT master in pure Rust that is no_std compatible"
 keywords = ["ethercat", "beckhoff", "automation", "fieldbus", "soem"]
 exclude = ["dumps", "doc", "NOTES.md", "SPECNOTES.md"]
 resolver = "2"
-rust-version = "1.75"
+rust-version = "1.79"
 
 [workspace]
 members = ["ethercrab-wire", "ethercrab-wire-derive"]

--- a/ethercrab-wire-derive/CHANGELOG.md
+++ b/ethercrab-wire-derive/CHANGELOG.md
@@ -6,6 +6,11 @@ Derives for `ethercrab`.
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- **(breaking)** [#230](https://github.com/ethercrab-rs/ethercrab/pull/230) Increase MSRV from 1.77
+  to 1.79.
+
 ## [0.2.0] - 2024-07-28
 
 ## [0.1.4] - 2024-03-31
@@ -39,10 +44,12 @@ Derives for `ethercrab`.
 - Initial release
 
 <!-- next-url -->
-[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-derive-v0.2.0...HEAD
-[0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-derive-v0.1.4...ethercrab-wire-derive-v0.2.0
 
-[0.1.4]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-derive-v0.1.3...ethercrab-wire-derive-v0.1.4
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-derive-v0.2.0...HEAD
+[0.2.0]:
+  https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-derive-v0.1.4...ethercrab-wire-derive-v0.2.0
+[0.1.4]:
+  https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-derive-v0.1.3...ethercrab-wire-derive-v0.1.4
 [0.1.3]:
   https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-derive-v0.1.2...ethercrab-wire-derive-v0.1.3
 [0.1.2]:

--- a/ethercrab-wire-derive/Cargo.toml
+++ b/ethercrab-wire-derive/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/ethercrab-derive"
 description = "Derive macros for EtherCrab"
 resolver = "2"
 keywords = ["ethercat", "ethercrab", "beckhoff", "automation", "fieldbus"]
+rust-version = "1.79"
 
 [lib]
 proc-macro = true

--- a/ethercrab-wire-derive/src/parse_enum.rs
+++ b/ethercrab-wire-derive/src/parse_enum.rs
@@ -20,7 +20,9 @@ pub struct VariantMeta {
     pub name: Ident,
     pub discriminant: i128,
     pub catch_all: bool,
+    #[allow(unused)]
     pub default: bool,
+    #[allow(unused)]
     pub alternatives: Vec<i128>,
 }
 

--- a/ethercrab-wire-derive/src/parse_struct.rs
+++ b/ethercrab-wire-derive/src/parse_struct.rs
@@ -12,14 +12,19 @@ pub struct StructMeta {
 
 #[derive(Clone)]
 pub struct FieldMeta {
+    #[allow(unused)]
     pub vis: Visibility,
     pub name: Ident,
     pub ty: Type,
     // Will be None for arrays
     pub ty_name: Option<Ident>,
+    #[allow(unused)]
     pub bit_start: usize,
+    #[allow(unused)]
     pub bit_end: usize,
+    #[allow(unused)]
     pub byte_start: usize,
+    #[allow(unused)]
     pub byte_end: usize,
     /// Offset of the starting bit in the starting byte.
     pub bit_offset: usize,
@@ -27,7 +32,9 @@ pub struct FieldMeta {
     pub bits: Range<usize>,
     pub bytes: Range<usize>,
 
+    #[allow(unused)]
     pub pre_skip: Option<usize>,
+    #[allow(unused)]
     pub post_skip: Option<usize>,
 
     pub skip: bool,

--- a/ethercrab-wire/CHANGELOG.md
+++ b/ethercrab-wire/CHANGELOG.md
@@ -9,6 +9,11 @@ Primarily used by `ethercrab`.
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- **(breaking)** [#230](https://github.com/ethercrab-rs/ethercrab/pull/230) Increase MSRV from 1.77
+  to 1.79.
+
 ## [0.2.0] - 2024-07-28
 
 ### Changed
@@ -43,9 +48,10 @@ Primarily used by `ethercrab`.
 - Initial release
 
 <!-- next-url -->
-[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-v0.2.0...HEAD
 
-[0.2.0]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-v0.1.4...ethercrab-wire-v0.2.0
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-v0.2.0...HEAD
+[0.2.0]:
+  https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-v0.1.4...ethercrab-wire-v0.2.0
 [0.1.4]:
   https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-wire-v0.1.3...ethercrab-wire-v0.1.4
 [0.1.3]:

--- a/ethercrab-wire/Cargo.toml
+++ b/ethercrab-wire/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/ethercrab-wire"
 description = "On-the-wire tools for the EtherCrab crate"
 keywords = ["ethercat", "ethercrab", "beckhoff", "automation", "fieldbus"]
 resolver = "2"
-rust-version = "1.75"
+rust-version = "1.79"
 
 [dependencies]
 defmt = { version = "0.3.5", optional = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77"
+channel = "1.79"
 profile = "default"
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/timer_factory.rs
+++ b/src/timer_factory.rs
@@ -26,7 +26,7 @@ impl<T, O> IntoTimeout<O> for T
 where
     T: Future<Output = Result<O, Error>>,
 {
-    fn timeout(self, timeout: Duration) -> TimeoutFuture<T> {
+    fn timeout(self, timeout: Duration) -> TimeoutFuture<impl Future<Output = Result<O, Error>>> {
         let timeout = timer(timeout);
 
         TimeoutFuture { f: self, timeout }


### PR DESCRIPTION
Mostly to support `collapse_debuginfo` in `embassy-time`.