### PR TITLE
Support up to 64 PDO entries when reading from EEPROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ An EtherCAT master written in Rust.
 
 - **(breaking)** [#230](https://github.com/ethercrab-rs/ethercrab/pull/230) Increase MSRV from 1.77
   to 1.79.
+- [#231](https://github.com/ethercrab-rs/ethercrab/pull/231) Enable reading of up to 64 PDO entries
+  per PDO from EEPROM.
 
 ### Fixed
 

--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -3,8 +3,14 @@
 use crate::{base_data_types::PrimitiveDataType, coe::SdoExpedited, sync_manager_channel};
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
 
-pub const TX_PDO_RANGE: core::ops::RangeInclusive<u16> = 0x1A00..=0x1bff;
-pub const RX_PDO_RANGE: core::ops::RangeInclusive<u16> = 0x1600..=0x17ff;
+/// Ranges defined in ETG1000.6 Table 25 – Structure Category TXPDO and RXPDO for each PDO.
+///
+/// Data sent to the MainDevice (TX from the SubDevice).
+pub const SUBDEVICE_OUTPUTS_PDO_RANGE: core::ops::RangeInclusive<u16> = 0x1A00..=0x1bff;
+/// Ranges defined in ETG1000.6 Table 25 – Structure Category TXPDO and RXPDO for each PDO.
+///
+/// Data sent to the SubDevice (RX into the SubDevice).
+pub const SUBDEVICE_INPUTS_PDO_RANGE: core::ops::RangeInclusive<u16> = 0x1600..=0x17ff;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default, ethercrab_wire::EtherCrabWireReadWrite)]
 #[repr(u8)]
@@ -244,7 +250,10 @@ pub enum CategoryType {
 /// The type of PDO to search for.
 #[derive(Debug, Copy, Clone)]
 pub enum PdoType {
+    /// SubDevice send, MainDevice receive.
     Tx = 50,
+
+    /// SubDevice receive, MainDevice send.
     Rx = 51,
 }
 

--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -3,15 +3,6 @@
 use crate::{base_data_types::PrimitiveDataType, coe::SdoExpedited, sync_manager_channel};
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
 
-/// Ranges defined in ETG1000.6 Table 25 – Structure Category TXPDO and RXPDO for each PDO.
-///
-/// Data sent to the MainDevice (TX from the SubDevice).
-pub const SUBDEVICE_OUTPUTS_PDO_RANGE: core::ops::RangeInclusive<u16> = 0x1A00..=0x1bff;
-/// Ranges defined in ETG1000.6 Table 25 – Structure Category TXPDO and RXPDO for each PDO.
-///
-/// Data sent to the SubDevice (RX into the SubDevice).
-pub const SUBDEVICE_INPUTS_PDO_RANGE: core::ops::RangeInclusive<u16> = 0x1600..=0x17ff;
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default, ethercrab_wire::EtherCrabWireReadWrite)]
 #[repr(u8)]
 pub enum SiiOwner {

--- a/src/subdevice/configuration.rs
+++ b/src/subdevice/configuration.rs
@@ -500,16 +500,16 @@ where
         direction: PdoDirection,
         offset: &mut PdiOffset,
     ) -> Result<PdiSegment, Error> {
-        let pdos: heapless::Vec<Pdo, 16> = match direction {
+        let pdos = match direction {
             PdoDirection::MasterRead => {
-                let read_pdos = self.eeprom().master_read_pdos().await?;
+                let read_pdos = self.eeprom().maindevice_read_pdos().await?;
 
                 fmt::trace!("SubDevice inputs PDOs {:#?}", read_pdos);
 
                 read_pdos
             }
             PdoDirection::MasterWrite => {
-                let write_pdos = self.eeprom().master_write_pdos().await?;
+                let write_pdos = self.eeprom().maindevice_write_pdos().await?;
 
                 fmt::trace!("SubDevice outputs PDOs {:#?}", write_pdos);
 

--- a/src/subdevice/configuration.rs
+++ b/src/subdevice/configuration.rs
@@ -2,7 +2,7 @@ use super::{SubDevice, SubDeviceRef};
 use crate::{
     coe::{SdoExpedited, SubIndex},
     eeprom::types::{
-        CoeDetails, FmmuUsage, MailboxProtocols, Pdo, SiiOwner, SyncManager, SyncManagerEnable,
+        CoeDetails, FmmuUsage, MailboxProtocols, SiiOwner, SyncManager, SyncManagerEnable,
         SyncManagerType,
     },
     error::{Error, Item},

--- a/src/subdevice/eeprom.rs
+++ b/src/subdevice/eeprom.rs
@@ -217,7 +217,7 @@ where
             // TODO: Return some kind of iterator so we don't have to have a fixed length vec
             for idx in 0..pdo.num_entries {
                 let Some(entry) = cat.next_sub_item::<PdoEntry>().await? else {
-                    log::error!("Failed to read PDO entry {}", idx);
+                    fmt::error!("Failed to read PDO entry {}", idx);
 
                     return Err(Error::Eeprom(EepromError::Decode));
                 };


### PR DESCRIPTION
This PR also stops validating PDO ranges as I think I had that logic incorrect. For example, the EL2262 has a PDO mapping of 0x1701 which was outside the checked ranges, but is valid for a fixed set of mappings.

There's also some small refactoring around reading sub-items from the EEPROM which makes the code cleaner to read.

Closes #175 