### PR TITLE
Add a blocking Windows TX/RX function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ An EtherCAT MainDevice written in Rust.
   chunked into however many fit into a frame, instead of being sent separately.
 - [#241](https://github.com/ethercrab-rs/ethercrab/pull/241) (@david-boles) During init, SMs and
   FMMUs are reset one-by-one instead of the entire block being written to.
+- **(breaking)** [#246](https://github.com/ethercrab-rs/ethercrab/pull/246) `PduRx::receive_frame`
+  now returns `Result<ReceiveAction, Error>` instead of `Result<(), Error>`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ An EtherCAT MainDevice written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Deprecated
+
+- [#246](https://github.com/ethercrab-rs/ethercrab/pull/246) **Windows only**. `tx_rx_task` is
+  replaced with `tx_rx_task_blocking` which is no longer `async`. It must be spawned into its own
+  thread instead of an async task. `tx_rx_task` will be removed in a future release.
+
 ### Added
 
 - [#234](https://github.com/ethercrab-rs/ethercrab/pull/234) Added `SubDeviceRef::sdo_write_array`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ An EtherCAT MainDevice written in Rust.
 
 ### Deprecated
 
-- [#246](https://github.com/ethercrab-rs/ethercrab/pull/246) **Windows only**. `tx_rx_task` is
-  replaced with `tx_rx_task_blocking` which is no longer `async`. It must be spawned into its own
-  thread instead of an async task. `tx_rx_task` will be removed in a future release.
+- [#246](https://github.com/ethercrab-rs/ethercrab/pull/246) **Windows:** `tx_rx_task` is replaced
+  with `tx_rx_task_blocking` which is no longer `async`. It must be spawned into its own thread
+  instead of an async task. `tx_rx_task` will be removed in a future release.
 
 ### Added
 
@@ -19,6 +19,8 @@ An EtherCAT MainDevice written in Rust.
 - [#239](https://github.com/ethercrab-rs/ethercrab/pull/239) Add
   `MailboxError::Emergency { error_code, error_register }` variant to surface EMERGENCY responses
   from CoE transactions.
+- [#246](https://github.com/ethercrab-rs/ethercrab/pull/246) **Windows:** Add `tx_rx_task_blocking`
+  to use in a separate thread to send/receive EitherCAT frames.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ quanta = "0.12.3"
 [target.'cfg(target_os = "windows")'.dependencies]
 pnet_datalink = { version = "0.34.0", features = ["std"], optional = true }
 async-channel = "2.2.0"
+pcap = "2.2.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.149"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,6 @@ sealed = "0.5.0"
 serde = { version = "1.0.190", features = ["derive"], optional = true }
 smlang = "0.6.0"
 ethercrab-wire = { version = "0.2.0", path = "./ethercrab-wire" }
-spin_sleep = "1.2.1"
-quanta = "0.12.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 pnet_datalink = { version = "0.34.0", features = ["std"], optional = true }
@@ -78,6 +76,8 @@ serde = { version = "1.0.190", default-features = false, features = ["derive"] }
 signal-hook = "0.3.17"
 core_affinity = "0.8.1"
 anyhow = "1.0.82"
+spin_sleep = "1.2.1"
+quanta = "0.12.3"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ sealed = "0.5.0"
 serde = { version = "1.0.190", features = ["derive"], optional = true }
 smlang = "0.6.0"
 ethercrab-wire = { version = "0.2.0", path = "./ethercrab-wire" }
+spin_sleep = "1.2.1"
+quanta = "0.12.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 pnet_datalink = { version = "0.34.0", features = ["std"], optional = true }

--- a/examples/ek1100.rs
+++ b/examples/ek1100.rs
@@ -17,9 +17,11 @@
 use env_logger::Env;
 use ethercrab::{
     error::Error,
-    std::{ethercat_now, tx_rx_task},
+    std::{ethercat_now, tx_rx_task_blocking},
     MainDevice, MainDeviceConfig, PduStorage, Timeouts,
 };
+use futures_lite::StreamExt;
+use spin_sleep::{SpinSleeper, SpinStrategy};
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -27,6 +29,7 @@ use std::{
     },
     time::Duration,
 };
+use thread_priority::{ThreadPriority, ThreadPriorityValue};
 use tokio::time::MissedTickBehavior;
 
 /// Maximum number of SubDevices that can be stored. This must be a power of 2 greater than 1.
@@ -40,8 +43,7 @@ const PDI_LEN: usize = 64;
 
 static PDU_STORAGE: PduStorage<MAX_FRAMES, MAX_PDU_DATA> = PduStorage::new();
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     let interface = std::env::args()
@@ -61,100 +63,151 @@ async fn main() -> Result<(), Error> {
         Timeouts {
             wait_loop_delay: Duration::from_millis(2),
             mailbox_response: Duration::from_millis(1000),
+            eeprom: Duration::from_millis(50),
+            state_transition: Duration::from_secs(20),
+            pdu: Duration::from_millis(50),
             ..Default::default()
         },
-        MainDeviceConfig::default(),
+        MainDeviceConfig {
+            dc_static_sync_iterations: 1000,
+            ..MainDeviceConfig::default()
+        },
     ));
 
-    tokio::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task"));
+    let core_ids = core_affinity::get_core_ids().unwrap();
 
-    let mut group = maindevice
-        .init_single_group::<MAX_SUBDEVICES, PDI_LEN>(ethercat_now)
-        .await
-        .expect("Init");
+    // Pick the non-HT cores
+    let main_thread_core = core_ids[0];
+    let tx_rx_core = core_ids[2];
 
-    log::info!("Discovered {} SubDevices", group.len());
+    core_affinity::set_for_current(main_thread_core);
 
-    for subdevice in group.iter(&maindevice) {
-        if subdevice.name() == "EL3004" {
-            log::info!("Found EL3004. Configuring...");
+    thread_priority::ThreadBuilder::default()
+        .name("tx-rx-thread")
+        // Might need to set `<user> hard rtprio 99` and `<user> soft rtprio 99` in `/etc/security/limits.conf`
+        // Check limits with `ulimit -Hr` or `ulimit -Sr`
+        // .priority(ThreadPriority::Crossplatform(
+        //     ThreadPriorityValue::try_from(49u8).unwrap(),
+        // ))
+        // // NOTE: Requires a realtime kernel
+        // .policy(ThreadSchedulePolicy::Realtime(
+        //     RealtimeThreadSchedulePolicy::Fifo,
+        // ))
+        .spawn(move |_| {
+            core_affinity::set_for_current(tx_rx_core)
+                .then_some(())
+                .expect("Set TX/RX thread core");
 
-            subdevice.sdo_write(0x1c12, 0, 0u8).await?;
+            let local = smol::LocalExecutor::new();
 
-            subdevice
-                .sdo_write_array(0x1c13, &[0x1a00u16, 0x1a02, 0x1a04, 0x1a06])
-                .await?;
+            tx_rx_task_blocking(&interface, tx, rx).expect("TX/RX task");
+        })
+        .unwrap();
 
-            // The `sdo_write_array` call above is equivalent to the following
-            // subdevice.sdo_write(0x1c13, 0, 0u8).await?;
-            // subdevice.sdo_write(0x1c13, 1, 0x1a00u16).await?;
-            // subdevice.sdo_write(0x1c13, 2, 0x1a02u16).await?;
-            // subdevice.sdo_write(0x1c13, 3, 0x1a04u16).await?;
-            // subdevice.sdo_write(0x1c13, 4, 0x1a06u16).await?;
-            // subdevice.sdo_write(0x1c13, 0, 4u8).await?;
-        }
-    }
+    // smol::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task")).detach();
 
-    let mut group = group.into_op(&maindevice).await.expect("PRE-OP -> OP");
+    smol::block_on(async {
+        let mut group = maindevice
+            .init_single_group::<MAX_SUBDEVICES, PDI_LEN>(ethercat_now)
+            .await
+            .expect("Init");
 
-    for subdevice in group.iter(&maindevice) {
-        let (i, o) = subdevice.io_raw();
+        log::info!("Discovered {} SubDevices", group.len());
 
-        log::info!(
-            "-> SubDevice {:#06x} {} inputs: {} bytes, outputs: {} bytes",
-            subdevice.configured_address(),
-            subdevice.name(),
-            i.len(),
-            o.len()
-        );
-    }
+        for subdevice in group.iter(&maindevice) {
+            if subdevice.name() == "EL3004" {
+                log::info!("Found EL3004. Configuring...");
 
-    let mut tick_interval = tokio::time::interval(Duration::from_millis(5));
-    tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                subdevice.sdo_write(0x1c12, 0, 0u8).await?;
 
-    let shutdown = Arc::new(AtomicBool::new(false));
-    signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&shutdown))
-        .expect("Register hook");
+                subdevice
+                    .sdo_write_array(0x1c13, &[0x1a00u16, 0x1a02, 0x1a04, 0x1a06])
+                    .await?;
 
-    loop {
-        // Graceful shutdown on Ctrl + C
-        if shutdown.load(Ordering::Relaxed) {
-            log::info!("Shutting down...");
-
-            break;
-        }
-
-        group.tx_rx(&maindevice).await.expect("TX/RX");
-
-        // Increment every output byte for every SubDevice by one
-        for mut subdevice in group.iter(&maindevice) {
-            let (_i, o) = subdevice.io_raw_mut();
-
-            for byte in o.iter_mut() {
-                *byte = byte.wrapping_add(1);
+                // The `sdo_write_array` call above is equivalent to the following
+                // subdevice.sdo_write(0x1c13, 0, 0u8).await?;
+                // subdevice.sdo_write(0x1c13, 1, 0x1a00u16).await?;
+                // subdevice.sdo_write(0x1c13, 2, 0x1a02u16).await?;
+                // subdevice.sdo_write(0x1c13, 3, 0x1a04u16).await?;
+                // subdevice.sdo_write(0x1c13, 4, 0x1a06u16).await?;
+                // subdevice.sdo_write(0x1c13, 0, 4u8).await?;
             }
         }
 
-        tick_interval.tick().await;
-    }
+        let mut group = group.into_op(&maindevice).await.expect("PRE-OP -> OP");
 
-    let group = group
-        .into_safe_op(&maindevice)
-        .await
-        .expect("OP -> SAFE-OP");
+        for subdevice in group.iter(&maindevice) {
+            let (i, o) = subdevice.io_raw();
 
-    log::info!("OP -> SAFE-OP");
+            log::info!(
+                "-> SubDevice {:#06x} {} inputs: {} bytes, outputs: {} bytes",
+                subdevice.configured_address(),
+                subdevice.name(),
+                i.len(),
+                o.len()
+            );
+        }
 
-    let group = group
-        .into_pre_op(&maindevice)
-        .await
-        .expect("SAFE-OP -> PRE-OP");
+        // let mut tick_interval = tokio::time::interval(Duration::from_millis(5));
+        // tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-    log::info!("SAFE-OP -> PRE-OP");
+        let mut tick_interval = smol::Timer::interval(Duration::from_millis(5));
 
-    let _group = group.into_init(&maindevice).await.expect("PRE-OP -> INIT");
+        let sleeper = SpinSleeper::default().with_spin_strategy(SpinStrategy::SpinLoopHint);
 
-    log::info!("PRE-OP -> INIT, shutdown complete");
+        let mut clock = quanta::Clock::new();
 
-    Ok(())
+        let shutdown = Arc::new(AtomicBool::new(false));
+        signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&shutdown))
+            .expect("Register hook");
+
+        // Run for 10 seconds
+        for _ in 0..2_000 {
+            let now = clock.now();
+
+            // Graceful shutdown on Ctrl + C
+            if shutdown.load(Ordering::Relaxed) {
+                log::info!("Shutting down...");
+
+                break;
+            }
+
+            group.tx_rx(&maindevice).await.expect("TX/RX");
+
+            // Increment every output byte for every SubDevice by one
+            for mut subdevice in group.iter(&maindevice) {
+                let (_i, o) = subdevice.io_raw_mut();
+
+                for byte in o.iter_mut() {
+                    *byte = byte.wrapping_add(1);
+                }
+            }
+
+            let wait = Duration::from_millis(5).saturating_sub(now.elapsed());
+
+            // tick_interval.next().await;
+
+            sleeper.sleep(wait);
+        }
+
+        let group = group
+            .into_safe_op(&maindevice)
+            .await
+            .expect("OP -> SAFE-OP");
+
+        log::info!("OP -> SAFE-OP");
+
+        let group = group
+            .into_pre_op(&maindevice)
+            .await
+            .expect("SAFE-OP -> PRE-OP");
+
+        log::info!("SAFE-OP -> PRE-OP");
+
+        let _group = group.into_init(&maindevice).await.expect("PRE-OP -> INIT");
+
+        log::info!("PRE-OP -> INIT, shutdown complete");
+
+        Ok(())
+    })
 }

--- a/examples/ek1100.rs
+++ b/examples/ek1100.rs
@@ -17,11 +17,9 @@
 use env_logger::Env;
 use ethercrab::{
     error::Error,
-    std::{ethercat_now, tx_rx_task_blocking},
+    std::{ethercat_now, tx_rx_task},
     MainDevice, MainDeviceConfig, PduStorage, Timeouts,
 };
-use futures_lite::StreamExt;
-use spin_sleep::{SpinSleeper, SpinStrategy};
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -29,7 +27,6 @@ use std::{
     },
     time::Duration,
 };
-use thread_priority::{ThreadPriority, ThreadPriorityValue};
 use tokio::time::MissedTickBehavior;
 
 /// Maximum number of SubDevices that can be stored. This must be a power of 2 greater than 1.
@@ -43,7 +40,8 @@ const PDI_LEN: usize = 64;
 
 static PDU_STORAGE: PduStorage<MAX_FRAMES, MAX_PDU_DATA> = PduStorage::new();
 
-fn main() -> Result<(), Error> {
+#[tokio::main]
+async fn main() -> Result<(), Error> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     let interface = std::env::args()
@@ -63,151 +61,100 @@ fn main() -> Result<(), Error> {
         Timeouts {
             wait_loop_delay: Duration::from_millis(2),
             mailbox_response: Duration::from_millis(1000),
-            eeprom: Duration::from_millis(50),
-            state_transition: Duration::from_secs(20),
-            pdu: Duration::from_millis(50),
             ..Default::default()
         },
-        MainDeviceConfig {
-            dc_static_sync_iterations: 1000,
-            ..MainDeviceConfig::default()
-        },
+        MainDeviceConfig::default(),
     ));
 
-    let core_ids = core_affinity::get_core_ids().unwrap();
+    tokio::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task"));
 
-    // Pick the non-HT cores
-    let main_thread_core = core_ids[0];
-    let tx_rx_core = core_ids[2];
+    let mut group = maindevice
+        .init_single_group::<MAX_SUBDEVICES, PDI_LEN>(ethercat_now)
+        .await
+        .expect("Init");
 
-    core_affinity::set_for_current(main_thread_core);
+    log::info!("Discovered {} SubDevices", group.len());
 
-    thread_priority::ThreadBuilder::default()
-        .name("tx-rx-thread")
-        // Might need to set `<user> hard rtprio 99` and `<user> soft rtprio 99` in `/etc/security/limits.conf`
-        // Check limits with `ulimit -Hr` or `ulimit -Sr`
-        // .priority(ThreadPriority::Crossplatform(
-        //     ThreadPriorityValue::try_from(49u8).unwrap(),
-        // ))
-        // // NOTE: Requires a realtime kernel
-        // .policy(ThreadSchedulePolicy::Realtime(
-        //     RealtimeThreadSchedulePolicy::Fifo,
-        // ))
-        .spawn(move |_| {
-            core_affinity::set_for_current(tx_rx_core)
-                .then_some(())
-                .expect("Set TX/RX thread core");
+    for subdevice in group.iter(&maindevice) {
+        if subdevice.name() == "EL3004" {
+            log::info!("Found EL3004. Configuring...");
 
-            let local = smol::LocalExecutor::new();
+            subdevice.sdo_write(0x1c12, 0, 0u8).await?;
 
-            tx_rx_task_blocking(&interface, tx, rx).expect("TX/RX task");
-        })
-        .unwrap();
+            subdevice
+                .sdo_write_array(0x1c13, &[0x1a00u16, 0x1a02, 0x1a04, 0x1a06])
+                .await?;
 
-    // smol::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task")).detach();
+            // The `sdo_write_array` call above is equivalent to the following
+            // subdevice.sdo_write(0x1c13, 0, 0u8).await?;
+            // subdevice.sdo_write(0x1c13, 1, 0x1a00u16).await?;
+            // subdevice.sdo_write(0x1c13, 2, 0x1a02u16).await?;
+            // subdevice.sdo_write(0x1c13, 3, 0x1a04u16).await?;
+            // subdevice.sdo_write(0x1c13, 4, 0x1a06u16).await?;
+            // subdevice.sdo_write(0x1c13, 0, 4u8).await?;
+        }
+    }
 
-    smol::block_on(async {
-        let mut group = maindevice
-            .init_single_group::<MAX_SUBDEVICES, PDI_LEN>(ethercat_now)
-            .await
-            .expect("Init");
+    let mut group = group.into_op(&maindevice).await.expect("PRE-OP -> OP");
 
-        log::info!("Discovered {} SubDevices", group.len());
+    for subdevice in group.iter(&maindevice) {
+        let (i, o) = subdevice.io_raw();
 
-        for subdevice in group.iter(&maindevice) {
-            if subdevice.name() == "EL3004" {
-                log::info!("Found EL3004. Configuring...");
+        log::info!(
+            "-> SubDevice {:#06x} {} inputs: {} bytes, outputs: {} bytes",
+            subdevice.configured_address(),
+            subdevice.name(),
+            i.len(),
+            o.len()
+        );
+    }
 
-                subdevice.sdo_write(0x1c12, 0, 0u8).await?;
+    let mut tick_interval = tokio::time::interval(Duration::from_millis(5));
+    tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-                subdevice
-                    .sdo_write_array(0x1c13, &[0x1a00u16, 0x1a02, 0x1a04, 0x1a06])
-                    .await?;
+    let shutdown = Arc::new(AtomicBool::new(false));
+    signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&shutdown))
+        .expect("Register hook");
 
-                // The `sdo_write_array` call above is equivalent to the following
-                // subdevice.sdo_write(0x1c13, 0, 0u8).await?;
-                // subdevice.sdo_write(0x1c13, 1, 0x1a00u16).await?;
-                // subdevice.sdo_write(0x1c13, 2, 0x1a02u16).await?;
-                // subdevice.sdo_write(0x1c13, 3, 0x1a04u16).await?;
-                // subdevice.sdo_write(0x1c13, 4, 0x1a06u16).await?;
-                // subdevice.sdo_write(0x1c13, 0, 4u8).await?;
+    loop {
+        // Graceful shutdown on Ctrl + C
+        if shutdown.load(Ordering::Relaxed) {
+            log::info!("Shutting down...");
+
+            break;
+        }
+
+        group.tx_rx(&maindevice).await.expect("TX/RX");
+
+        // Increment every output byte for every SubDevice by one
+        for mut subdevice in group.iter(&maindevice) {
+            let (_i, o) = subdevice.io_raw_mut();
+
+            for byte in o.iter_mut() {
+                *byte = byte.wrapping_add(1);
             }
         }
 
-        let mut group = group.into_op(&maindevice).await.expect("PRE-OP -> OP");
+        tick_interval.tick().await;
+    }
 
-        for subdevice in group.iter(&maindevice) {
-            let (i, o) = subdevice.io_raw();
+    let group = group
+        .into_safe_op(&maindevice)
+        .await
+        .expect("OP -> SAFE-OP");
 
-            log::info!(
-                "-> SubDevice {:#06x} {} inputs: {} bytes, outputs: {} bytes",
-                subdevice.configured_address(),
-                subdevice.name(),
-                i.len(),
-                o.len()
-            );
-        }
+    log::info!("OP -> SAFE-OP");
 
-        // let mut tick_interval = tokio::time::interval(Duration::from_millis(5));
-        // tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let group = group
+        .into_pre_op(&maindevice)
+        .await
+        .expect("SAFE-OP -> PRE-OP");
 
-        let mut tick_interval = smol::Timer::interval(Duration::from_millis(5));
+    log::info!("SAFE-OP -> PRE-OP");
 
-        let sleeper = SpinSleeper::default().with_spin_strategy(SpinStrategy::SpinLoopHint);
+    let _group = group.into_init(&maindevice).await.expect("PRE-OP -> INIT");
 
-        let mut clock = quanta::Clock::new();
+    log::info!("PRE-OP -> INIT, shutdown complete");
 
-        let shutdown = Arc::new(AtomicBool::new(false));
-        signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&shutdown))
-            .expect("Register hook");
-
-        // Run for 10 seconds
-        for _ in 0..2_000 {
-            let now = clock.now();
-
-            // Graceful shutdown on Ctrl + C
-            if shutdown.load(Ordering::Relaxed) {
-                log::info!("Shutting down...");
-
-                break;
-            }
-
-            group.tx_rx(&maindevice).await.expect("TX/RX");
-
-            // Increment every output byte for every SubDevice by one
-            for mut subdevice in group.iter(&maindevice) {
-                let (_i, o) = subdevice.io_raw_mut();
-
-                for byte in o.iter_mut() {
-                    *byte = byte.wrapping_add(1);
-                }
-            }
-
-            let wait = Duration::from_millis(5).saturating_sub(now.elapsed());
-
-            // tick_interval.next().await;
-
-            sleeper.sleep(wait);
-        }
-
-        let group = group
-            .into_safe_op(&maindevice)
-            .await
-            .expect("OP -> SAFE-OP");
-
-        log::info!("OP -> SAFE-OP");
-
-        let group = group
-            .into_pre_op(&maindevice)
-            .await
-            .expect("SAFE-OP -> PRE-OP");
-
-        log::info!("SAFE-OP -> PRE-OP");
-
-        let _group = group.into_init(&maindevice).await.expect("PRE-OP -> INIT");
-
-        log::info!("PRE-OP -> INIT, shutdown complete");
-
-        Ok(())
-    })
+    Ok(())
 }

--- a/examples/windows.rs
+++ b/examples/windows.rs
@@ -52,6 +52,7 @@ async fn main() -> Result<(), ethercrab::error::Error> {
             // Windows timers are rubbish (min delay is ~15ms) which will cause a bunch of timeouts
             // if `wait_loop_delay` is anything above 0.
             wait_loop_delay: Duration::ZERO,
+            eeprom: Duration::from_millis(50),
             // Other timeouts can be left alone, or increased if other issues are found.
             ..Default::default()
         },

--- a/examples/windows.rs
+++ b/examples/windows.rs
@@ -1,0 +1,196 @@
+//! A simple test program that demonstrates tweaks recommended to improve performance on Windows.
+//!
+//! Tested on Windows 11, i5-8500T, Intel i219-LM NIC. Your mileage may vary! Please open Github
+//! issue with a Wireshark capture if you encounter perf issues.
+
+#[cfg(windows)]
+#[tokio::main]
+async fn main() -> Result<(), ethercrab::error::Error> {
+    use env_logger::Env;
+    use ethercrab::{
+        std::{ethercat_now, tx_rx_task_blocking},
+        MainDevice, MainDeviceConfig, PduStorage, Timeouts,
+    };
+    use spin_sleep::{SpinSleeper, SpinStrategy};
+    use std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+    use thread_priority::{ThreadPriority, ThreadPriorityOsValue, WinAPIThreadPriority};
+
+    /// Maximum number of SubDevices that can be stored. This must be a power of 2 greater than 1.
+    const MAX_SUBDEVICES: usize = 16;
+    /// Maximum PDU data payload size - set this to the max PDI size or higher.
+    const MAX_PDU_DATA: usize = PduStorage::element_size(1100);
+    /// Maximum number of EtherCAT frames that can be in flight at any one time.
+    const MAX_FRAMES: usize = 16;
+    /// Maximum total PDI length.
+    const PDI_LEN: usize = 64;
+
+    static PDU_STORAGE: PduStorage<MAX_FRAMES, MAX_PDU_DATA> = PduStorage::new();
+
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    let interface = std::env::args()
+        .nth(1)
+        .expect("Provide network interface as first argument.");
+
+    log::info!("Starting EK1100/EK1501 demo...");
+    log::info!(
+        "Ensure an EK1100 or EK1501 is the first SubDevice, with any number of modules connected after"
+    );
+    log::info!("Run with RUST_LOG=ethercrab=debug or =trace for debug information");
+
+    let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
+
+    let maindevice = Arc::new(MainDevice::new(
+        pdu_loop,
+        Timeouts {
+            // Windows timers are rubbish (min delay is ~15ms) which will cause a bunch of timeouts
+            // if `wait_loop_delay` is anything above 0.
+            wait_loop_delay: Duration::ZERO,
+            // Other timeouts can be left alone, or increased if other issues are found.
+            ..Default::default()
+        },
+        MainDeviceConfig {
+            // Quicker startup, mainly just for testing.
+            dc_static_sync_iterations: 1000,
+            ..MainDeviceConfig::default()
+        },
+    ));
+
+    let core_ids = core_affinity::get_core_ids().expect("Get core IDs");
+
+    // Pick the non-HT cores on my Intel i5-8500T test system. YMMV!
+    let main_thread_core = core_ids[0];
+    let tx_rx_core = core_ids[2];
+
+    // Pinning this and the TX/RX thread reduce packet RTT spikes significantly
+    core_affinity::set_for_current(main_thread_core);
+
+    // For best performance, use e.g.
+    // https://www.techpowerup.com/download/microsoft-interrupt-affinity-tool/ to pin NIC IRQs to
+    // the same core as the TX/RX thread.
+    thread_priority::ThreadBuilder::default()
+        .name("tx-rx-thread")
+        // For best performance, this MUST be set if pinning NIC IRQs to the same core
+        .priority(ThreadPriority::Os(ThreadPriorityOsValue::from(
+            WinAPIThreadPriority::TimeCritical,
+        )))
+        .spawn(move |_| {
+            core_affinity::set_for_current(tx_rx_core)
+                .then_some(())
+                .expect("Set TX/RX thread core");
+
+            tx_rx_task_blocking(&interface, tx, rx).expect("TX/RX task");
+        })
+        .unwrap();
+
+    let mut group = maindevice
+        .init_single_group::<MAX_SUBDEVICES, PDI_LEN>(ethercat_now)
+        .await
+        .expect("Init");
+
+    log::info!("Discovered {} SubDevices", group.len());
+
+    for subdevice in group.iter(&maindevice) {
+        if subdevice.name() == "EL3004" {
+            log::info!("Found EL3004. Configuring...");
+
+            subdevice.sdo_write(0x1c12, 0, 0u8).await?;
+
+            subdevice
+                .sdo_write_array(0x1c13, &[0x1a00u16, 0x1a02, 0x1a04, 0x1a06])
+                .await?;
+
+            // The `sdo_write_array` call above is equivalent to the following
+            // subdevice.sdo_write(0x1c13, 0, 0u8).await?;
+            // subdevice.sdo_write(0x1c13, 1, 0x1a00u16).await?;
+            // subdevice.sdo_write(0x1c13, 2, 0x1a02u16).await?;
+            // subdevice.sdo_write(0x1c13, 3, 0x1a04u16).await?;
+            // subdevice.sdo_write(0x1c13, 4, 0x1a06u16).await?;
+            // subdevice.sdo_write(0x1c13, 0, 4u8).await?;
+        }
+    }
+
+    let mut group = group.into_op(&maindevice).await.expect("PRE-OP -> OP");
+
+    for subdevice in group.iter(&maindevice) {
+        let (i, o) = subdevice.io_raw();
+
+        log::info!(
+            "-> SubDevice {:#06x} {} inputs: {} bytes, outputs: {} bytes",
+            subdevice.configured_address(),
+            subdevice.name(),
+            i.len(),
+            o.len()
+        );
+    }
+
+    let cycle_time = Duration::from_millis(5);
+
+    // Both `smol` and `tokio` use Windows' coarse timer, which has a resolution of at least
+    // 15ms. This isn't useful for decent cycle times, so we use a more accurate clock from
+    // `quanta` and a spin sleeper to get better timing accuracy.
+    let sleeper = SpinSleeper::default().with_spin_strategy(SpinStrategy::SpinLoopHint);
+    let clock = quanta::Clock::new();
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&shutdown))
+        .expect("Register hook");
+
+    loop {
+        let now = clock.now();
+
+        // Graceful shutdown on Ctrl + C
+        if shutdown.load(Ordering::Relaxed) {
+            log::info!("Shutting down...");
+
+            break;
+        }
+
+        group.tx_rx(&maindevice).await.expect("TX/RX");
+
+        // Increment every output byte for every SubDevice by one
+        for mut subdevice in group.iter(&maindevice) {
+            let (_i, o) = subdevice.io_raw_mut();
+
+            for byte in o.iter_mut() {
+                *byte = byte.wrapping_add(1);
+            }
+        }
+
+        let wait = cycle_time.saturating_sub(now.elapsed());
+        sleeper.sleep(wait);
+    }
+
+    let group = group
+        .into_safe_op(&maindevice)
+        .await
+        .expect("OP -> SAFE-OP");
+
+    log::info!("OP -> SAFE-OP");
+
+    let group = group
+        .into_pre_op(&maindevice)
+        .await
+        .expect("SAFE-OP -> PRE-OP");
+
+    log::info!("SAFE-OP -> PRE-OP");
+
+    let _group = group.into_init(&maindevice).await.expect("PRE-OP -> INIT");
+
+    log::info!("PRE-OP -> INIT, shutdown complete");
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn main() {
+    eprintln!(
+        "Windows-only - the performance changes in this example don't make sense for other OSes"
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ pub use ethercrab_wire::{
 use ethernet::EthernetAddress;
 pub use maindevice::MainDevice;
 pub use maindevice_config::{MainDeviceConfig, RetryBehaviour};
-pub use pdu_loop::{PduLoop, PduRx, PduStorage, PduTx, SendableFrame};
+pub use pdu_loop::{PduLoop, PduRx, PduStorage, PduTx, ReceiveAction, SendableFrame};
 pub use register::{DcSupport, RegisterAddress};
 pub use subdevice::{DcSync, SubDevice, SubDeviceIdentity, SubDevicePdi, SubDeviceRef};
 pub use subdevice_group::{GroupId, GroupSubDeviceIterator, SubDeviceGroup, SubDeviceGroupHandle};

--- a/src/pdu_loop/mod.rs
+++ b/src/pdu_loop/mod.rs
@@ -10,6 +10,9 @@ pub mod storage;
 use crate::{command::Command, error::Error, pdu_loop::storage::PduStorageRef};
 use core::time::Duration;
 pub use pdu_rx::PduRx;
+// NOTE: Allowing unused because `ReceiveAction` isn't used when `xdp` is not enabled.
+#[allow(unused)]
+pub use pdu_rx::ReceiveAction;
 pub use pdu_tx::PduTx;
 pub use storage::PduStorage;
 
@@ -250,7 +253,7 @@ mod tests {
 
             let result = rx.receive_frame(&written_packet);
 
-            assert_eq!(result, Ok(()));
+            assert_eq!(result, Ok(crate::ReceiveAction::Processed));
 
             // The frame has received a response at this point so should be ready to get the data
             // from
@@ -377,7 +380,7 @@ mod tests {
 
             let result = rx.receive_frame(&ethernet_packet);
 
-            assert_eq!(result, Ok(()));
+            assert_eq!(result, Ok(crate::ReceiveAction::Processed));
 
             // The frame has received a response at this point so should be ready to get the data
             // from

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 #[cfg(target_os = "windows")]
-pub use self::windows::{ethercat_now, tx_rx_task_blocking};
+pub use self::windows::{ethercat_now, tx_rx_task, tx_rx_task_blocking};
 #[cfg(unix)]
 pub use unix::{ethercat_now, tx_rx_task};
 // io_uring is Linux-only

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -8,7 +8,7 @@ mod unix;
 mod windows;
 
 #[cfg(target_os = "windows")]
-pub use self::windows::{ethercat_now, tx_rx_task};
+pub use self::windows::{ethercat_now, tx_rx_task, tx_rx_task_blocking};
 #[cfg(unix)]
 pub use unix::{ethercat_now, tx_rx_task};
 // io_uring is Linux-only

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -7,6 +7,12 @@ mod unix;
 #[cfg(target_os = "windows")]
 mod windows;
 
+use std::{
+    sync::Arc,
+    task::Wake,
+    thread::{self, Thread},
+};
+
 #[cfg(target_os = "windows")]
 pub use self::windows::{ethercat_now, tx_rx_task, tx_rx_task_blocking};
 #[cfg(unix)]
@@ -14,3 +20,29 @@ pub use unix::{ethercat_now, tx_rx_task};
 // io_uring is Linux-only
 #[cfg(target_os = "linux")]
 pub use io_uring::tx_rx_task_io_uring;
+
+struct ParkSignal {
+    current_thread: Thread,
+}
+
+impl ParkSignal {
+    fn new() -> Self {
+        Self {
+            current_thread: thread::current(),
+        }
+    }
+
+    fn wait(&self) {
+        thread::park();
+    }
+
+    // fn wait_timeout(&self, timeout: Duration) {
+    //     thread::park_timeout(timeout)
+    // }
+}
+
+impl Wake for ParkSignal {
+    fn wake(self: Arc<Self>) {
+        self.current_thread.unpark();
+    }
+}

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 #[cfg(target_os = "windows")]
-pub use self::windows::{ethercat_now, tx_rx_task, tx_rx_task_blocking};
+pub use self::windows::{ethercat_now, tx_rx_task_blocking};
 #[cfg(unix)]
 pub use unix::{ethercat_now, tx_rx_task};
 // io_uring is Linux-only

--- a/src/std/unix/mod.rs
+++ b/src/std/unix/mod.rs
@@ -92,7 +92,7 @@ impl Future for TxRxFut<'_> {
 
                             return Poll::Ready(Err(Error::ReceiveFrame));
                         }
-                        Ok(()) => break,
+                        Ok(_) => break,
                     }
                 }
             }

--- a/src/std/windows.rs
+++ b/src/std/windows.rs
@@ -49,6 +49,7 @@ fn get_tx_rx(
 }
 
 /// Create a task that waits for PDUs to send, and receives PDU responses.
+#[deprecated = "use `tx_rx_task_blocking` instead"]
 pub fn tx_rx_task<'sto>(
     device: &str,
     mut pdu_tx: PduTx<'sto>,

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -4,7 +4,7 @@ use ethercrab::{
     error::Error,
     internals::{EthercatFrameHeader, EthernetAddress, EthernetFrame, PduHeader},
     std::tx_rx_task,
-    PduRx, PduTx,
+    PduRx, PduTx, ReceiveAction,
 };
 use ethercrab_wire::EtherCrabWireRead;
 use pcap_file::pcapng::{Block, PcapNgReader};
@@ -80,7 +80,7 @@ struct DummyTxRxFut<'a> {
 }
 
 impl Future for DummyTxRxFut<'_> {
-    type Output = Result<(), Error>;
+    type Output = Result<ReceiveAction, Error>;
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
         self.tx.replace_waker(ctx.waker());
@@ -126,7 +126,7 @@ impl Future for DummyTxRxFut<'_> {
                 .pop_front()
                 .expect("Not enough packets for this preamble");
 
-            self.rx.receive_frame(expected.as_ref()).expect("Frame RX")
+            self.rx.receive_frame(expected.as_ref()).expect("Frame RX");
         }
 
         Poll::Pending
@@ -138,7 +138,7 @@ pub fn dummy_tx_rx_task(
     capture_file_path: &str,
     pdu_tx: PduTx<'static>,
     pdu_rx: PduRx<'static>,
-) -> Result<impl Future<Output = Result<(), Error>>, std::io::Error> {
+) -> Result<impl Future<Output = Result<ReceiveAction, Error>>, std::io::Error> {
     // let file_in = File::open(capture_file_path).expect("Error opening file");
     let file_in2 = File::open(capture_file_path).expect("Error opening file");
     // let pcapng_reader = PcapNgReader::new(file_in).expect("Failed to init PCAP reader");


### PR DESCRIPTION
TODO

- [x] Clean up example code again
- [x] Changelog entry to add blocking method
- [x] Deprecate the async Windows `tx_rx_task` so a backport to 0.5 will give warnings
- [x] Park the TX/RX threads when there's nothing in flight to save CPU
- [x] Have a look at [`async-spin-sleep`](https://github.com/kang-sw/async-spin-sleep-rs) and see what performance and CPU usage is like, with a mind to recommending it for applications that still require `async` timers.