### PR TITLE
Pack as many state changes as possible into check frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ An EtherCAT MainDevice written in Rust.
   of 16 devices to speed up group status reads.
 - [#239](https://github.com/ethercrab-rs/ethercrab/pull/239) Mailbox emergency responses now return
   `Error::Mailbox(MailboxError::Emergency)` instead of being ignored.
+- [#238](https://github.com/ethercrab-rs/ethercrab/pull/238) Group SubDevice status checks are now
+  chunked into however many fit into a frame, instead of being sent separately.
 
 ### Fixed
 

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -27,7 +27,7 @@ use ta::Next;
 const MAX_SUBDEVICES: usize = 16;
 const MAX_PDU_DATA: usize = PduStorage::element_size(1100);
 const MAX_FRAMES: usize = 32;
-const PDI_LEN: usize = 128;
+const PDI_LEN: usize = 64;
 
 static PDU_STORAGE: PduStorage<MAX_FRAMES, MAX_PDU_DATA> = PduStorage::new();
 
@@ -293,7 +293,7 @@ fn main() -> Result<(), Error> {
                 // Less than 100ns max deviation as an example threshold.
                 // <https://github.com/OpenEtherCATsociety/SOEM/issues/487#issuecomment-786245585>
                 // mentions less than 100us as a good enough value as well.
-                if max_deviation < 100_000_00 {
+                if max_deviation < 100 {
                     log::info!("Clocks settled after {} ms", start.elapsed().as_millis());
 
                     break;

--- a/examples/dc.rs
+++ b/examples/dc.rs
@@ -27,7 +27,7 @@ use ta::Next;
 const MAX_SUBDEVICES: usize = 16;
 const MAX_PDU_DATA: usize = PduStorage::element_size(1100);
 const MAX_FRAMES: usize = 32;
-const PDI_LEN: usize = 64;
+const PDI_LEN: usize = 128;
 
 static PDU_STORAGE: PduStorage<MAX_FRAMES, MAX_PDU_DATA> = PduStorage::new();
 
@@ -293,7 +293,7 @@ fn main() -> Result<(), Error> {
                 // Less than 100ns max deviation as an example threshold.
                 // <https://github.com/OpenEtherCATsociety/SOEM/issues/487#issuecomment-786245585>
                 // mentions less than 100us as a good enough value as well.
-                if max_deviation < 100 {
+                if max_deviation < 100_000_00 {
                     log::info!("Clocks settled after {} ms", start.elapsed().as_millis());
 
                     break;
@@ -339,10 +339,6 @@ fn main() -> Result<(), Error> {
         let mut process_stats =
             csv::Writer::from_writer(File::create("dc-pd.csv").expect("Open CSV"));
 
-        let term = Arc::new(AtomicBool::new(false));
-        signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&term))
-            .expect("Register hook");
-
         let mut print_tick = Instant::now();
 
         // Request OP state without waiting for all SubDevices to reach it. Allows the immediate
@@ -381,6 +377,10 @@ fn main() -> Result<(), Error> {
             "All SubDevices entered OP in {} us",
             op_request.elapsed().as_micros()
         );
+
+        let term = Arc::new(AtomicBool::new(false));
+        signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&term))
+            .expect("Register hook");
 
         // Main application process data cycle
         loop {

--- a/src/maindevice.rs
+++ b/src/maindevice.rs
@@ -509,7 +509,7 @@ impl<'sto> MainDevice<'sto> {
     ) -> Result<ReceivedPdu<'sto>, Error> {
         let mut frame = self.pdu_loop.alloc_frame()?;
 
-        let handle = frame.push_pdu(command, data, len_override, false)?;
+        let handle = frame.push_pdu(command, data, len_override)?;
 
         let frame = frame.mark_sendable(
             &self.pdu_loop,

--- a/src/pdu_loop/frame_element/received_frame.rs
+++ b/src/pdu_loop/frame_element/received_frame.rs
@@ -122,6 +122,13 @@ impl<'sto> ReceivedFrame<'sto> {
             _storage: PhantomData,
         })
     }
+
+    pub fn into_iter(self) -> ReceivedPduIter<'sto> {
+        ReceivedPduIter {
+            frame: self,
+            buf_pos: 0,
+        }
+    }
 }
 
 impl<'sto> Drop for ReceivedFrame<'sto> {
@@ -134,6 +141,66 @@ impl<'sto> Drop for ReceivedFrame<'sto> {
 
         // Set frame empty sentinel so we don't get false-positive matches when receiving frames
         self.inner.clear_first_pdu();
+    }
+}
+
+// NOTE: Takes ownership of frame so we can't do double reads with handles
+pub struct ReceivedPduIter<'sto> {
+    frame: ReceivedFrame<'sto>,
+    buf_pos: usize,
+}
+
+impl<'sto> Iterator for ReceivedPduIter<'sto> {
+    type Item = Result<ReceivedPdu<'sto>, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let buf = self.frame.inner.pdu_buf().get(self.buf_pos..)?;
+
+        let pdu_header = match PduHeader::unpack_from_slice(buf) {
+            Ok(h) => h,
+            Err(e) => return Some(Err(e.into())),
+        };
+
+        let payload_len = usize::from(pdu_header.flags.len());
+        let this_pdu_len = PduHeader::PACKED_LEN + payload_len + 2;
+
+        // If buffer isn't long enough to hold payload and WKC, this is probably a corrupt PDU or
+        // someone is committing epic haxx.
+        if buf.len() < payload_len + 2 {
+            return Some(Err(Error::Pdu(PduError::TooLong)));
+        }
+
+        let payload_ptr = unsafe {
+            NonNull::new_unchecked(buf.get(PduHeader::PACKED_LEN..)?.as_ptr().cast_mut())
+        };
+
+        let working_counter = match buf
+            .get((PduHeader::PACKED_LEN + payload_len)..)
+            .ok_or(Error::Internal)
+            .and_then(|b| u16::unpack_from_slice(b).map_err(Error::from))
+        {
+            Ok(wkc) => wkc,
+            Err(e) => return Some(Err(e)),
+        };
+
+        let res = Ok(ReceivedPdu {
+            data_start: payload_ptr,
+            len: payload_len,
+            working_counter,
+            _storage: PhantomData,
+        });
+
+        // Update buffer pos for next iteration if there are more PDUs to come
+        if pdu_header.flags.more_follows {
+            self.buf_pos += this_pdu_len;
+        }
+        // No more frames, so quit the next time round by trying to read way off the end of the
+        // buffer.
+        else {
+            self.buf_pos = usize::MAX
+        }
+
+        Some(res)
     }
 }
 

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -83,12 +83,7 @@ impl<'sto> PduLoop<'sto> {
     ) -> Result<(), Error> {
         let mut frame = self.storage.alloc_frame()?;
 
-        frame.push_pdu(
-            Command::bwr(register).into(),
-            (),
-            Some(payload_length),
-            false,
-        )?;
+        frame.push_pdu(Command::bwr(register).into(), (), Some(payload_length))?;
 
         let frame = frame.mark_sendable(self, timeout, retries);
 
@@ -136,7 +131,6 @@ mod tests {
                 .into(),
                 (),
                 Some(16),
-                false,
             )
             .expect("Push PDU");
 
@@ -170,7 +164,7 @@ mod tests {
         let mut frame = pdu_loop.storage.alloc_frame().unwrap();
 
         let _handle = frame
-            .push_pdu(Command::fpwr(0x5678, 0x1234).into(), data, None, false)
+            .push_pdu(Command::fpwr(0x5678, 0x1234).into(), data, None)
             .expect("Push");
 
         let frame = frame.mark_sendable(&pdu_loop, Duration::MAX, usize::MAX);
@@ -214,7 +208,7 @@ mod tests {
             let mut frame = pdu_loop.storage.alloc_frame().expect("Frame alloc");
 
             let handle = frame
-                .push_pdu(Command::fpwr(0x5678, 0x1234).into(), &data, None, false)
+                .push_pdu(Command::fpwr(0x5678, 0x1234).into(), &data, None)
                 .expect("Push PDU");
 
             let mut frame_fut = pin!(frame.mark_sendable(&pdu_loop, Duration::MAX, usize::MAX));
@@ -292,7 +286,7 @@ mod tests {
         let mut frame = pdu_loop.storage.alloc_frame().unwrap();
 
         let _handle = frame
-            .push_pdu(Command::fpwr(0x5678, 0x1234).into(), data, None, false)
+            .push_pdu(Command::fpwr(0x5678, 0x1234).into(), data, None)
             .expect("Push PDU");
 
         // Drop frame future to reset its state to `FrameState::None`
@@ -305,7 +299,7 @@ mod tests {
         let mut frame = pdu_loop.storage.alloc_frame().unwrap();
 
         let _handle = frame
-            .push_pdu(Command::fpwr(0x6789, 0x1234).into(), data, None, false)
+            .push_pdu(Command::fpwr(0x6789, 0x1234).into(), data, None)
             .expect("Push second PDU");
 
         let frame = frame.mark_sendable(&pdu_loop, Duration::MAX, usize::MAX);
@@ -362,12 +356,7 @@ mod tests {
             let mut frame = pdu_loop.storage.alloc_frame().unwrap();
 
             let handle = frame
-                .push_pdu(
-                    Command::fpwr(0x6789, 0x1234).into(),
-                    &data_bytes,
-                    None,
-                    false,
-                )
+                .push_pdu(Command::fpwr(0x6789, 0x1234).into(), &data_bytes, None)
                 .expect("Push PDU");
 
             let mut frame_fut = pin!(frame.mark_sendable(&pdu_loop, Duration::MAX, usize::MAX));
@@ -467,7 +456,7 @@ mod tests {
             let mut frame = pdu_loop.storage.alloc_frame().expect("Frame alloc");
 
             let handle = frame
-                .push_pdu(Command::fpwr(0x1000, 0x980).into(), data, None, false)
+                .push_pdu(Command::fpwr(0x1000, 0x980).into(), data, None)
                 .expect("Push PDU");
 
             let result = frame
@@ -571,7 +560,7 @@ mod tests {
                     let mut frame = pdu_loop.storage.alloc_frame().expect("Frame alloc");
 
                     let handle = frame
-                        .push_pdu(Command::fpwr(0x1000, 0x980).into(), data, None, false)
+                        .push_pdu(Command::fpwr(0x1000, 0x980).into(), data, None)
                         .expect("Push PDU");
 
                     let mut x =

--- a/src/pdu_loop/storage.rs
+++ b/src/pdu_loop/storage.rs
@@ -294,12 +294,7 @@ mod tests {
         let mut frame = pdu_loop.alloc_frame().expect("Allocate first frame");
 
         frame
-            .push_pdu(
-                Command::bwr(0x1000).into(),
-                [0xaa, 0xbb, 0xcc, 0xdd],
-                None,
-                false,
-            )
+            .push_pdu(Command::bwr(0x1000).into(), [0xaa, 0xbb, 0xcc, 0xdd], None)
             .unwrap();
 
         // Drop frame future to reset its state to `FrameState::None`
@@ -309,9 +304,7 @@ mod tests {
 
         const LEN: usize = 8;
 
-        frame
-            .push_pdu(Command::Nop, (), Some(LEN as u16), false)
-            .unwrap();
+        frame.push_pdu(Command::Nop, (), Some(LEN as u16)).unwrap();
 
         let pdu_start = EthernetFrame::<&[u8]>::header_len()
             + EthercatFrameHeader::header_len()

--- a/src/subdevice_group/mod.rs
+++ b/src/subdevice_group/mod.rs
@@ -641,33 +641,48 @@ impl<const MAX_SUBDEVICES: usize, const MAX_PDI: usize, S, DC>
     ) -> Result<bool, Error> {
         fmt::trace!("Check group state");
 
-        // Send this many status frames in a single PDU.
-        // TODO: Check ahead of time that this many PDUs will fit in the given frame size.
-        const CHUNK_SIZE: usize = 16;
+        let mut subdevices = self.inner().subdevices.iter();
 
-        for (chunk_idx, chunk) in self.inner().subdevices.chunks(CHUNK_SIZE).enumerate() {
+        let mut frame_idx = 0;
+
+        // Send as many frames as required to check statuses of all subdevices
+        loop {
             let mut frame = maindevice.pdu_loop.alloc_frame()?;
 
-            let mut handles = heapless::Vec::<_, CHUNK_SIZE>::new();
+            let mut num_in_this_frame = 0;
 
-            let idx_range = chunk_idx * CHUNK_SIZE..chunk_idx * CHUNK_SIZE + CHUNK_SIZE;
-
-            fmt::trace!("--> Group index chunk {:?}", idx_range);
-
-            for (position_in_chunk, sd_address) in chunk
-                .iter()
-                .map(|sd| sd.borrow().configured_address())
-                .enumerate()
-            {
-                let handle = frame.push_pdu(
-                    Command::fprd(sd_address, RegisterAddress::AlStatus.into()).into(),
+            // Fill frame with status requests
+            while let Some(sd) = subdevices.next() {
+                match frame.push_pdu(
+                    Command::fprd(
+                        sd.borrow().configured_address(),
+                        RegisterAddress::AlStatus.into(),
+                    )
+                    .into(),
                     (),
                     Some(AlControl::PACKED_LEN as u16),
-                    position_in_chunk < chunk.len() - 1,
-                )?;
+                ) {
+                    Ok(_) => (),
+                    // Frame is full, we'll do more next time round
+                    Err(PduError::TooLong) => {
+                        fmt::trace!(
+                            "--> Pushed {} checks into frame {}",
+                            num_in_this_frame,
+                            frame_idx
+                        );
 
-                // SAFETY: Handles has the same length as the chunk, so this should always succeed.
-                let _ = handles.push(handle).map_err(|_| unreachable!());
+                        break;
+                    }
+                    // Bail on a legitimate failure
+                    Err(e) => return Err(e.into()),
+                }
+
+                num_in_this_frame += 1;
+            }
+
+            // Nothing to send, we've checked all SDs
+            if num_in_this_frame == 0 {
+                break;
             }
 
             let frame = frame.mark_sendable(
@@ -678,25 +693,19 @@ impl<const MAX_SUBDEVICES: usize, const MAX_PDI: usize, S, DC>
 
             maindevice.pdu_loop.wake_sender();
 
-            let received = frame.await.map_err(|e| {
-                fmt::error!(
-                    "Failed to get group SubDevice chunk {:?} status: {}",
-                    idx_range,
-                    e
-                );
+            let received = frame.await?;
 
-                e
-            })?;
+            for pdu in received.into_iter() {
+                let pdu = pdu?;
 
-            for handle in handles {
-                let result = received.pdu(handle)?;
-
-                let result = AlControl::unpack_from_slice(&result)?;
+                let result = AlControl::unpack_from_slice(&pdu)?;
 
                 if result.state != desired_state {
                     return Ok(false);
                 }
             }
+
+            frame_idx += 1;
         }
 
         Ok(true)
@@ -935,14 +944,12 @@ where
                 Command::frmw(dc_ref, RegisterAddress::DcSystemTime.into()).into(),
                 0u64,
                 None,
-                true,
             )?;
 
             let pdu_handle = frame.push_pdu(
                 Command::lrw(self.inner().pdi_start.start_address).into(),
                 self.pdi(),
                 None,
-                false,
             )?;
 
             let frame = frame.mark_sendable(
@@ -1142,14 +1149,12 @@ where
             Command::frmw(self.dc_conf.reference, RegisterAddress::DcSystemTime.into()).into(),
             0u64,
             None,
-            true,
         )?;
 
         let pdu_handle = frame.push_pdu(
             Command::lrw(self.inner().pdi_start.start_address).into(),
             self.pdi(),
             None,
-            false,
         )?;
 
         let frame = frame.mark_sendable(

--- a/src/subdevice_group/mod.rs
+++ b/src/subdevice_group/mod.rs
@@ -678,6 +678,14 @@ impl<const MAX_SUBDEVICES: usize, const MAX_PDI: usize, S, DC>
                 }
 
                 num_in_this_frame += 1;
+
+                // A status check datagram is 14 bytes, meaning we can fit at most just over 100
+                // checks per normal EtherCAT frame. This leaves spare PDU indices available for
+                // other purposes, however if the user is using jumbo frames or something, we should
+                // always leave some indices free for e.g. other threads.
+                if num_in_this_frame > 128 {
+                    break;
+                }
             }
 
             // Nothing to send, we've checked all SDs


### PR DESCRIPTION
This was previously done in chunks of 16 in #237 but that was a pretty arbitrary limitation. Now, the check frame is filled until nothing else will fit in it. At this point, another frame is sent if the group is large enough to need more than one.