### PR TITLE
Avoid overflow when calculating time on systems with 32-bit time_t

### DIFF
--- a/src/std/unix/mod.rs
+++ b/src/std/unix/mod.rs
@@ -152,7 +152,7 @@ pub fn ethercat_now() -> u64 {
         libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut time);
     };
 
-    let t = (time.tv_sec * 1000 * 1000 * 1000 + time.tv_nsec) as u64;
+    let t = (time.tv_sec as u64) * 1_000_000_000 + (time.tv_nsec as u64);
 
     // EtherCAT epoch is 2000-01-01
     t.saturating_sub(946684800)


### PR DESCRIPTION
Discovered when trying to run ethercrab's `discover` example with dev profile on raspberry pi 3B+. 
Generally this prevents the overflow, but it still leaves the code vunerable to Y2k38 problem. Unfortunetally `libc` crate doesn't yet provide the option to use 64 bit version of `time_t` on 32 bit systems, hence I submit only this minimal change.  


Here's the full stacktrace for `discover` example:
```
thread 'main' panicked at src/std/unix/mod.rs:155:14:
attempt to multiply with overflow
stack backtrace:
   0: rust_begin_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:72:14
   2: core::panicking::panic_const::panic_const_mul_overflow
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:180:21
   3: ethercrab::std::unix::ethercat_now
             at /project/src/std/unix/mod.rs:155:14
   4: core::ops::function::Fn::call
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ops/function.rs:79:5
   5: ethercrab::dc::configure_dc::{{closure}}
             at /project/src/dc.rs:430:25
   6: ethercrab::maindevice::MainDevice::init::{{closure}}
             at /project/src/maindevice.rs:297:83
   7: ethercrab::maindevice::MainDevice::init_single_group::{{closure}}
             at /project/src/maindevice.rs:428:14
   8: discover::main::{{closure}}
             at /project/examples/discover.rs:46:14
   9: async_io::driver::block_on::{{closure}}
             at /cargo/registry/src/index.crates.io-6f17d22bba15001f/async-io-2.4.0/src/driver.rs:199:37
  10: std::thread::local::LocalKey<T>::try_with
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/thread/local.rs:286:12
  11: std::thread::local::LocalKey<T>::with
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/thread/local.rs:262:9
  12: async_io::driver::block_on
             at /cargo/registry/src/index.crates.io-6f17d22bba15001f/async-io-2.4.0/src/driver.rs:175:5
  13: discover::main
             at /project/examples/discover.rs:41:5
  14: core::ops::function::FnOnce::call_once
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

```