### PR TITLE
Support PDIs longer than a single frame can hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ An EtherCAT MainDevice written in Rust.
   from CoE transactions.
 - [#246](https://github.com/ethercrab-rs/ethercrab/pull/246) **Windows:** Add `tx_rx_task_blocking`
   to use in a separate thread to send/receive EitherCAT frames.
+- [#242](https://github.com/ethercrab-rs/ethercrab/pull/242) Add support for PDIs longer than a
+  single PDU
 
 ### Changed
 

--- a/src/maindevice.rs
+++ b/src/maindevice.rs
@@ -504,7 +504,7 @@ impl<'sto> MainDevice<'sto> {
         .await
     }
 
-    pub(crate) fn max_frame_data(&self) -> usize {
+    pub(crate) const fn max_frame_data(&self) -> usize {
         self.pdu_loop.max_frame_data()
     }
 

--- a/src/pdu_loop/frame_element/created_frame.rs
+++ b/src/pdu_loop/frame_element/created_frame.rs
@@ -243,7 +243,7 @@ impl<'sto> CreatedFrame<'sto> {
             .pdu_buf_mut()
             .get_mut(buf_range.clone())
             .ok_or_else(|| {
-                fmt::error!(
+                fmt::trace!(
                     "Push PDU buf range too long: wanted {:?} from {:?}",
                     buf_range,
                     0..l

--- a/src/pdu_loop/frame_element/frame_box.rs
+++ b/src/pdu_loop/frame_element/frame_box.rs
@@ -154,6 +154,7 @@ impl<'sto> FrameBox<'sto> {
         }
     }
 
+    /// Get the number of bytes consumed in the region of the frame used to store one or more PDUs.
     pub fn pdu_payload_len(&self) -> usize {
         unsafe { *addr_of!((*self.frame.as_ptr()).pdu_payload_len) }
     }
@@ -172,6 +173,9 @@ impl<'sto> FrameBox<'sto> {
         }
     }
 
+    /// Add the given number of bytes in `alloc_size` to the consumed bytes counter in the frame.
+    ///
+    /// Also sets the first PDU index if it hasn't already been set.
     pub fn add_pdu(&mut self, alloc_size: usize, pdu_idx: u8) {
         unsafe { *addr_of_mut!((*self.frame.as_ptr()).pdu_payload_len) += alloc_size };
 

--- a/src/pdu_loop/frame_element/frame_box.rs
+++ b/src/pdu_loop/frame_element/frame_box.rs
@@ -60,8 +60,11 @@ impl<'sto> FrameBox<'sto> {
     pub fn init(&mut self) {
         unsafe {
             addr_of_mut!((*self.frame.as_ptr()).waker).write(AtomicWaker::new());
+
             (&*addr_of_mut!((*self.frame.as_ptr()).first_pdu))
                 .store(FIRST_PDU_EMPTY, Ordering::Relaxed);
+
+            addr_of_mut!((*self.frame.as_ptr()).pdu_payload_len).write(0);
         }
 
         let mut ethernet_frame = self.ethernet_frame_mut();

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -77,6 +77,8 @@ pub struct FrameElement<const N: usize> {
     frame_index: u8,
     status: AtomicFrameState,
     waker: AtomicWaker,
+
+    /// Keeps track of how much of the PDU data buffer has been consumed.
     pdu_payload_len: usize,
 
     // Atomic as we iterate over all `FrameElement`s and read this field when receiving a frame.

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -171,8 +171,9 @@ impl<const N: usize> FrameElement<N> {
         // matters slightly less for all other state transitions because once we have a created
         // frame nothing else is able to take it unless it is put back into the `None` state.
         let this = Self::swap_state(this, FrameState::None, FrameState::Created).map_err(|e| {
-            fmt::debug!(
-                "Failed to claim frame: status is {:?}, expected {:?}",
+            fmt::trace!(
+                "Failed to claim frame {}: status is {:?}, expected {:?}",
+                frame_index,
                 e,
                 FrameState::None
             );

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -67,7 +67,7 @@ impl<'sto> PduLoop<'sto> {
         Self { storage }
     }
 
-    pub(crate) fn max_frame_data(&self) -> usize {
+    pub(crate) const fn max_frame_data(&self) -> usize {
         self.storage.frame_data_len
     }
 

--- a/src/std/io_uring.rs
+++ b/src/std/io_uring.rs
@@ -8,14 +8,7 @@ use crate::{
 use core::{mem::MaybeUninit, task::Waker};
 use io_uring::{opcode, IoUring};
 use smallvec::{smallvec, SmallVec};
-use std::{
-    io,
-    os::fd::AsRawFd,
-    sync::Arc,
-    task::Wake,
-    thread::{self, Thread},
-    time::Instant,
-};
+use std::{io, os::fd::AsRawFd, sync::Arc, thread, time::Instant};
 
 /// Use the upper bit of a u64 to mark whether a frame is a write (`1`) or a read (`0`).
 const WRITE_MASK: u64 = 1 << 63;

--- a/src/subdevice/configuration.rs
+++ b/src/subdevice/configuration.rs
@@ -47,7 +47,8 @@ where
 
         self.request_subdevice_state(SubDeviceState::PreOp).await?;
 
-        if self.state.config.mailbox.has_coe {
+        if false {
+            panic!("No COE pls {:#06x}", self.configured_address());
             // TODO: Abstract this no-complete-access check into a method call so we can reuse it.
             // CA is currently only used here inside EtherCrab, but may need to be used in other
             // places eventually.

--- a/src/subdevice/configuration.rs
+++ b/src/subdevice/configuration.rs
@@ -47,8 +47,7 @@ where
 
         self.request_subdevice_state(SubDeviceState::PreOp).await?;
 
-        if false {
-            panic!("No COE pls {:#06x}", self.configured_address());
+        if self.state.config.mailbox.has_coe {
             // TODO: Abstract this no-complete-access check into a method call so we can reuse it.
             // CA is currently only used here inside EtherCrab, but may need to be used in other
             // places eventually.

--- a/src/subdevice_group/mod.rs
+++ b/src/subdevice_group/mod.rs
@@ -900,8 +900,11 @@ where
 
             let start_addr = self.inner().pdi_start.start_address + total_bytes_sent as u32;
 
-            let (bytes_in_this_chunk, pdu_handle) =
-                frame.push_pdu_slice_rest(Command::lrw(start_addr).into(), remaining)?;
+            let Some((bytes_in_this_chunk, pdu_handle)) =
+                frame.push_pdu_slice_rest(Command::lrw(start_addr).into(), remaining)?
+            else {
+                continue;
+            };
 
             remaining = &remaining[bytes_in_this_chunk..];
 
@@ -980,8 +983,11 @@ where
 
                 let start_addr = self.inner().pdi_start.start_address + total_bytes_sent as u32;
 
-                let (bytes_in_this_chunk, pdu_handle) =
-                    frame.push_pdu_slice_rest(Command::lrw(start_addr).into(), remaining)?;
+                let Some((bytes_in_this_chunk, pdu_handle)) =
+                    frame.push_pdu_slice_rest(Command::lrw(start_addr).into(), remaining)?
+                else {
+                    continue;
+                };
 
                 fmt::trace!("Wrote {} byte chunk", bytes_in_this_chunk);
 
@@ -1198,8 +1204,11 @@ where
 
             let start_addr = self.inner().pdi_start.start_address + total_bytes_sent as u32;
 
-            let (bytes_in_this_chunk, pdu_handle) =
-                frame.push_pdu_slice_rest(Command::lrw(start_addr).into(), remaining)?;
+            let Some((bytes_in_this_chunk, pdu_handle)) =
+                frame.push_pdu_slice_rest(Command::lrw(start_addr).into(), remaining)?
+            else {
+                continue;
+            };
 
             remaining = &remaining[bytes_in_this_chunk..];
 

--- a/src/subdevice_group/mod.rs
+++ b/src/subdevice_group/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     error::{DistributedClockError, Error, Item, PduError},
     fmt,
     pdi::PdiOffset,
+    pdu_loop::CreatedFrame,
     subdevice::{
         configuration::PdoDirection, pdi::SubDevicePdi, IoRanges, SubDevice, SubDeviceRef,
     },
@@ -32,6 +33,9 @@ pub use self::iterator::GroupSubDeviceIterator;
 pub use configurator::SubDeviceGroupRef;
 
 static GROUP_ID: AtomicUsize = AtomicUsize::new(0);
+
+/// The size of a DC sync PDU.
+const DC_PDU_SIZE: usize = CreatedFrame::PDU_OVERHEAD_BYTES + u64::PACKED_LEN;
 
 /// A typestate for [`SubDeviceGroup`] representing a group that is shut down.
 ///
@@ -893,19 +897,51 @@ where
             self.read_pdi_len
         );
 
-        assert!(
-            self.len() <= maindevice.max_frame_data(),
-            "Chunked sends not yet supported. Buffer len {} B too long to send in {} B frame",
-            self.len(),
-            maindevice.max_frame_data()
-        );
+        let mut remaining = self.pdi();
+        let mut total_bytes_sent = 0;
+        let mut lrw_wkc_sum = 0;
 
-        let data = Command::lrw(self.inner().pdi_start.start_address)
-            .ignore_wkc()
-            .send_receive_slice(maindevice, self.pdi())
-            .await?;
+        while !remaining.is_empty() {
+            let mut frame = maindevice.pdu_loop.alloc_frame()?;
 
-        self.process_pdi_response(&data)
+            let start_addr = self.inner().pdi_start.start_address + total_bytes_sent as u32;
+
+            let (num_bytes_written, pdu_handle) =
+                frame.push_pdu_slice_rest(Command::lrw(start_addr).into(), remaining)?;
+
+            remaining = &remaining[num_bytes_written..];
+
+            let frame = frame.mark_sendable(
+                &maindevice.pdu_loop,
+                maindevice.timeouts.pdu,
+                maindevice.config.retry_behaviour.retry_count(),
+            );
+
+            maindevice.pdu_loop.wake_sender();
+
+            let received = frame.await?;
+
+            let data = received.first_pdu(pdu_handle)?;
+
+            let wkc = data.working_counter;
+
+            // If we've read the inputs chunk, write it back into the PDI (PDI is organised as
+            // IIIIOOOO)
+            if num_bytes_written > 0 && total_bytes_sent < self.read_pdi_len {
+                let inputs_range =
+                    total_bytes_sent..(total_bytes_sent + self.read_pdi_len.min(num_bytes_written));
+
+                self.pdi_mut()
+                    .get_mut(inputs_range.clone())
+                    .ok_or(Error::Internal)?
+                    .copy_from_slice(data.get(0..inputs_range.len()).ok_or(Error::Internal)?);
+            }
+
+            total_bytes_sent += num_bytes_written;
+            lrw_wkc_sum += wkc;
+        }
+
+        Ok(lrw_wkc_sum)
     }
 
     /// Drive the SubDevice group's inputs and outputs and synchronise EtherCAT system time with
@@ -915,18 +951,13 @@ where
     /// periodically. It will send an `LRW` to update SubDevice outputs and read SubDevice inputs.
     ///
     /// This method returns the working counter and the current EtherCAT system time in nanoseconds
-    /// on success.
+    /// on success. If the PDI must be sent in multiple chunks, the returned working counter is the
+    /// sum of all returned working counter values.
     ///
     /// # Errors
     ///
     /// This method will return with an error if the PDU could not be sent over the network, or the
     /// response times out.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if the frame data length of the group is too large to fit in the
-    /// configured maximum PDU length set by the `DATA` const generic of
-    /// [`PduStorage`](crate::PduStorage).
     pub async fn tx_rx_sync_system_time<'sto>(
         &self,
         maindevice: &'sto MainDevice<'sto>,
@@ -946,73 +977,83 @@ where
         );
 
         if let Some(dc_ref) = maindevice.dc_ref_address() {
-            let mut frame = maindevice.pdu_loop.alloc_frame()?;
+            let mut remaining = self.pdi();
+            let mut total_bytes_sent = 0;
+            let mut time = 0;
+            let mut lrw_wkc_sum = 0;
+            let mut time_read = false;
 
-            let dc_handle = frame.push_pdu(
-                Command::frmw(dc_ref, RegisterAddress::DcSystemTime.into()).into(),
-                0u64,
-                None,
-            )?;
+            loop {
+                let mut frame = maindevice.pdu_loop.alloc_frame()?;
 
-            let pdu_handle = frame.push_pdu(
-                Command::lrw(self.inner().pdi_start.start_address).into(),
-                self.pdi(),
-                None,
-            )?;
+                let dc_handle = if !time_read {
+                    let dc_handle = frame.push_pdu(
+                        Command::frmw(dc_ref, RegisterAddress::DcSystemTime.into()).into(),
+                        0u64,
+                        None,
+                    )?;
 
-            let frame = frame.mark_sendable(
-                &maindevice.pdu_loop,
-                maindevice.timeouts.pdu,
-                maindevice.config.retry_behaviour.retry_count(),
-            );
+                    // Just double checking
+                    debug_assert_eq!(dc_handle.alloc_size, DC_PDU_SIZE);
 
-            maindevice.pdu_loop.wake_sender();
+                    Some(dc_handle)
+                } else {
+                    None
+                };
 
-            let received = frame.await?;
+                let start_addr = self.inner().pdi_start.start_address + total_bytes_sent as u32;
 
-            let (time, wkc) = self.process_pdi_response_with_time(
-                &received.pdu(dc_handle)?,
-                &received.pdu(pdu_handle)?,
-            )?;
+                let (num_bytes_written, pdu_handle) =
+                    frame.push_pdu_slice_rest(Command::lrw(start_addr).into(), remaining)?;
 
-            Ok((wkc, Some(time)))
+                remaining = &remaining[num_bytes_written..];
+
+                let frame = frame.mark_sendable(
+                    &maindevice.pdu_loop,
+                    maindevice.timeouts.pdu,
+                    maindevice.config.retry_behaviour.retry_count(),
+                );
+
+                maindevice.pdu_loop.wake_sender();
+
+                let received = frame.await?;
+
+                if let Some(dc_handle) = dc_handle {
+                    time = received
+                        .pdu(dc_handle)
+                        .and_then(|rx| u64::unpack_from_slice(&rx).map_err(Error::from))?;
+
+                    time_read = true;
+                }
+
+                let data = &received.pdu(pdu_handle)?;
+
+                let wkc = data.working_counter;
+
+                // If we've read the inputs chunk, write it back into the PDI (PDI is organised as
+                // IIIIOOOO)
+                if num_bytes_written > 0 && total_bytes_sent < self.read_pdi_len {
+                    let inputs_range = total_bytes_sent
+                        ..(total_bytes_sent + self.read_pdi_len.min(num_bytes_written));
+
+                    self.pdi_mut()
+                        .get_mut(inputs_range.clone())
+                        .ok_or(Error::Internal)?
+                        .copy_from_slice(data.get(0..inputs_range.len()).ok_or(Error::Internal)?);
+                }
+
+                total_bytes_sent += num_bytes_written;
+                lrw_wkc_sum += wkc;
+
+                // NOTE: Not using a while loop as we want to always send the DC sync PDU even if the
+                // PDI is empty.
+                if remaining.is_empty() {
+                    break Ok((lrw_wkc_sum, Some(time)));
+                }
+            }
         } else {
             self.tx_rx(maindevice).await.map(|wkc| (wkc, None))
         }
-    }
-
-    fn process_pdi_response_with_time(
-        &self,
-        dc: &crate::pdu_loop::ReceivedPdu,
-        data: &crate::pdu_loop::ReceivedPdu,
-    ) -> Result<(u64, u16), Error> {
-        let time = u64::unpack_from_slice(dc)?;
-
-        Ok((time, self.process_pdi_response(data)?))
-    }
-
-    /// Take a received PDI and copy its inputs into the group's memory.
-    ///
-    /// Returns working counter on success.
-    fn process_pdi_response(&self, data: &crate::pdu_loop::ReceivedPdu) -> Result<u16, Error> {
-        if data.len() != self.pdi().len() {
-            fmt::error!(
-                "Data length {} does not match value length {}",
-                data.len(),
-                self.pdi().len()
-            );
-
-            return Err(Error::Pdu(PduError::Decode));
-        }
-
-        let wkc = data.working_counter;
-
-        self.pdi_mut()
-            .get_mut(0..self.read_pdi_len)
-            .ok_or(Error::Internal)?
-            .copy_from_slice(data.get(0..self.read_pdi_len).ok_or(Error::Internal)?);
-
-        Ok(wkc)
     }
 }
 
@@ -1035,12 +1076,6 @@ where
     ///
     /// This method will return with an error if the PDU could not be sent over the network, or the
     /// response times out.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if the frame data length of the group is too large to fit in the
-    /// configured maximum PDU length set by the `DATA` const generic of
-    /// [`PduStorage`](crate::PduStorage).
     ///
     /// # Examples
     ///
@@ -1137,13 +1172,6 @@ where
         &self,
         maindevice: &'sto MainDevice<'sto>,
     ) -> Result<(u16, CycleInfo), Error> {
-        assert!(
-            self.len() <= maindevice.max_frame_data(),
-            "Chunked sends not yet supported. Buffer len {} B too long to send in {} B frame",
-            self.len(),
-            maindevice.max_frame_data()
-        );
-
         fmt::trace!(
             "Group TX/RX with DC sync, start address {:#010x}, data len {}, of which read bytes: {}",
             self.inner().pdi_start.start_address,
@@ -1151,34 +1179,81 @@ where
             self.read_pdi_len
         );
 
-        let mut frame = maindevice.pdu_loop.alloc_frame()?;
+        let mut remaining = self.pdi();
+        let mut total_bytes_sent = 0;
+        let mut time = 0;
+        let mut lrw_wkc_sum = 0;
+        let mut time_read = false;
 
-        let dc_handle = frame.push_pdu(
-            Command::frmw(self.dc_conf.reference, RegisterAddress::DcSystemTime.into()).into(),
-            0u64,
-            None,
-        )?;
+        loop {
+            let mut frame = maindevice.pdu_loop.alloc_frame()?;
 
-        let pdu_handle = frame.push_pdu(
-            Command::lrw(self.inner().pdi_start.start_address).into(),
-            self.pdi(),
-            None,
-        )?;
+            let dc_handle = if !time_read {
+                let dc_handle = frame.push_pdu(
+                    Command::frmw(self.dc_conf.reference, RegisterAddress::DcSystemTime.into())
+                        .into(),
+                    0u64,
+                    None,
+                )?;
 
-        let frame = frame.mark_sendable(
-            &maindevice.pdu_loop,
-            maindevice.timeouts.pdu,
-            maindevice.config.retry_behaviour.retry_count(),
-        );
+                // Just double checking
+                debug_assert_eq!(dc_handle.alloc_size, DC_PDU_SIZE);
 
-        maindevice.pdu_loop.wake_sender();
+                Some(dc_handle)
+            } else {
+                None
+            };
 
-        let received = frame.await?;
+            let start_addr = self.inner().pdi_start.start_address + total_bytes_sent as u32;
 
-        let (time, wkc) = self.process_pdi_response_with_time(
-            &received.pdu(dc_handle)?,
-            &received.pdu(pdu_handle)?,
-        )?;
+            let (num_bytes_written, pdu_handle) =
+                frame.push_pdu_slice_rest(Command::lrw(start_addr).into(), remaining)?;
+
+            remaining = &remaining[num_bytes_written..];
+
+            let frame = frame.mark_sendable(
+                &maindevice.pdu_loop,
+                maindevice.timeouts.pdu,
+                maindevice.config.retry_behaviour.retry_count(),
+            );
+
+            maindevice.pdu_loop.wake_sender();
+
+            let received = frame.await?;
+
+            if let Some(dc_handle) = dc_handle {
+                time = received
+                    .pdu(dc_handle)
+                    .and_then(|rx| u64::unpack_from_slice(&rx).map_err(Error::from))?;
+
+                time_read = true;
+            }
+
+            let data = &received.pdu(pdu_handle)?;
+
+            let wkc = data.working_counter;
+
+            // If we've read the inputs chunk, write it back into the PDI (PDI is organised as
+            // IIIIOOOO)
+            if num_bytes_written > 0 && total_bytes_sent < self.read_pdi_len {
+                let inputs_range =
+                    total_bytes_sent..(total_bytes_sent + self.read_pdi_len.min(num_bytes_written));
+
+                self.pdi_mut()
+                    .get_mut(inputs_range.clone())
+                    .ok_or(Error::Internal)?
+                    .copy_from_slice(data.get(0..inputs_range.len()).ok_or(Error::Internal)?);
+            }
+
+            total_bytes_sent += num_bytes_written;
+            lrw_wkc_sum += wkc;
+
+            // NOTE: Not using a while loop as we want to always send the DC sync PDU even if the
+            // PDI is empty.
+            if remaining.is_empty() {
+                break;
+            }
+        }
 
         // Nanoseconds from the start of the cycle. This works because the first SYNC0 pulse
         // time is rounded to a whole number of `sync0_period`-length cycles.
@@ -1188,7 +1263,7 @@ where
             (self.dc_conf.sync0_period - cycle_start_offset) + self.dc_conf.sync0_shift;
 
         Ok((
-            wkc,
+            lrw_wkc_sum,
             CycleInfo {
                 dc_system_time: time,
                 cycle_start_offset: Duration::from_nanos(cycle_start_offset),

--- a/src/subdevice_group/mod.rs
+++ b/src/subdevice_group/mod.rs
@@ -983,6 +983,8 @@ where
                 let (bytes_in_this_chunk, pdu_handle) =
                     frame.push_pdu_slice_rest(Command::lrw(start_addr).into(), remaining)?;
 
+                fmt::trace!("Wrote {} byte chunk", bytes_in_this_chunk);
+
                 remaining = &remaining[bytes_in_this_chunk..];
 
                 let frame = frame.mark_sendable(


### PR DESCRIPTION
This chunks a SubDevice group's PDI and sends it over multiple Ethernet/EtherCAT frames if the allocated storage is too small to send the whole PDI in one PDU.

TODO

- [x] Test in a real system with large PDI, at least larger than the largest SubDevice mailbox on the network
- [x] DRY up the code in `subdevice_group/mod.rs` - there's a lot of bug-prone copypasta in the `tx_rx_*` methods.
- [x] Revert testing commit that disables COE configuration