### PR TITLE
Reduce embedded example binary size a bit

### DIFF
--- a/src/dc.rs
+++ b/src/dc.rs
@@ -23,7 +23,7 @@ async fn latch_dc_times(
 ) -> Result<(), Error> {
     let num_subdevices_with_dc: usize = subdevices
         .iter()
-        .filter(|subdevice| subdevice.flags.dc_supported)
+        .filter(|subdevice| subdevice.dc_support().any())
         .count();
 
     // Latch receive times into all ports of all SubDevices.
@@ -35,7 +35,7 @@ async fn latch_dc_times(
     // Read receive times for all SubDevices and store on SubDevice structs
     for subdevice in subdevices
         .iter_mut()
-        .filter(|subdevice| subdevice.flags.dc_supported)
+        .filter(|subdevice| subdevice.dc_support().any())
     {
         let sl = SubDeviceRef::new(maindevice, subdevice.configured_address(), ());
 
@@ -316,10 +316,10 @@ fn assign_parent_relationships(subdevices: &mut [SubDevice]) -> Result<(), Error
         subdevice.parent_index = find_subdevice_parent(parents, subdevice)?;
 
         fmt::debug!(
-            "SubDevice {:#06x} {} {}",
+            "SubDevice {:#06x} {} DC support {:?}",
             subdevice.configured_address(),
             subdevice.name,
-            subdevice.flags
+            subdevice.dc_support()
         );
 
         // If this SubDevice has a parent, find it, then assign the parent's next open port to this
@@ -335,7 +335,7 @@ fn assign_parent_relationships(subdevices: &mut [SubDevice]) -> Result<(), Error
             );
         }
 
-        if subdevice.flags.dc_supported {
+        if subdevice.dc_support().any() {
             configure_subdevice_offsets(subdevice, parents, &mut delay_accum);
         } else {
             fmt::trace!(
@@ -427,7 +427,7 @@ pub(crate) async fn configure_dc<'subdevices>(
 
     let first_dc_subdevice = subdevices
         .iter()
-        .find(|subdevice| subdevice.flags.dc_supported);
+        .find(|subdevice| subdevice.dc_support().any());
 
     if let Some(first_dc_subdevice) = first_dc_subdevice.as_ref() {
         let now_nanos = now();
@@ -483,8 +483,8 @@ pub(crate) async fn run_dc_static_sync(
 mod tests {
     use super::*;
     use crate::{
-        register::SupportFlags,
         subdevice::ports::{tests::make_ports, Port, Ports},
+        DcSupport,
     };
 
     // A SubDevice in the middle of the chain
@@ -509,11 +509,6 @@ mod tests {
             configured_address: 0x0000,
             ports: Ports::default(),
             name: "Default".try_into().unwrap(),
-            flags: SupportFlags::default(),
-            dc_receive_time: 0,
-            index: 0,
-            parent_index: None,
-            propagation_delay: 0,
             ..Default::default()
         };
 
@@ -568,11 +563,6 @@ mod tests {
             configured_address: 0x0000,
             ports: Ports::default(),
             name: "Default".try_into().unwrap(),
-            flags: SupportFlags::default(),
-            dc_receive_time: 0,
-            index: 0,
-            parent_index: None,
-            propagation_delay: 0,
             ..Default::default()
         };
 
@@ -643,11 +633,6 @@ mod tests {
             configured_address: 0x1000,
             ports: Ports::default(),
             name: "Default".try_into().unwrap(),
-            flags: SupportFlags::default(),
-            dc_receive_time: 0,
-            index: 0,
-            parent_index: None,
-            propagation_delay: 0,
             ..Default::default()
         };
 
@@ -702,11 +687,6 @@ mod tests {
             configured_address: 0x1000,
             ports,
             name: "Default".try_into().unwrap(),
-            flags: SupportFlags::default(),
-            dc_receive_time: 0,
-            index: 0,
-            parent_index: None,
-            propagation_delay: 0,
             ..Default::default()
         };
 
@@ -750,10 +730,7 @@ mod tests {
             ports: Ports::default(),
             dc_receive_time: 0,
             index: 0,
-            flags: SupportFlags {
-                dc_supported: true,
-                ..SupportFlags::default()
-            },
+            dc_support: DcSupport::Bits64,
             ..SubDevice::default()
         };
 
@@ -860,10 +837,7 @@ mod tests {
             ports: Ports::default(),
             dc_receive_time: 0,
             index: 0,
-            flags: SupportFlags {
-                dc_supported: true,
-                ..SupportFlags::default()
-            },
+            dc_support: DcSupport::Bits64,
             ..SubDevice::default()
         };
 

--- a/src/dc.rs
+++ b/src/dc.rs
@@ -4,6 +4,8 @@
 //! [Hardware Data Sheet Section
 //! I](https://download.beckhoff.com/download/document/io/ethercat-development-products/ethercat_esc_datasheet_sec1_technology_2i3.pdf).
 
+use core::num::NonZeroU16;
+
 use crate::{
     command::Command,
     error::Error,
@@ -327,7 +329,8 @@ fn assign_parent_relationships(subdevices: &mut [SubDevice]) -> Result<(), Error
                 fmt::unwrap_opt!(parents.iter_mut().find(|parent| parent.index == parent_idx));
 
             fmt::unwrap_opt!(
-                parent.ports.assign_next_downstream_port(subdevice.index),
+                NonZeroU16::new(subdevice.index)
+                    .and_then(|index| parent.ports.assign_next_downstream_port(index)),
                 "no free ports on parent"
             );
         }

--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -1,6 +1,6 @@
 //! SubDevice Information Interface (SII).
 
-use crate::{base_data_types::PrimitiveDataType, coe::SdoExpedited, sync_manager_channel};
+use crate::{coe::SdoExpedited, sync_manager_channel};
 use ethercrab_wire::{EtherCrabWireRead, EtherCrabWireSized};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default, ethercrab_wire::EtherCrabWireReadWrite)]
@@ -541,23 +541,23 @@ pub enum SyncManagerType {
 impl SdoExpedited for SyncManagerType {}
 
 /// Defined in ETG2010 Table 14 – Structure Category TXPDO and RXPDO for each PDO
-#[derive(Clone, PartialEq, ethercrab_wire::EtherCrabWireRead)]
+#[derive(Debug, Copy, Clone, PartialEq, ethercrab_wire::EtherCrabWireRead)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[wire(bytes = 8)]
 pub struct Pdo {
-    #[wire(bytes = 2)]
-    pub(crate) index: u16,
-    #[wire(bytes = 1)]
+    // #[wire(bytes = 2)]
+    // pub(crate) index: u16,
+    #[wire(bytes = 1, pre_skip_bytes = 2)]
     pub(crate) num_entries: u8,
-    #[wire(bytes = 1)]
+    #[wire(bytes = 1, post_skip_bytes = 4)]
     pub(crate) sync_manager: u8,
-    #[wire(bytes = 1)]
-    pub(crate) dc_sync: u8,
-    /// Index into EEPROM Strings section for PDO name.
-    #[wire(bytes = 1)]
-    pub(crate) name_string_idx: u8,
-    #[wire(bytes = 2)]
-    pub(crate) flags: PdoFlags,
+    // #[wire(bytes = 1)]
+    // pub(crate) dc_sync: u8,
+    // /// Index into EEPROM Strings section for PDO name.
+    // #[wire(bytes = 1)]
+    // pub(crate) name_string_idx: u8,
+    // #[wire(bytes = 2)]
+    // pub(crate) flags: PdoFlags,
 
     // NOTE: Field is only used to sum up `bit_len`, so we don't need to read or store it.
     // Definition is left here in case we need it later.
@@ -571,20 +571,20 @@ pub struct Pdo {
     pub(crate) bit_len: u16,
 }
 
-impl core::fmt::Debug for Pdo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Pdo")
-            .field("index", &format_args!("{:#06x}", self.index))
-            .field("num_entries", &self.num_entries)
-            .field("sync_manager", &self.sync_manager)
-            .field("dc_sync", &self.dc_sync)
-            .field("name_string_idx", &self.name_string_idx)
-            .field("flags", &self.flags)
-            // .field("entries", &self.entries)
-            .field("bit_len", &self.bit_len)
-            .finish()
-    }
-}
+// impl core::fmt::Debug for Pdo {
+//     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+//         f.debug_struct("Pdo")
+//             // .field("index", &format_args!("{:#06x}", self.index))
+//             .field("num_entries", &self.num_entries)
+//             // .field("sync_manager", &self.sync_manager)
+//             // .field("dc_sync", &self.dc_sync)
+//             // .field("name_string_idx", &self.name_string_idx)
+//             // .field("flags", &self.flags)
+//             // .field("entries", &self.entries)
+//             .field("bit_len", &self.bit_len)
+//             .finish()
+//     }
+// }
 
 // impl Pdo {
 //     /// Compute the total bit length of this PDO by iterating over and summing the bit length of
@@ -597,37 +597,37 @@ impl core::fmt::Debug for Pdo {
 //     }
 // }
 
-#[derive(Clone, PartialEq, ethercrab_wire::EtherCrabWireRead)]
+#[derive(Debug, Clone, PartialEq, ethercrab_wire::EtherCrabWireRead)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[wire(bytes = 8)]
 pub struct PdoEntry {
-    #[wire(bytes = 2)]
-    pub(crate) index: u16,
-    #[wire(bytes = 1)]
-    pub(crate) sub_index: u8,
-    #[wire(bytes = 1)]
-    pub(crate) name_string_idx: u8,
-    // See page 103 of ETG2000
-    #[wire(bytes = 1)]
-    pub(crate) data_type: PrimitiveDataType,
-    #[wire(bytes = 1)]
+    // #[wire(bytes = 2)]
+    // pub(crate) index: u16,
+    // #[wire(bytes = 1)]
+    // pub(crate) sub_index: u8,
+    // #[wire(bytes = 1)]
+    // pub(crate) name_string_idx: u8,
+    // // See page 103 of ETG2000
+    // #[wire(bytes = 1)]
+    // pub(crate) data_type: PrimitiveDataType,
+    #[wire(bytes = 1, pre_skip_bytes = 5, post_skip_bytes = 2)]
     pub(crate) data_length_bits: u8,
-    #[wire(bytes = 2)]
-    pub(crate) flags: u16,
+    // #[wire(bytes = 2)]
+    // pub(crate) flags: u16,
 }
 
-impl core::fmt::Debug for PdoEntry {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PdoEntry")
-            .field("index", &format_args!("{:#06x}", self.index))
-            .field("sub_index", &self.sub_index)
-            .field("name_string_idx", &self.name_string_idx)
-            .field("data_type", &self.data_type)
-            .field("data_length_bits", &self.data_length_bits)
-            .field("flags", &self.flags)
-            .finish()
-    }
-}
+// impl core::fmt::Debug for PdoEntry {
+//     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+//         f.debug_struct("PdoEntry")
+//             .field("index", &format_args!("{:#06x}", self.index))
+//             .field("sub_index", &self.sub_index)
+//             .field("name_string_idx", &self.name_string_idx)
+//             .field("data_type", &self.data_type)
+//             .field("data_length_bits", &self.data_length_bits)
+//             .field("flags", &self.flags)
+//             .finish()
+//     }
+// }
 
 bitflags::bitflags! {
     /// Defined in ETG2010 Table 14 offset 0x0006.

--- a/src/pdi.rs
+++ b/src/pdi.rs
@@ -72,7 +72,7 @@ impl PdiOffset {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PdiSegment {
     pub bytes: Range<usize>,
-    pub bit_len: usize,
+    // pub bit_len: usize,
 }
 
 impl PdiSegment {
@@ -87,12 +87,8 @@ impl PdiSegment {
 
 impl core::fmt::Display for PdiSegment {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if self.bit_len > 0 {
-            write!(
-                f,
-                "{:#010x}..{:#010x} ({} bits)",
-                self.bytes.start, self.bytes.end, self.bit_len
-            )
+        if !self.bytes.is_empty() {
+            write!(f, "{:#010x}..{:#010x}", self.bytes.start, self.bytes.end,)
         } else {
             f.write_str("(empty)")
         }

--- a/src/register.rs
+++ b/src/register.rs
@@ -217,7 +217,7 @@ impl From<RegisterAddress> for u16 {
 
 impl RegisterAddress {
     /// FMMU by index.
-    pub fn fmmu(index: u8) -> Self {
+    pub const fn fmmu(index: u8) -> Self {
         match index {
             0 => Self::Fmmu0,
             1 => Self::Fmmu1,
@@ -235,12 +235,12 @@ impl RegisterAddress {
             13 => Self::Fmmu13,
             14 => Self::Fmmu14,
             15 => Self::Fmmu15,
-            index => unreachable!("Bad FMMU index {}", index),
+            _index => unreachable!(),
         }
     }
 
     /// Sync manager by index.
-    pub fn sync_manager(index: u8) -> Self {
+    pub const fn sync_manager(index: u8) -> Self {
         match index {
             0 => Self::Sm0,
             1 => Self::Sm1,
@@ -258,7 +258,7 @@ impl RegisterAddress {
             13 => Self::Sm13,
             14 => Self::Sm14,
             15 => Self::Sm15,
-            index => unreachable!("Bad SM index {}", index),
+            _index => unreachable!(),
         }
     }
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -365,9 +365,11 @@ impl core::fmt::Display for SupportFlags {
 }
 
 /// SubDevice DC support status.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DcSupport {
     /// No support at all.
+    #[default]
     None,
     /// This device can be used as the DC reference, but cannot be configured for `SYNC`/`LATCH`.
     RefOnly,

--- a/src/subdevice/configuration.rs
+++ b/src/subdevice/configuration.rs
@@ -309,7 +309,7 @@ where
         //     .await?;
 
         let start_offset = *global_offset;
-        let mut total_bit_len = 0;
+        // let mut total_bit_len = 0;
 
         for (sync_manager_index, sm_type) in self
             .state
@@ -431,11 +431,11 @@ where
                 .await?;
             }
 
-            total_bit_len += sm_bit_len;
+            // total_bit_len += sm_bit_len;
         }
 
         Ok(PdiSegment {
-            bit_len: total_bit_len.into(),
+            // bit_len: total_bit_len.into(),
             bytes: start_offset.up_to(*global_offset),
         })
     }
@@ -520,7 +520,7 @@ where
         let fmmu_sm_mappings = self.eeprom().fmmu_mappings().await?;
 
         let start_offset = *offset;
-        let mut total_bit_len = 0;
+        // let mut total_bit_len = 0;
 
         let (sm_type, fmmu_type) = direction.filter_terms();
 
@@ -537,7 +537,7 @@ where
                 .map(|pdo| pdo.bit_len)
                 .sum();
 
-            total_bit_len += bit_len;
+            // total_bit_len += bit_len;
 
             // Look for FMMU index using FMMU_EX section in EEPROM. If it's empty, default
             // to looking through FMMU usage list and picking out the appropriate kind
@@ -578,7 +578,7 @@ where
         }
 
         Ok(PdiSegment {
-            bit_len: total_bit_len.into(),
+            // bit_len: total_bit_len.into(),
             bytes: start_offset.up_to(*offset),
         })
     }

--- a/src/subdevice/configuration.rs
+++ b/src/subdevice/configuration.rs
@@ -108,8 +108,10 @@ where
         group_start_address: u32,
         direction: PdoDirection,
     ) -> Result<PdiOffset, Error> {
-        let sync_managers = self.eeprom().sync_managers().await?;
-        let fmmu_usage = self.eeprom().fmmus().await?;
+        let eeprom = self.eeprom();
+
+        let sync_managers = eeprom.sync_managers().await?;
+        let fmmu_usage = eeprom.fmmus().await?;
 
         let state = self.state().await?;
 
@@ -208,10 +210,12 @@ where
 
     /// Configure SM0 and SM1 for mailbox communication.
     async fn configure_mailbox_sms(&mut self, sync_managers: &[SyncManager]) -> Result<(), Error> {
-        // Read default mailbox configuration from SubDevice information area
-        let mailbox_config = self.eeprom().mailbox_config().await?;
+        let eeprom = self.eeprom();
 
-        let general = self.eeprom().general().await?;
+        // Read default mailbox configuration from SubDevice information area
+        let mailbox_config = eeprom.mailbox_config().await?;
+
+        let general = eeprom.general().await?;
 
         fmt::trace!(
             "SubDevice {:#06x} Mailbox configuration: {:#?}",
@@ -500,16 +504,18 @@ where
         direction: PdoDirection,
         offset: &mut PdiOffset,
     ) -> Result<PdiSegment, Error> {
+        let eeprom = self.eeprom();
+
         let pdos = match direction {
             PdoDirection::MasterRead => {
-                let read_pdos = self.eeprom().maindevice_read_pdos().await?;
+                let read_pdos = eeprom.maindevice_read_pdos().await?;
 
                 fmt::trace!("SubDevice inputs PDOs {:#?}", read_pdos);
 
                 read_pdos
             }
             PdoDirection::MasterWrite => {
-                let write_pdos = self.eeprom().maindevice_write_pdos().await?;
+                let write_pdos = eeprom.maindevice_write_pdos().await?;
 
                 fmt::trace!("SubDevice outputs PDOs {:#?}", write_pdos);
 
@@ -517,7 +523,7 @@ where
             }
         };
 
-        let fmmu_sm_mappings = self.eeprom().fmmu_mappings().await?;
+        let fmmu_sm_mappings = eeprom.fmmu_mappings().await?;
 
         let start_offset = *offset;
         // let mut total_bit_len = 0;

--- a/src/subdevice/configuration.rs
+++ b/src/subdevice/configuration.rs
@@ -194,7 +194,7 @@ where
         };
 
         self.write(RegisterAddress::sync_manager(sync_manager_index))
-            .send(self.maindevice, sm_config)
+            .send(self.maindevice, &sm_config)
             .await?;
 
         fmt::debug!(
@@ -481,7 +481,7 @@ where
         };
 
         self.write(RegisterAddress::fmmu(fmmu_index as u8))
-            .send(self.maindevice, fmmu_config)
+            .send(self.maindevice, &fmmu_config)
             .await?;
 
         fmt::debug!(

--- a/src/subdevice/eeprom.rs
+++ b/src/subdevice/eeprom.rs
@@ -298,7 +298,7 @@ where
             }
 
             pdos.push(pdo).map_err(|_| {
-                fmt::error!("Too many PDOs, max 16");
+                fmt::error!("Too many PDOs, max 64");
 
                 Error::Capacity(Item::Pdo)
             })?;

--- a/src/subdevice/eeprom.rs
+++ b/src/subdevice/eeprom.rs
@@ -284,7 +284,6 @@ where
         while let Some(mut pdo) = cat.next().await? {
             fmt::debug!("Discovered PDO:\n{:#?}", pdo);
 
-            // TODO: Return some kind of iterator so we don't have to have a fixed length vec
             for idx in 0..pdo.num_entries {
                 let Some(entry) = cat.next_sub_item::<PdoEntry>().await? else {
                     fmt::error!("Failed to read PDO entry {}", idx);
@@ -481,8 +480,8 @@ mod tests {
         eeprom::{
             file_provider::EepromFile,
             types::{
-                CoeDetails, Flags, MailboxProtocols, PdoFlags, PortStatus, PortStatuses,
-                SyncManagerEnable, SyncManagerType,
+                CoeDetails, Flags, MailboxProtocols, PortStatus, PortStatuses, SyncManagerEnable,
+                SyncManagerType,
             },
         },
         sync_manager_channel::{Control, Direction, OperationMode},
@@ -736,7 +735,7 @@ mod tests {
             "../../dumps/eeprom/el2828.hex"
         )));
 
-        fn pdo(index: u16, name_string_idx: u8, _entry_idx: u16) -> Pdo {
+        fn pdo(_index: u16, _name_string_idx: u8, _entry_idx: u16) -> Pdo {
             // let entry_defaults = PdoEntry {
             //     index: 0x7000,
             //     sub_index: 1,
@@ -747,14 +746,12 @@ mod tests {
             // };
 
             let pdo_defaults = Pdo {
-                index: 0x1600,
-                name_string_idx: 5,
-
+                // index: 0x1600,
+                // name_string_idx: 5,
                 num_entries: 1,
                 sync_manager: 0,
-                dc_sync: 0,
-                flags: PdoFlags::PDO_MANDATORY | PdoFlags::PDO_FIXED_CONTENT,
-
+                // dc_sync: 0,
+                // flags: PdoFlags::PDO_MANDATORY | PdoFlags::PDO_FIXED_CONTENT,
                 bit_len: 1,
                 // entries: heapless::Vec::from_slice(&[PdoEntry {
                 //     index: 0x7000,
@@ -764,9 +761,8 @@ mod tests {
             };
 
             Pdo {
-                index,
-                name_string_idx,
-
+                // index,
+                // name_string_idx,
                 bit_len: 1,
                 // entries: heapless::Vec::from_slice(&[PdoEntry {
                 //     index: entry_idx,

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -159,24 +159,22 @@ impl SubDevice {
         // Make sure master has access to SubDevice EEPROM
         subdevice_ref.set_eeprom_mode(SiiOwner::Master).await?;
 
-        let identity = subdevice_ref.eeprom().identity().await?;
+        let eeprom = subdevice_ref.eeprom();
 
-        let name = subdevice_ref
-            .eeprom()
-            .device_name()
-            .await?
-            .unwrap_or_else(|| {
-                let mut s = heapless::String::new();
+        let identity = eeprom.identity().await?;
 
-                fmt::unwrap!(write!(
-                    s,
-                    "manu. {:#010x}, device {:#010x}, serial {:#010x}",
-                    identity.vendor_id, identity.product_id, identity.serial
-                )
-                .map_err(|_| ()));
+        let name = eeprom.device_name().await?.unwrap_or_else(|| {
+            let mut s = heapless::String::new();
 
-                s
-            });
+            fmt::unwrap!(write!(
+                s,
+                "manu. {:#010x}, device {:#010x}, serial {:#010x}",
+                identity.vendor_id, identity.product_id, identity.serial
+            )
+            .map_err(|_| ()));
+
+            s
+        });
 
         let flags = subdevice_ref
             .read(RegisterAddress::SupportFlags)

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -62,9 +62,10 @@ pub struct SubDevice {
     // NOTE: Default length in SOEM is 40 bytes
     pub(crate) name: heapless::String<64>,
 
-    pub(crate) flags: SupportFlags,
-
+    // pub(crate) flags: SupportFlags,
     pub(crate) ports: Ports,
+
+    pub(crate) dc_support: DcSupport,
 
     /// Distributed Clock latch receive time.
     pub(crate) dc_receive_time: u64,
@@ -101,7 +102,7 @@ impl PartialEq for SubDevice {
             && self.config == other.config
             && self.identity == other.identity
             && self.name == other.name
-            && self.flags == other.flags
+            && self.dc_support == other.dc_support
             && self.ports == other.ports
             && self.dc_receive_time == other.dc_receive_time
             && self.index == other.index
@@ -123,7 +124,7 @@ impl Clone for SubDevice {
             config: self.config.clone(),
             identity: self.identity,
             name: self.name.clone(),
-            flags: self.flags.clone(),
+            dc_support: self.dc_support.clone(),
             ports: self.ports,
             dc_receive_time: self.dc_receive_time,
             index: self.index,
@@ -182,6 +183,8 @@ impl SubDevice {
             .receive::<SupportFlags>(maindevice)
             .await?;
 
+        fmt::debug!("--> Support flags {:?}", flags);
+
         let alias_address = subdevice_ref
             .read(RegisterAddress::ConfiguredStationAlias)
             .receive::<u16>(maindevice)
@@ -222,7 +225,7 @@ impl SubDevice {
             dc_receive_time: 0,
             identity,
             name,
-            flags,
+            dc_support: flags.dc_support(),
             ports,
             dc_sync: DcSync::Disabled,
             // 0 is a reserved value, so we initialise the cycle at 1. The cycle repeats 1 - 7.
@@ -296,7 +299,7 @@ impl SubDevice {
 
     /// Distributed Clock (DC) support.
     pub fn dc_support(&self) -> DcSupport {
-        self.flags.dc_support()
+        self.dc_support
     }
 
     pub(crate) fn io_segments(&self) -> &IoRanges {
@@ -425,7 +428,7 @@ where
 
     /// Distributed Clock (DC) support.
     pub fn dc_support(&self) -> DcSupport {
-        self.state.flags.dc_support()
+        self.state.dc_support
     }
 
     pub(crate) fn dc_sync(&self) -> DcSync {

--- a/src/subdevice/pdi.rs
+++ b/src/subdevice/pdi.rs
@@ -228,11 +228,11 @@ mod tests {
         sd.config.io = IoRanges {
             input: PdiSegment {
                 bytes: 0..2,
-                bit_len: 16,
+                // bit_len: 16,
             },
             output: PdiSegment {
                 bytes: 2..4,
-                bit_len: 16,
+                // bit_len: 16,
             },
         };
 


### PR DESCRIPTION
Reduces Embassy example binary size from:

```
❯ cargo size -q --release
   text    data     bss     dec     hex filename
  98444      80  110456  208980   33054 ethercrab-stm32-embassy
```

to:

```
❯ cargo size -q --release
   text    data     bss     dec     hex filename
  96272      80  110456  206808   327d8 ethercrab-stm32-embassy
```

The example now compiles and works, so:

Closes #276 