### PR TITLE
Increase size limit for device descriptions to 128 bytes

### DIFF
--- a/examples/discover.rs
+++ b/examples/discover.rs
@@ -57,7 +57,7 @@ fn main() {
                     .description()
                     .await
                     .expect("Failed to read description")
-                    .unwrap_or(heapless::String::<64>::from_str("[no description]").unwrap()),
+                    .unwrap_or(heapless::String::from_str("[no description]").unwrap()),
                 subdevice.identity()
             );
         }

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -247,7 +247,7 @@ impl SubDevice {
     pub async fn description(
         &self,
         maindevice: &MainDevice<'_>,
-    ) -> Result<Option<heapless::String<64>>, Error> {
+    ) -> Result<Option<heapless::String<128>>, Error> {
         let subdevice_ref = SubDeviceRef::new(maindevice, self.configured_address, ());
 
         subdevice_ref.eeprom().device_description().await
@@ -362,7 +362,7 @@ where
     ///
     /// In the case that a SubDevice does not have a description, this method will return
     /// `Ok(None)`.
-    pub async fn description(&self) -> Result<Option<heapless::String<64>>, Error> {
+    pub async fn description(&self) -> Result<Option<heapless::String<128>>, Error> {
         SubDevice::description(&self.state, &self.maindevice).await
     }
 


### PR DESCRIPTION
I found that the device description for a Beckhoff EL1259 is 68B, just over the 64B limit presently.  Doubling the limit solves the issue.