### PR TITLE
Remove now-unused loops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 target_steps_std: &target_steps_std
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.72
+    - image: cimg/rust:1.83
   steps:
     - checkout
     - restore_cache:
@@ -42,12 +42,12 @@ target_steps_std: &target_steps_std
 miri_steps: &miri_steps
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.72
+    - image: cimg/rust:1.83
   steps:
     - checkout
     - run: sudo apt update && sudo apt install -y libpcap-dev
     - restore_cache:
-        key: v12-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+        key: v13-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
 
     # Arbitrary nightly version - just the latest at time of writing. This can be changed freely.
     - run: rustup toolchain add nightly-2024-12-20 --target $TARGET --component miri
@@ -69,7 +69,7 @@ miri_steps: &miri_steps
         cargo +nightly-2024-12-20 miri test --features '__internals' --target $TARGET
 
     - save_cache:
-        key: v12-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+        key: v13-ethercrab-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
         paths:
           - ./target
           - /home/circleci/.cargo/registry
@@ -77,7 +77,7 @@ miri_steps: &miri_steps
 target_steps_no_std: &target_steps_no_std
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.72
+    - image: cimg/rust:1.83
   steps:
     - checkout
     - restore_cache:
@@ -96,7 +96,7 @@ target_steps_no_std: &target_steps_no_std
 target_steps_embassy: &target_steps_embassy
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.72
+    - image: cimg/rust:1.83
   steps:
     - checkout
     - restore_cache:
@@ -116,7 +116,7 @@ basic_steps: &basic_steps
   resource_class: large
   docker:
     # NOTE: Exact version is overridden in `rust-toolchain.toml`
-    - image: cimg/rust:1.72
+    - image: cimg/rust:1.83
   steps:
     - checkout
     - restore_cache:
@@ -158,7 +158,7 @@ jobs:
     resource_class: large
     docker:
       # NOTE: Exact version is overridden in `rust-toolchain.toml`
-      - image: cimg/rust:1.72
+      - image: cimg/rust:1.83
     steps:
       - checkout
       - restore_cache:

--- a/src/std/io_uring.rs
+++ b/src/std/io_uring.rs
@@ -196,12 +196,9 @@ pub fn tx_rx_task_io_uring<'sto>(
                     key,
                 );
 
-                loop {
-                    match pdu_rx.receive_frame(&frame) {
-                        Ok(_) => break,
-                        Err(e) => return Err(io::Error::other(e)),
-                    }
-                }
+                pdu_rx
+                    .receive_frame(&frame)
+                    .map_err(|e| io::Error::other(e))?;
 
                 fmt::trace!("Received frame in {} ns", received.elapsed().as_nanos());
             }

--- a/src/std/unix/mod.rs
+++ b/src/std/unix/mod.rs
@@ -82,15 +82,10 @@ impl Future for TxRxFut<'_> {
                     fmt::warn!("Received zero bytes");
                 }
 
-                loop {
-                    match self.rx.receive_frame(packet) {
-                        Err(e) => {
-                            fmt::error!("Failed to receive frame: {}", e);
+                if let Err(e) = self.rx.receive_frame(packet) {
+                    fmt::error!("Failed to receive frame: {}", e);
 
-                            return Poll::Ready(Err(Error::ReceiveFrame));
-                        }
-                        Ok(_) => break,
-                    }
+                    return Poll::Ready(Err(Error::ReceiveFrame));
                 }
             }
             Poll::Ready(Err(e)) => {

--- a/src/std/windows.rs
+++ b/src/std/windows.rs
@@ -248,12 +248,9 @@ pub fn tx_rx_task_blocking<'sto>(
                             .get(0x11)
                             .ok_or_else(|| io::Error::other(Error::Internal))?;
 
-                        let res = loop {
-                            match pdu_rx.receive_frame(&frame_buf) {
-                                Ok(res) => break res,
-                                Err(e) => return Err(io::Error::other(e)),
-                            }
-                        };
+                        let res = pdu_rx
+                            .receive_frame(&frame)
+                            .map_err(|e| io::Error::other(e))?;
 
                         fmt::trace!(
                             "Received and {:?} frame {:#04x} ({} bytes)",

--- a/src/std/windows.rs
+++ b/src/std/windows.rs
@@ -249,7 +249,7 @@ pub fn tx_rx_task_blocking<'sto>(
                             .ok_or_else(|| io::Error::other(Error::Internal))?;
 
                         let res = pdu_rx
-                            .receive_frame(&frame)
+                            .receive_frame(&frame_buf)
                             .map_err(|e| io::Error::other(e))?;
 
                         fmt::trace!(


### PR DESCRIPTION
The behaviour is the same, but now the code is easier to follow.

This should've been in #260, but I forgot to change it before merging.