### PR TITLE
Add `release` and `release_all` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ An EtherCAT MainDevice written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
-### Deprecated
-
-- [#246](https://github.com/ethercrab-rs/ethercrab/pull/246) **Windows:** `tx_rx_task` is replaced
-  with `tx_rx_task_blocking` which is no longer `async`. It must be spawned into its own thread
-  instead of an async task. `tx_rx_task` will be removed in a future release.
-
 ### Added
 
 - [#234](https://github.com/ethercrab-rs/ethercrab/pull/234) Added `SubDeviceRef::sdo_write_array`
@@ -36,6 +30,9 @@ An EtherCAT MainDevice written in Rust.
 - **(breaking)** [#263](https://github.com/ethercrab-rs/ethercrab/pull/263) `SubDeviceIterator` is
   removed. The returned iterator's type signature is now
   `impl Iterator<Item = SubDeviceRef<'group, ...>>`
+- **(breaking)** [#270](https://github.com/ethercrab-rs/ethercrab/pull/270) **Windows:**
+  `tx_rx_task` is removed and replaced with `tx_rx_task_blocking` which is no longer `async`. It
+  must be spawned into its own thread instead of an async task.
 
 ### Changed
 

--- a/ethercrab-wire/tests/irl.rs
+++ b/ethercrab-wire/tests/irl.rs
@@ -3,7 +3,7 @@ use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireReadWrite};
 #[test]
 fn sync_manager_channel() {
     #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, EtherCrabWireReadWrite)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[wire(bits = 8)]
     pub struct Control {
         #[wire(bits = 2)]
@@ -40,7 +40,7 @@ fn sync_manager_channel() {
 #[test]
 fn pdo() {
     #[derive(Clone, PartialEq, ethercrab_wire::EtherCrabWireReadWrite)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[wire(bytes = 6)]
     pub struct Pdo {
         #[wire(bytes = 2)]
@@ -107,7 +107,7 @@ fn bare_enum() {
 #[test]
 fn arr() {
     #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, EtherCrabWireReadWrite)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[wire(bytes = 4)]
     pub struct Control {
         #[wire(bytes = 4)]
@@ -118,7 +118,7 @@ fn arr() {
 #[test]
 fn enum_u16() {
     #[derive(Debug, Copy, Clone, ethercrab_wire::EtherCrabWireReadWrite)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[repr(u16)]
     pub enum AlStatusCode {
         NoError = 0x0000,
@@ -132,7 +132,7 @@ fn enum_alternatives() {
     #[derive(
         Default, Debug, Copy, Clone, PartialEq, Eq, ethercrab_wire::EtherCrabWireReadWrite,
     )]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[repr(u16)]
     pub enum Alternatives {
         #[default]
@@ -145,7 +145,7 @@ fn enum_alternatives() {
 #[test]
 fn enum_default_and_catch_all() {
     #[derive(Default, Debug, Copy, Clone, ethercrab_wire::EtherCrabWireReadWrite)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[repr(u16)]
     pub enum AlStatusCode {
         NoError = 0x0000,
@@ -159,7 +159,7 @@ fn enum_default_and_catch_all() {
 #[test]
 fn enum_default_only() {
     #[derive(Default, Debug, Copy, Clone, ethercrab_wire::EtherCrabWireReadWrite)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[repr(u16)]
     pub enum AlStatusCode {
         NoError = 0x0000,
@@ -173,7 +173,7 @@ fn heapless_vec() {
     #[derive(
         Default, Debug, Copy, Clone, PartialEq, Eq, ethercrab_wire::EtherCrabWireReadWrite,
     )]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
     #[repr(u8)]
     pub enum SyncManagerType {
         /// Not used or unknown.

--- a/ethercrab-wire/tests/signed-enums.rs
+++ b/ethercrab-wire/tests/signed-enums.rs
@@ -121,6 +121,7 @@ fn cia402_control_word() {
 }
 
 #[test]
+#[allow(unused)]
 fn sized() {
     #[derive(ethercrab_wire::EtherCrabWireRead)]
     #[wire(bytes = 9)]

--- a/ethercrab-wire/tests/std.rs
+++ b/ethercrab-wire/tests/std.rs
@@ -1,7 +1,8 @@
-use ethercrab_wire::EtherCrabWireRead;
-
+#[cfg(feature = "std")]
 #[test]
 fn std_string() {
+    use ethercrab_wire::EtherCrabWireRead;
+
     let input = "Hello world".as_bytes();
 
     assert_eq!(

--- a/examples/release.rs
+++ b/examples/release.rs
@@ -1,0 +1,191 @@
+//! Demonstrate releasing of a global `PduLoop`, then of the PDU loop and all TX/RX handles so they
+//! can be reused.
+//!
+//! The process data loop does 256 iterations then moves on to the next scenario.
+
+use env_logger::Env;
+use ethercrab::{
+    error::Error,
+    std::{ethercat_now, tx_rx_task},
+    MainDevice, MainDeviceConfig, PduStorage, Timeouts,
+};
+use std::time::Duration;
+use tokio::time::MissedTickBehavior;
+
+/// Maximum number of SubDevices that can be stored. This must be a power of 2 greater than 1.
+const MAX_SUBDEVICES: usize = 16;
+/// Maximum PDU data payload size - set this to the max PDI size or higher.
+const MAX_PDU_DATA: usize = PduStorage::element_size(1100);
+/// Maximum number of EtherCAT frames that can be in flight at any one time.
+const MAX_FRAMES: usize = 16;
+/// Maximum total PDI length.
+const PDI_LEN: usize = 64;
+
+static PDU_STORAGE: PduStorage<MAX_FRAMES, MAX_PDU_DATA> = PduStorage::new();
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    let interface = std::env::args()
+        .nth(1)
+        .expect("Provide network interface as first argument.");
+
+    log::info!("Starting release demo...");
+    log::info!("Run with RUST_LOG=ethercrab=debug or =trace for debug information");
+
+    let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
+
+    // ---
+    // ---
+    // First cycle: normal TX/RX
+    // ---
+    // ---
+
+    let maindevice = MainDevice::new(pdu_loop, Timeouts::default(), MainDeviceConfig::default());
+
+    let tx_rx_handle = tokio::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task"));
+
+    process_loop(&maindevice).await;
+
+    // SAFETY: Any groups created with the current `maindevice` MUST be dropped before this line.
+    // They cannot be reused with a new `MainDevice` instance and must be initialised again.
+    let pdu_loop = unsafe { maindevice.release() };
+
+    // ---
+    // ---
+    // Second cycle: reuse TX/RX task and PDU loop, but create a new `MainDevice`.
+    // ---
+    // ---
+
+    log::info!("PduLoop was released, starting new MainDevice...");
+
+    // Now make a new MainDevice with the same PDU loop
+    let maindevice = MainDevice::new(pdu_loop, Timeouts::default(), MainDeviceConfig::default());
+
+    process_loop(&maindevice).await;
+
+    // SAFETY: Any groups created with the current `maindevice` MUST be dropped before this line.
+    // They cannot be reused with a new `MainDevice` instance and must be initialised again.
+    let pdu_loop = unsafe { maindevice.release_all() };
+
+    // ---
+    // ---
+    // Third cycle: stop the previous TX/RX task and create a new one with the now-released TX/RX
+    // handles.
+    // ---
+    // ---
+
+    let (tx, rx) = tx_rx_handle
+        .await
+        .expect("Failed to stop TX/RX task")
+        .expect("TX/RX task error");
+
+    log::info!("PduLoop, PduTx and PduRx were released, starting new TX/RX task and making new MainDevice...");
+
+    // Now spawn a new TX/RX task. You could use a different network interface here, for example.
+    let tx_rx_handle = tokio::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task"));
+
+    let maindevice = MainDevice::new(pdu_loop, Timeouts::default(), MainDeviceConfig::default());
+
+    process_loop(&maindevice).await;
+
+    log::info!("Third PDU loop with second TX/RX task shutdown complete");
+
+    // SAFETY: Any groups created with the current `maindevice` MUST be dropped before this line.
+    // They cannot be reused with a new `MainDevice` instance and must be initialised again.
+    let pdu_loop = unsafe { maindevice.release_all() };
+
+    let (tx, rx) = tx_rx_handle
+        .await
+        .expect("Failed to stop TX/RX task")
+        .expect("TX/RX task error");
+
+    // ---
+    // ---
+    // Fourth cycle: do the same with `io_uring` (Linux only)
+    // ---
+    // ---
+    #[cfg(target_os = "linux")]
+    {
+        use ethercrab::std::tx_rx_task_io_uring;
+
+        log::info!("Linux only: reuse TX/RX with io_uring");
+
+        // NOTE: This is a suboptimal TX/RX thread spawn. See the `io-uring` example for how to do it properly.
+        let tx_rx_handle = std::thread::spawn(move || tx_rx_task_io_uring(&interface, tx, rx));
+
+        let maindevice =
+            MainDevice::new(pdu_loop, Timeouts::default(), MainDeviceConfig::default());
+
+        process_loop(&maindevice).await;
+
+        // SAFETY: Any groups created with the current `maindevice` MUST be dropped before this line.
+        // They cannot be reused with a new `MainDevice` instance and must be initialised again.
+        let _pdu_loop = unsafe { maindevice.release_all() };
+
+        let (tx, rx) = tx_rx_handle
+            .join()
+            .expect("io_uring TX/RX thread")
+            .expect("Could not recover TX/RX hadnles");
+
+        // Handles are ready for reuse
+        assert_eq!(tx.should_exit(), false);
+        assert_eq!(rx.should_exit(), false);
+    }
+
+    Ok(())
+}
+
+async fn process_loop(maindevice: &MainDevice<'_>) {
+    let group = maindevice
+        .init_single_group::<MAX_SUBDEVICES, PDI_LEN>(ethercat_now)
+        .await
+        .expect("Init")
+        .into_op(&maindevice)
+        .await
+        .expect("PRE-OP -> OP");
+
+    log::info!("Discovered {} SubDevices", group.len());
+
+    for subdevice in group.iter(&maindevice) {
+        let io = subdevice.io_raw();
+
+        log::info!(
+            "-> SubDevice {:#06x} {} inputs: {} bytes, outputs: {} bytes",
+            subdevice.configured_address(),
+            subdevice.name(),
+            io.inputs().len(),
+            io.outputs().len()
+        );
+    }
+
+    let mut tick_interval = tokio::time::interval(Duration::from_millis(5));
+    tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    for _ in 0..u8::MAX {
+        group.tx_rx(&maindevice).await.expect("TX/RX");
+
+        // Increment every output byte for every SubDevice by one
+        for subdevice in group.iter(&maindevice) {
+            let mut o = subdevice.outputs_raw_mut();
+
+            for byte in o.iter_mut() {
+                *byte = byte.wrapping_add(1);
+            }
+        }
+
+        tick_interval.tick().await;
+    }
+
+    let _ = group
+        .into_safe_op(&maindevice)
+        .await
+        .expect("OP -> SAFE-OP")
+        .into_pre_op(&maindevice)
+        .await
+        .expect("SAFE-OP -> PRE-OP")
+        .into_init(&maindevice)
+        .await
+        .expect("PRE-OP -> INIT");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@
 #![deny(unused_import_braces)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
+#![deny(clippy::missing_safety_doc)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/ethercrab-rs/ethercrab/5185a914f49abad8b0f71a1b3b689500077e7c2b/ethercrab-logo-docsrs.svg"
 )]

--- a/src/maindevice.rs
+++ b/src/maindevice.rs
@@ -547,7 +547,14 @@ impl<'sto> MainDevice<'sto> {
     /// received after this method has been called, the [`PduRx`](crate::PduRx) instance handling
     /// that frame will most likely produce an error as the underlying storage for that frame has
     /// been freed.
-    pub fn release(mut self) -> PduLoop<'sto> {
+    ///
+    /// # Safety
+    ///
+    /// Any groups configured using the previous `MainDevice` instance **must not** be used again
+    /// with any `MainDevice`s created with the `PduLoop` returned by this method. The group state
+    /// (PDI addresses, offsets, sizes, etc) are only valid with the `MainDevice` the group was
+    /// initialised with.
+    pub unsafe fn release(mut self) -> PduLoop<'sto> {
         // Clear out any in-use frames.
         self.pdu_loop.reset();
 
@@ -567,8 +574,18 @@ impl<'sto> MainDevice<'sto> {
     /// received after this method has been called, the [`PduRx`](crate::PduRx) instance handling
     /// that frame will most likely produce an error as the underlying storage for that frame has
     /// been freed.
-    pub fn release_all(mut self) -> PduLoop<'sto> {
+    ///
+    /// # Safety
+    ///
+    /// Any groups configured using the previous `MainDevice` instance **must not** be used again
+    /// with any `MainDevice`s created with the `PduLoop` returned by this method. The group state
+    /// (PDI addresses, offsets, sizes, etc) are only valid with the `MainDevice` the group was
+    /// initialised with.
+    pub unsafe fn release_all(mut self) -> PduLoop<'sto> {
         self.pdu_loop.reset_all();
+
+        // Wake the TX/RX loop up so it can check for the stop flag
+        self.pdu_loop.wake_sender();
 
         self.pdu_loop
     }

--- a/src/pdu_loop/frame_element/mod.rs
+++ b/src/pdu_loop/frame_element/mod.rs
@@ -131,7 +131,7 @@ impl<const N: usize> FrameElement<N> {
     }
 
     /// Set the frame's state without checking its current state.
-    unsafe fn set_state(this: NonNull<FrameElement<N>>, state: FrameState) {
+    pub(in crate::pdu_loop) unsafe fn set_state(this: NonNull<FrameElement<N>>, state: FrameState) {
         let fptr = this.as_ptr();
 
         (*addr_of_mut!((*fptr).status)).store(state, Ordering::Release);

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -6,6 +6,7 @@ use crate::{
     pdu_loop::frame_header::EthercatFrameHeader,
     ETHERCAT_ETHERTYPE, MASTER_ADDR,
 };
+use core::sync::atomic::Ordering;
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
 
 /// What happened to a received Ethernet frame.
@@ -48,6 +49,10 @@ impl<'sto> PduRx<'sto> {
     /// sent the frame.
     // NOTE: &mut self so this struct can only be used in one place.
     pub fn receive_frame(&mut self, ethernet_frame: &[u8]) -> Result<ReceiveAction, Error> {
+        if self.should_exit() {
+            return Ok(ReceiveAction::Ignored);
+        }
+
         let raw_packet = EthernetFrame::new_checked(ethernet_frame)?;
 
         // Look for EtherCAT packets whilst ignoring broadcast packets sent from self. As per
@@ -118,5 +123,12 @@ impl<'sto> PduRx<'sto> {
         frame.mark_received()?;
 
         Ok(ReceiveAction::Processed)
+    }
+
+    /// Returns `true` if the PDU sender should exit.
+    ///
+    /// This will be triggered by [`MainDevice::release_all`](crate::MainDevice::release_all).
+    pub fn should_exit(&self) -> bool {
+        self.storage.exit_flag.load(Ordering::Acquire)
     }
 }

--- a/src/pdu_loop/pdu_rx.rs
+++ b/src/pdu_loop/pdu_rx.rs
@@ -131,4 +131,14 @@ impl<'sto> PduRx<'sto> {
     pub fn should_exit(&self) -> bool {
         self.storage.exit_flag.load(Ordering::Acquire)
     }
+
+    /// Reset this object ready for reuse.
+    ///
+    /// When giving back ownership of the `PduRx`, be sure to call
+    /// [`release`](crate::PduRx::release) to ensure all internal state is correct before reuse.
+    pub fn release(self) -> Self {
+        self.storage.exit_flag.store(false, Ordering::Relaxed);
+
+        self
+    }
 }

--- a/src/pdu_loop/pdu_tx.rs
+++ b/src/pdu_loop/pdu_tx.rs
@@ -1,5 +1,5 @@
 use super::{frame_element::sendable_frame::SendableFrame, storage::PduStorageRef};
-use core::task::Waker;
+use core::{sync::atomic::Ordering, task::Waker};
 
 /// EtherCAT frame transmit adapter.
 pub struct PduTx<'sto> {
@@ -20,6 +20,10 @@ impl<'sto> PduTx<'sto> {
     // NOTE: Mutable so it can only be used in one task.
     pub fn next_sendable_frame(&mut self) -> Option<SendableFrame<'sto>> {
         for idx in 0..self.storage.num_frames {
+            if self.should_exit() {
+                return None;
+            }
+
             let frame = self.storage.frame_at_index(idx);
 
             let Some(sending) = SendableFrame::claim_sending(
@@ -67,5 +71,12 @@ impl<'sto> PduTx<'sto> {
     )]
     pub fn replace_waker(&self, waker: &Waker) {
         self.storage.tx_waker.register(waker);
+    }
+
+    /// Returns `true` if the PDU sender should exit.
+    ///
+    /// This will be triggered by [`MainDevice::release_all`](crate::MainDevice::release_all).
+    pub fn should_exit(&self) -> bool {
+        self.storage.exit_flag.load(Ordering::Acquire)
     }
 }

--- a/src/pdu_loop/pdu_tx.rs
+++ b/src/pdu_loop/pdu_tx.rs
@@ -75,8 +75,17 @@ impl<'sto> PduTx<'sto> {
 
     /// Returns `true` if the PDU sender should exit.
     ///
-    /// This will be triggered by [`MainDevice::release_all`](crate::MainDevice::release_all).
+    /// This will be triggered by [`MainDevice::release_all`](crate::MainDevice::release_all). When
+    /// giving back ownership of the `PduTx`, be sure to call [`release`](crate::PduTx::release) to
+    /// ensure all internal state is correct before reuse.
     pub fn should_exit(&self) -> bool {
         self.storage.exit_flag.load(Ordering::Acquire)
+    }
+
+    /// Reset this object ready for reuse.
+    pub fn release(self) -> Self {
+        self.storage.exit_flag.store(false, Ordering::Relaxed);
+
+        self
     }
 }

--- a/src/std/io_uring.rs
+++ b/src/std/io_uring.rs
@@ -16,7 +16,7 @@ pub fn tx_rx_task_io_uring<'sto>(
     interface: &str,
     mut pdu_tx: PduTx<'sto>,
     mut pdu_rx: PduRx<'sto>,
-) -> Result<(), io::Error> {
+) -> Result<(PduTx<'sto>, PduRx<'sto>), io::Error> {
     let mut socket = RawSocketDesc::new(interface)?;
 
     let mtu = socket.interface_mtu()?;
@@ -222,7 +222,7 @@ pub fn tx_rx_task_io_uring<'sto>(
             if pdu_tx.should_exit() {
                 fmt::debug!("io_uring TX/RX was asked to exit");
 
-                return Ok(());
+                return Ok((pdu_tx.release(), pdu_rx.release()));
             }
         } else {
             fmt::trace!(

--- a/src/std/io_uring.rs
+++ b/src/std/io_uring.rs
@@ -218,6 +218,12 @@ pub fn tx_rx_task_io_uring<'sto>(
             signal.wait();
 
             fmt::trace!("--> Waited for {} ns", start.elapsed().as_nanos());
+
+            if pdu_tx.should_exit() {
+                fmt::debug!("io_uring TX/RX was asked to exit");
+
+                return Ok(());
+            }
         } else {
             fmt::trace!(
                 "Buf keys {:?} in flight",

--- a/src/std/mod.rs
+++ b/src/std/mod.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 #[cfg(target_os = "windows")]
-pub use self::windows::{ethercat_now, tx_rx_task, tx_rx_task_blocking, TxRxTaskConfig};
+pub use self::windows::{ethercat_now, tx_rx_task_blocking, TxRxTaskConfig};
 #[cfg(unix)]
 pub use unix::{ethercat_now, tx_rx_task};
 // io_uring is Linux-only

--- a/src/std/unix/mod.rs
+++ b/src/std/unix/mod.rs
@@ -33,6 +33,12 @@ impl Future for TxRxFut<'_> {
         // Re-register waker to make sure this future is polled again
         self.tx.replace_waker(ctx.waker());
 
+        if self.tx.should_exit() {
+            fmt::debug!("TX/RX future was asked to exit");
+
+            return Poll::Ready(Ok(()));
+        }
+
         while let Some(frame) = self.tx.next_sendable_frame() {
             let res = frame.send_blocking(|data| {
                 match Pin::new(&mut self.socket).poll_write(ctx, data) {

--- a/src/std/unix/mod.rs
+++ b/src/std/unix/mod.rs
@@ -22,24 +22,33 @@ use futures_lite::{AsyncRead, AsyncWrite};
 struct TxRxFut<'a> {
     socket: Async<RawSocketDesc>,
     mtu: usize,
-    tx: PduTx<'a>,
-    rx: PduRx<'a>,
+    tx: Option<PduTx<'a>>,
+    rx: Option<PduRx<'a>>,
 }
 
-impl Future for TxRxFut<'_> {
-    type Output = Result<(), Error>;
+impl<'a> Future for TxRxFut<'a> {
+    type Output = Result<(PduTx<'a>, PduRx<'a>), Error>;
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
-        // Re-register waker to make sure this future is polled again
-        self.tx.replace_waker(ctx.waker());
+        unsafe {
+            // Re-register waker to make sure this future is polled again
+            self.tx
+                .as_mut()
+                .unwrap_unchecked()
+                .replace_waker(ctx.waker());
 
-        if self.tx.should_exit() {
-            fmt::debug!("TX/RX future was asked to exit");
+            if self.tx.as_mut().unwrap_unchecked().should_exit() {
+                fmt::debug!("TX/RX future was asked to exit");
 
-            return Poll::Ready(Ok(()));
+                return Poll::Ready(Ok((
+                    self.tx.take().unwrap().release(),
+                    self.rx.take().unwrap().release(),
+                )));
+            }
         }
 
-        while let Some(frame) = self.tx.next_sendable_frame() {
+        while let Some(frame) = unsafe { self.tx.as_mut().unwrap_unchecked() }.next_sendable_frame()
+        {
             let res = frame.send_blocking(|data| {
                 match Pin::new(&mut self.socket).poll_write(ctx, data) {
                     Poll::Ready(Ok(bytes_written)) => {
@@ -88,7 +97,8 @@ impl Future for TxRxFut<'_> {
                     fmt::warn!("Received zero bytes");
                 }
 
-                if let Err(e) = self.rx.receive_frame(packet) {
+                if let Err(e) = unsafe { self.rx.as_mut().unwrap_unchecked() }.receive_frame(packet)
+                {
                     fmt::error!("Failed to receive frame: {}", e);
 
                     return Poll::Ready(Err(Error::ReceiveFrame));
@@ -109,7 +119,8 @@ pub fn tx_rx_task<'sto>(
     interface: &str,
     pdu_tx: PduTx<'sto>,
     #[allow(unused_mut)] mut pdu_rx: PduRx<'sto>,
-) -> Result<impl Future<Output = Result<(), Error>> + 'sto, std::io::Error> {
+) -> Result<impl Future<Output = Result<(PduTx<'sto>, PduRx<'sto>), Error>> + 'sto, std::io::Error>
+{
     let mut socket = RawSocketDesc::new(interface)?;
 
     // macOS forcibly sets the source address to the NIC's MAC, so instead of using `MASTER_ADDR`
@@ -130,8 +141,8 @@ pub fn tx_rx_task<'sto>(
     let task = TxRxFut {
         socket: async_socket,
         mtu,
-        tx: pdu_tx,
-        rx: pdu_rx,
+        tx: Some(pdu_tx),
+        rx: Some(pdu_rx),
     };
 
     Ok(task)

--- a/src/std/windows.rs
+++ b/src/std/windows.rs
@@ -182,15 +182,15 @@ pub fn tx_rx_task_blocking<'sto>(
             if pdu_tx.should_exit() {
                 fmt::debug!("io_uring TX/RX was asked to exit");
 
-                return Ok((pdu_tx.release(), pdu_rx.release()));
+                // Break out of entire TX/RX loop
+                break;
             }
         } else {
             std::hint::spin_loop()
         }
     }
 
-    #[allow(unreachable_code)]
-    Ok(())
+    Ok((pdu_tx.release(), pdu_rx.release()))
 }
 
 /// Get the current time in nanoseconds from the EtherCAT epoch, 2000-01-01.


### PR DESCRIPTION
TODO

- [x] The TX/RX task side of this
- [-] ~Tests for both `release` and `release_all`~ very, very difficult to do replay tests with the current harness.
- [x] Example