### PR TITLE
Expose escape hatch for manual PDI configuration, misc other changes.

### DIFF
--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -262,10 +262,14 @@ impl From<PdoType> for CategoryType {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum FmmuUsage {
+    /// TODO
     #[wire(alternatives = [0xff])]
     Unused = 0x00,
+    /// TODO
     Outputs = 0x01,
+    /// TODO
     Inputs = 0x02,
+    /// TODO
     SyncManagerStatus = 0x03,
 }
 
@@ -435,20 +439,26 @@ impl EtherCrabWireRead for CoeDetails {
     }
 }
 
+/// TODO
 #[derive(Copy, Clone, PartialEq, Eq, ethercrab_wire::EtherCrabWireRead)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[wire(bytes = 8)]
 pub struct SyncManager {
+    /// TODO
     #[wire(bytes = 2)]
-    pub(crate) start_addr: u16,
+    pub start_addr: u16,
+    /// TODO
     #[wire(bytes = 2)]
-    pub(crate) length: u16,
+    pub length: u16,
+    /// TODO
     #[wire(bytes = 1, post_skip_bytes = 1)]
-    pub(crate) control: sync_manager_channel::Control,
+    pub control: sync_manager_channel::Control,
+    /// TODO
     #[wire(bytes = 1)]
-    pub(crate) enable: SyncManagerEnable,
+    pub enable: SyncManagerEnable,
+    /// TODO
     #[wire(bytes = 1)]
-    pub(crate) usage_type: SyncManagerType,
+    pub usage_type: SyncManagerType,
 }
 
 impl core::fmt::Debug for SyncManager {
@@ -464,6 +474,7 @@ impl core::fmt::Debug for SyncManager {
 }
 
 bitflags::bitflags! {
+    /// TODO
     #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct SyncManagerEnable: u8 {
         /// Bit 0: enable.
@@ -502,6 +513,7 @@ impl defmt::Format for SyncManagerEnable {
     }
 }
 
+/// TODO
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, ethercrab_wire::EtherCrabWireRead)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ pub mod std;
 pub use al_status_code::AlStatusCode;
 pub use coe::SubIndex;
 pub use command::{Command, Reads, WrappedRead, WrappedWrite, Writes};
+pub use eeprom::types::{SyncManager, SyncManagerEnable, SyncManagerType, FmmuUsage};
 pub use ethercrab_wire::{
     EtherCrabWireRead, EtherCrabWireReadSized, EtherCrabWireReadWrite, EtherCrabWireSized,
     EtherCrabWireWrite, EtherCrabWireWriteSized,
@@ -205,11 +206,14 @@ pub use ethercrab_wire::{
 use ethernet::EthernetAddress;
 pub use maindevice::MainDevice;
 pub use maindevice_config::{MainDeviceConfig, RetryBehaviour};
+pub use pdi::{PdiOffset, PdiSegment};
 pub use pdu_loop::{PduLoop, PduRx, PduStorage, PduTx, SendableFrame};
 pub use register::{DcSupport, RegisterAddress};
 pub use subdevice::{DcSync, SubDevice, SubDeviceIdentity, SubDevicePdi, SubDeviceRef};
+pub use subdevice::configuration::{ConfigureSubdevicePdi, ConfigureSubdevicePdiDefault, ConfigureSubdevicePdiBasedOnCoe, ConfigureSubdevicePdiBasedOnEeprom, PdoDirection, ConfigureSubdevicePdiError};
 pub use subdevice_group::{GroupId, GroupSubDeviceIterator, SubDeviceGroup, SubDeviceGroupHandle};
 pub use subdevice_state::SubDeviceState;
+pub use sync_manager_channel::Control as SyncManagerControl;
 pub use timer_factory::Timeouts;
 
 const LEN_MASK: u16 = 0b0000_0111_1111_1111;

--- a/src/maindevice.rs
+++ b/src/maindevice.rs
@@ -93,10 +93,14 @@ impl<'sto> MainDevice<'sto> {
             .await?;
 
         // Clear FMMUs. FMMU memory section is 0xff (255) bytes long - see ETG1000.4 Table 57
-        self.blank_memory(RegisterAddress::Fmmu0, 0xff).await?;
+        for fmmu_idx in 0..16 {
+            self.blank_memory(RegisterAddress::fmmu(fmmu_idx), 0x10).await?;
+        }
 
         // Clear SMs. SM memory section is 0x7f bytes long - see ETG1000.4 Table 59
-        self.blank_memory(RegisterAddress::Sm0, 0x7f).await?;
+        for sm_idx in 0..16 {
+            self.blank_memory(RegisterAddress::sync_manager(sm_idx), 0x8).await?;
+        }
 
         // Set DC control back to EtherCAT
         self.blank_memory(

--- a/src/pdi.rs
+++ b/src/pdi.rs
@@ -7,6 +7,7 @@ use core::ops::Range;
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PdiOffset {
+    /// TODO
     pub start_address: u32,
     // // Unused, but will become useful if we support bit-packed PDI mappings in the future.
     // start_bit: u8,
@@ -20,6 +21,7 @@ impl PdiOffset {
         self.increment_inner(0, inc_bytes)
     }
 
+    /// TODO
     pub fn increment(self, bytes: u16) -> Self {
         self.increment_inner(0, bytes)
     }
@@ -68,18 +70,23 @@ impl PdiOffset {
     // }
 }
 
+/// TODO
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PdiSegment {
+    /// TODO
     pub bytes: Range<usize>,
+    /// TODO
     pub bit_len: usize,
 }
 
 impl PdiSegment {
+    /// TODO
     pub fn len(&self) -> usize {
         self.bytes.len()
     }
 
+    /// TODO
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     subdevice::{ports::Ports, types::SubDeviceConfig},
     subdevice_state::SubDeviceState,
     timer_factory::IntoTimeout,
-    WrappedRead, WrappedWrite,
+    WrappedRead, WrappedWrite, BASE_SUBDEVICE_ADDRESS,
 };
 use core::{
     any::type_name,
@@ -325,6 +325,11 @@ where
     /// used by [`SubDeviceGroup::configure_dc_sync`](crate::SubDeviceGroup::configure_dc_sync).
     pub fn set_dc_sync(&mut self, dc_sync: DcSync) {
         self.state.dc_sync = dc_sync;
+    }
+
+    /// TODO
+    pub fn as_raw_ref_mut(&mut self) -> SubDeviceRef<'a, &mut SubDevice> {
+        SubDeviceRef { maindevice: self.maindevice, configured_address: self.configured_address, state: self.state.deref_mut() }
     }
 }
 
@@ -759,6 +764,11 @@ where
             Error::Pdu(PduError::Decode)
         })
     }
+
+    /// TODO
+    pub fn as_raw_ref(&self) -> SubDeviceRef<'a, &SubDevice> {
+        SubDeviceRef { maindevice: self.maindevice, configured_address: self.configured_address, state: self.state.deref() }
+    }
 }
 
 // General impl with no bounds
@@ -774,6 +784,11 @@ impl<'a, S> SubDeviceRef<'a, S> {
     /// Get the configured station address of the SubDevice.
     pub fn configured_address(&self) -> u16 {
         self.configured_address
+    }
+
+    /// Get the index of this subdevice in the overall EtherCAT network when it was first initialized.
+    pub fn topology_address_at_init(&self) -> u16 {
+        self.configured_address.wrapping_sub(BASE_SUBDEVICE_ADDRESS)
     }
 
     /// Get the sub device status.
@@ -862,11 +877,13 @@ impl<'a, S> SubDeviceRef<'a, S> {
         .await
     }
 
-    pub(crate) fn write(&self, register: impl Into<u16>) -> WrappedWrite {
+    /// TODO
+    pub fn write(&self, register: impl Into<u16>) -> WrappedWrite {
         Command::fpwr(self.configured_address, register.into())
     }
 
-    pub(crate) fn read(&self, register: impl Into<u16>) -> WrappedRead {
+    /// TODO
+    pub fn read(&self, register: impl Into<u16>) -> WrappedRead {
         Command::fprd(self.configured_address, register.into())
     }
 

--- a/src/sync_manager_channel.rs
+++ b/src/sync_manager_channel.rs
@@ -59,18 +59,24 @@ impl core::fmt::Display for SyncManagerChannel {
     }
 }
 
+/// TODO
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, ethercrab_wire::EtherCrabWireReadWrite)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[wire(bytes = 1)]
 pub struct Control {
+    /// TODO
     #[wire(bits = 2)]
     pub operation_mode: OperationMode,
+    /// TODO
     #[wire(bits = 2)]
     pub direction: Direction,
+    /// TODO
     #[wire(bits = 1)]
     pub ecat_event_enable: bool,
+    /// TODO
     #[wire(bits = 1)]
     pub dls_user_event_enable: bool,
+    /// TODO
     #[wire(bits = 1, post_skip = 1)]
     pub watchdog_enable: bool,
     // reserved1: bool


### PR DESCRIPTION
Hey James; following up on #228. These are the changes I needed to make use of ethercrab with my devices and in the context of the rest of my system. I'm not sure this is all realistically upstreamable, but I'd love to merge however much of it you'd like to take!

ESI files ended up missing a bunch of information that I needed (e.g. decomposing bytes into bit flags, my-system-specific representations and metadata for the ESI variables) so I didn't end up going down that path after all; represented here is a just a ~minimum-viable escape hatch to allow manual SM and FMMU configuration... plus a few other miscellaneous changes that I wanted.