### PR TITLE
Don't check returned counter in CoE responses

### DIFF
--- a/src/coe/services.rs
+++ b/src/coe/services.rs
@@ -87,11 +87,18 @@ pub trait CoeServiceRequest:
 {
     /// Get the auto increment counter value for this request.
     fn counter(&self) -> u8;
+
+    fn validate_response(&self, received_index: u16, received_subindex: u8) -> bool;
 }
 
 impl CoeServiceRequest for SdoExpeditedDownload {
     fn counter(&self) -> u8 {
         self.headers.header.counter
+    }
+
+    fn validate_response(&self, received_index: u16, received_subindex: u8) -> bool {
+        received_index == self.headers.sdo_header.index
+            && received_subindex == self.headers.sdo_header.sub_index
     }
 }
 
@@ -99,11 +106,20 @@ impl CoeServiceRequest for SdoNormal {
     fn counter(&self) -> u8 {
         self.header.counter
     }
+
+    fn validate_response(&self, received_index: u16, received_subindex: u8) -> bool {
+        received_index == self.sdo_header.index && received_subindex == self.sdo_header.sub_index
+    }
 }
 
 impl CoeServiceRequest for SdoSegmented {
     fn counter(&self) -> u8 {
         self.header.counter
+    }
+
+    // No values to check against, so always valid
+    fn validate_response(&self, _received_index: u16, _received_subindex: u8) -> bool {
+        true
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -282,6 +282,10 @@ pub enum MailboxError {
         /// The subindex used in the operation.
         sub_index: u8,
     },
+    /// The returned counter value does not match that which was sent.
+    ///
+    /// Slowing down mailbox reads may help mitigate this error.
+    InvalidCount,
 }
 
 impl core::fmt::Display for MailboxError {
@@ -303,6 +307,7 @@ impl core::fmt::Display for MailboxError {
                 "{:#06x}:{} invalid response from device",
                 address, sub_index
             ),
+            MailboxError::InvalidCount => f.write_str("incorrect mailbox count value"),
         }
     }
 }

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -440,7 +440,7 @@ where
             RegisterAddress::sync_manager_status(write_mailbox.sync_manager);
 
         // Ensure SubDevice OUT (master IN) mailbox is empty
-        {
+        for i in 0..10 {
             let sm_status = self
                 .read(mailbox_read_sm_status)
                 .receive::<crate::sync_manager_channel::Status>(self.maindevice)
@@ -458,6 +458,13 @@ where
                     .ignore_wkc()
                     .receive_slice(self.maindevice, read_mailbox.len)
                     .await?;
+            } else {
+                break;
+            }
+
+            // Don't delay on first iteration
+            if i > 0 {
+                self.maindevice.timeouts.loop_tick().await;
             }
         }
 

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -439,7 +439,8 @@ where
         let mailbox_write_sm_status =
             RegisterAddress::sync_manager_status(write_mailbox.sync_manager);
 
-        // Ensure SubDevice OUT (master IN) mailbox is empty
+        // Ensure SubDevice OUT (master IN) mailbox is empty. We'll retry this multiple times in
+        // case the SubDevice is still busy or bugged or something.
         for i in 0..10 {
             let sm_status = self
                 .read(mailbox_read_sm_status)
@@ -465,6 +466,10 @@ where
             // Don't delay on first iteration
             if i > 0 {
                 self.maindevice.timeouts.loop_tick().await;
+            }
+
+            if i > 1 {
+                fmt::debug!("--> Retrying clear");
             }
         }
 


### PR DESCRIPTION
A customer is seeing an issue where a CoE request is sent with `counter = 1`, but is returned with `counter = 2`. The response seems otherwise valid, with the expected index/subindex, so I'm not sure what's going on. 

This PR stops checking the returned counter value, and instead does some extra validation on the index/subindex to be more confident the response is to the request we sent.