### PR TITLE
Write EEPROM

### DIFF
--- a/src/eeprom/device_reader.rs
+++ b/src/eeprom/device_reader.rs
@@ -1,6 +1,6 @@
 use crate::{
     eeprom::{
-        types::{SiiControl, SiiRequest},
+        types::{SiiControl, SiiRequest, SiiWriteRequest},
         EepromDataProvider,
     },
     error::{EepromError, Error},
@@ -99,7 +99,7 @@ impl<'subdevice> EepromDataProvider for DeviceEeprom<'subdevice> {
         Command::fpwr(self.configured_address, RegisterAddress::SiiControl.into())
             .send(
                 self.maindevice,
-                SiiRequest::write(
+                SiiWriteRequest::write(
                     start_word,
                     u16::from_le_bytes(
                         data.try_into()

--- a/src/eeprom/file_reader.rs
+++ b/src/eeprom/file_reader.rs
@@ -80,4 +80,8 @@ impl<const CHUNK: usize> EepromDataProvider for EepromFile<CHUNK> {
     async fn clear_errors(&self) -> Result<(), Error> {
         Ok(())
     }
+
+    async fn write_chunk(&mut self, start_word: u16, data: &[u8]) -> Result<(), Error> {
+        unimplemented!()
+    }
 }

--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -860,7 +860,7 @@ mod tests {
     fn sii_request_read_unpack() {
         let packed = SiiRequest::read(0x1234);
 
-        let buf = [0x00, 0x01, 0x34, 0x12, 0x00, 0x00];
+        let buf = [0x00, 0x01, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00];
 
         assert_eq!(SiiRequest::unpack_from_slice(&buf), Ok(packed));
     }

--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -116,7 +116,7 @@ pub enum SiiAddressSize {
 }
 
 #[derive(PartialEq, ethercrab_wire::EtherCrabWireReadWrite)]
-#[wire(bytes = 8)]
+#[wire(bytes = 6)]
 pub struct SiiRequest {
     #[wire(bytes = 2)]
     control: SiiControl,
@@ -125,8 +125,6 @@ pub struct SiiRequest {
     // the extra 16 bits of padding here for the unusedhigh WORD.
     #[wire(bytes = 2, post_skip = 16)]
     address: u16,
-    #[wire(bytes = 2)]
-    data: u16,
 }
 
 impl core::fmt::Debug for SiiRequest {
@@ -143,24 +141,39 @@ impl SiiRequest {
         Self {
             control: SiiControl::read(),
             address,
-            data: 0,
         }
     }
+}
+
+#[derive(PartialEq, ethercrab_wire::EtherCrabWireReadWrite)]
+#[wire(bytes = 8)]
+pub struct SiiWriteRequest {
+    #[wire(bytes = 2)]
+    control: SiiControl,
+    // Post skip is required to send the correct amount of bytes on the wire. This is weird because
+    // addressing is all a single WORD, but the SII read request expects a low AND high WORD, hence
+    // the extra 16 bits of padding here for the unusedhigh WORD.
+    #[wire(bytes = 2, post_skip = 16)]
+    address: u16,
+    #[wire(bytes = 2)]
+    data: u16,
+}
+
+impl core::fmt::Debug for SiiWriteRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SiiRequest")
+            .field("control", &self.control)
+            .field("address", &format_args!("{:#06x}", self.address))
+            .finish()
+    }
+}
+
+impl SiiWriteRequest {
     pub fn write(address: u16, data: u16) -> Self {
         Self {
             control: SiiControl::write(),
             address,
             data,
-        }
-    }
-    pub fn reload() -> Self {
-        Self {
-            control: SiiControl {
-                reload: true,
-                ..Default::default()
-            },
-            address: 0,
-            data: 0,
         }
     }
 }
@@ -830,7 +843,34 @@ mod tests {
     fn sii_request_read_pack() {
         let packed = SiiRequest::read(0x1234).pack();
 
-        assert_eq!(packed, [0x00, 0x01, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(packed, [0x00, 0x01, 0x34, 0x12, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn sii_write_control_pack() {
+        let ctl = SiiControl {
+            access: SiiAccess::ReadWrite,
+            emulate_sii: false,
+            read_size: SiiReadSize::Octets4,
+            address_type: SiiAddressSize::U8,
+            read: false,
+            write: true,
+            reload: false,
+            checksum_error: false,
+            device_info_error: false,
+            command_error: false,
+            write_error: false,
+            busy: false,
+        };
+
+        assert_eq!(ctl.pack(), [0b0000_0001, 0b0000_0010],);
+    }
+
+    #[test]
+    fn sii_write_request_pack() {
+        let packed = SiiWriteRequest::write(0x1234, 0x5678).pack();
+
+        assert_eq!(packed, [0x01, 0x02, 0x34, 0x12, 0x00, 0x00, 0x78, 0x56]);
     }
 
     #[test]

--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -69,6 +69,14 @@ impl SiiControl {
             ..Default::default()
         }
     }
+
+    fn write() -> Self {
+        Self {
+            access: SiiAccess::ReadWrite,
+            write: true,
+            ..Default::default()
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default, ethercrab_wire::EtherCrabWireReadWrite)]
@@ -108,7 +116,7 @@ pub enum SiiAddressSize {
 }
 
 #[derive(PartialEq, ethercrab_wire::EtherCrabWireReadWrite)]
-#[wire(bytes = 6)]
+#[wire(bytes = 8)]
 pub struct SiiRequest {
     #[wire(bytes = 2)]
     control: SiiControl,
@@ -117,6 +125,8 @@ pub struct SiiRequest {
     // the extra 16 bits of padding here for the unusedhigh WORD.
     #[wire(bytes = 2, post_skip = 16)]
     address: u16,
+    #[wire(bytes = 2)]
+    data: u16,
 }
 
 impl core::fmt::Debug for SiiRequest {
@@ -133,6 +143,24 @@ impl SiiRequest {
         Self {
             control: SiiControl::read(),
             address,
+            data: 0,
+        }
+    }
+    pub fn write(address: u16, data: u16) -> Self {
+        Self {
+            control: SiiControl::write(),
+            address,
+            data,
+        }
+    }
+    pub fn reload() -> Self {
+        Self {
+            control: SiiControl {
+                reload: true,
+                ..Default::default()
+            },
+            address: 0,
+            data: 0,
         }
     }
 }
@@ -802,7 +830,7 @@ mod tests {
     fn sii_request_read_pack() {
         let packed = SiiRequest::read(0x1234).pack();
 
-        assert_eq!(packed, [0x00, 0x01, 0x34, 0x12, 0x00, 0x00]);
+        assert_eq!(packed, [0x00, 0x01, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00]);
     }
 
     #[test]

--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -900,7 +900,7 @@ mod tests {
     fn sii_request_read_unpack() {
         let packed = SiiRequest::read(0x1234);
 
-        let buf = [0x00, 0x01, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00];
+        let buf = [0x00, 0x01, 0x34, 0x12, 0x00, 0x00];
 
         assert_eq!(SiiRequest::unpack_from_slice(&buf), Ok(packed));
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -330,6 +330,10 @@ pub enum EepromError {
     SectionUnderrun,
     /// An attempt to clear errors on the device failed.
     ClearErrors,
+    /// Writing less or more than 2 bytes to the EEPROM data register.
+    InvalidDataLength,
+    /// An error occurred when writing to the EEPROM.
+    WriteError,
 }
 
 impl core::fmt::Display for EepromError {
@@ -340,6 +344,8 @@ impl core::fmt::Display for EepromError {
             EepromError::NoCategory => f.write_str("category not found"),
             EepromError::SectionUnderrun => f.write_str("section too short to fill buffer"),
             EepromError::ClearErrors => f.write_str("clear device errors failed"),
+            EepromError::InvalidDataLength => f.write_str("invalid data length"),
+            EepromError::WriteError => f.write_str("write error"),
         }
     }
 }

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -965,7 +965,8 @@ impl<'maindevice, S> SubDeviceRef<'maindevice, S> {
         futures_lite::future::try_zip(self.state(), code).await
     }
 
-    fn eeprom(&self) -> SubDeviceEeprom<DeviceEeprom> {
+    /// Get the SubDevice's EEPROM interface.
+    pub fn eeprom(&self) -> SubDeviceEeprom<DeviceEeprom> {
         SubDeviceEeprom::new(DeviceEeprom::new(self.maindevice, self.configured_address))
     }
 


### PR DESCRIPTION
I implemented functionality to write to the `SubDevice`'s EEPROM. This is relevant to persist identification values on the devices EEPROM.

This is also foundational to setting the [_Configured Station Alias_ ](https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_io_intro/1358010251.html&id=).
The _Configured Station Alias_ lives in the EEPROM at `0x0004` and is part of the [_EtherCAT Slave Controller Configuration Area (ESC)_ ](https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_io_intro/1358008331.html&id=5054579963582410224) but writing this single value "corrupts" the EEPROM and the device can't exit `INIT` stage until the area is overwritten by TwinCAT again. TwinCAT rewrites all values from `0x0000` to `0x0007` when the _Configured Station Alias_ is changed and `0x0007` seems like a CRC of some kind. So more reasearch is needed here.

Nevertheless the free space in the EEPROM can be used to store other identification values. I write values to tell different machines apart inside the same network and custom serial numbers.

This PR is a draft because there is some room for discussion in the implementation. The `write_chunk` was implemented in the `DeviceReader`. Should the `DeviceReader` be renamed or a `DeviceWriter` created? Also test are missing because The `FileReader` uses a `BufferReader` which doesn't implement a write function.