### PR TITLE
Add EEPROM API, `Deref` and `DerefMut` impls to `SubDevice{Ref}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ An EtherCAT MainDevice written in Rust.
   group, along with methods on `TxRxResponse` to test for various state conditions.
 - [#273](https://github.com/ethercrab-rs/ethercrab/pull/273) Added `SubDevice::set_alias_address`
   and `SubDeviceRef::set_alias_address` to write an alias address to a SubDevice's EEPROM.
+- [#278](https://github.com/ethercrab-rs/ethercrab/pull/278) Add
+  `SubDevice::{eeprom_read, eeprom_read_raw, eeprom_size, eeprom_write_dangerously}` methods for
+  working with a SubDevice's EEPROM.
 
 ### Removed
 
@@ -63,6 +66,8 @@ An EtherCAT MainDevice written in Rust.
   now returns `Result<ReceiveAction, Error>` instead of `Result<(), Error>`.
 - **(breaking)** [#269](https://github.com/ethercrab-rs/ethercrab/pull/269)
   `SubDeviceGroup::tx_rx_*` methods now return a `TxRxResponse` struct instead of a tuple.
+- [#278](https://github.com/ethercrab-rs/ethercrab/pull/278) Add `Deref` and `DerefMut` impls for
+  `SubDeviceRef` instead of copy/pasting methods from `SubDevice`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,10 +126,6 @@ required-features = ["std"]
 name = "multiple-groups"
 required-features = ["std"]
 
-[[example]]
-name = "dump-eeprom"
-required-features = ["std", "__internals"]
-
 [[bench]]
 name = "pdu_loop"
 harness = false

--- a/examples/dump-eeprom.rs
+++ b/examples/dump-eeprom.rs
@@ -2,9 +2,7 @@
 
 use env_logger::Env;
 use ethercrab::{
-    error::Error,
-    std::{ethercat_now, tx_rx_task},
-    MainDevice, MainDeviceConfig, PduStorage, Timeouts,
+    error::Error, std::ethercat_now, MainDevice, MainDeviceConfig, PduStorage, Timeouts,
 };
 use std::io::Write;
 
@@ -50,7 +48,18 @@ async fn main() -> Result<(), Error> {
         },
     );
 
-    tokio::spawn(tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task"));
+    #[cfg(target_os = "windows")]
+    std::thread::spawn(move || {
+        ethercrab::std::tx_rx_task_blocking(
+            &interface,
+            tx,
+            rx,
+            ethercrab::std::TxRxTaskConfig { spinloop: false },
+        )
+        .expect("TX/RX task")
+    });
+    #[cfg(not(target_os = "windows"))]
+    tokio::spawn(ethercrab::std::tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task"));
 
     let group = maindevice
         .init_single_group::<MAX_SUBDEVICES, PDI_LEN>(ethercat_now)

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -2,7 +2,4 @@
 //!
 //! Anything exported by this module should be considered unstable and may change at any time.
 
-pub use crate::eeprom::device_provider::DeviceEeprom;
-pub use crate::eeprom::EepromDataProvider;
-pub use crate::eeprom::EepromRange;
 pub use crate::ethernet::{EthernetAddress, EthernetFrame};

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -241,8 +241,8 @@ impl SubDevice {
 
     /// Get the long name of the SubDevice.
     ///
-    /// Using the EK1100 as an example, [`SubDevice::name`] will return `"EK1100"` wherease this
-    /// method will return `"EK1100 EtherCAT-Koppler (2A E-Bus)"`.
+    /// Using the EK1100 as an example, [`SubDevice::name`](fn@crate::SubDevice::name) will return
+    /// `"EK1100"` whereas this method will return `"EK1100 EtherCAT-Koppler (2A E-Bus)"`.
     ///
     /// In the case that a SubDevice does not have a description, this method will return
     /// `Ok(None)`.
@@ -438,6 +438,15 @@ impl<'maindevice> Clone for SubDeviceRef<'maindevice, ()> {
     }
 }
 
+impl<'maindevice, S> DerefMut for SubDeviceRef<'maindevice, S>
+where
+    S: DerefMut<Target = SubDevice>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.state
+    }
+}
+
 impl<'maindevice, S> SubDeviceRef<'maindevice, S>
 where
     S: DerefMut<Target = SubDevice>,
@@ -459,34 +468,30 @@ where
     }
 }
 
+impl<'maindevice, S> Deref for SubDeviceRef<'maindevice, S>
+where
+    S: Deref<Target = SubDevice>,
+{
+    type Target = SubDevice;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
 impl<'maindevice, S> SubDeviceRef<'maindevice, S>
 where
     S: Deref<Target = SubDevice>,
 {
-    /// Get the human readable name of the SubDevice.
-    pub fn name(&self) -> &str {
-        self.state.name.as_str()
-    }
-
     /// Get the long name of the SubDevice.
     ///
-    /// Using the EK1100 as an example, [`SubDeviceRef::name`] will return `"EK1100"` wherease this
-    /// method will return `"EK1100 EtherCAT-Koppler (2A E-Bus)"`.
+    /// Using the EK1100 as an example, the [`name`](crate::SubDevice::name) method will return
+    /// `"EK1100"` whereas this method will return `"EK1100 EtherCAT-Koppler (2A E-Bus)"`.
     ///
     /// In the case that a SubDevice does not have a description, this method will return
     /// `Ok(None)`.
     pub async fn description(&self) -> Result<Option<heapless::String<128>>, Error> {
         SubDevice::description(&self.state, self.maindevice).await
-    }
-
-    /// Get additional identifying details for the SubDevice.
-    pub fn identity(&self) -> SubDeviceIdentity {
-        self.state.identity
-    }
-
-    /// Get alias address for the SubDevice.
-    pub fn alias_address(&self) -> u16 {
-        self.state.alias_address
     }
 
     /// INTERNAL: Read address from EEPROM.
@@ -500,19 +505,6 @@ where
         let subdevice_ref = SubDeviceRef::new(maindevice, self.configured_address, ());
 
         subdevice_ref.eeprom().station_alias().await
-    }
-
-    /// Get the network propagation delay of this device in nanoseconds.
-    ///
-    /// Note that before [`MainDevice::init`](crate::MainDevice::init) is called, this method will
-    /// always return `0`.
-    pub fn propagation_delay(&self) -> u32 {
-        self.state.propagation_delay
-    }
-
-    /// Distributed Clock (DC) support.
-    pub fn dc_support(&self) -> DcSupport {
-        self.state.dc_support
     }
 
     pub(crate) fn dc_sync(&self) -> DcSync {
@@ -1103,11 +1095,6 @@ impl<'maindevice, S> SubDeviceRef<'maindevice, S> {
             configured_address,
             state,
         }
-    }
-
-    /// Get the configured station address of the SubDevice.
-    pub fn configured_address(&self) -> u16 {
-        self.configured_address
     }
 
     /// Get the sub device status.

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -32,9 +32,10 @@ use core::{
     ops::{Deref, DerefMut},
     sync::atomic::{AtomicU8, Ordering},
 };
+use embedded_io_async::{Read, Write as EioWrite};
 use ethercrab_wire::{
     EtherCrabWireRead, EtherCrabWireReadSized, EtherCrabWireReadWrite, EtherCrabWireSized,
-    EtherCrabWireWrite,
+    EtherCrabWireWrite, EtherCrabWireWriteSized,
 };
 
 pub use self::pdi::SubDevicePdi;
@@ -252,6 +253,91 @@ impl SubDevice {
         let subdevice_ref = SubDeviceRef::new(maindevice, self.configured_address, ());
 
         subdevice_ref.eeprom().device_description().await
+    }
+
+    /// Get the SubDevice's EEPROM size in bytes.
+    pub async fn eeprom_size(&self, maindevice: &MainDevice<'_>) -> Result<usize, Error> {
+        let subdevice_ref = SubDeviceRef::new(maindevice, self.configured_address, ());
+
+        subdevice_ref.eeprom().size().await
+    }
+
+    /// Read raw bytes from the SubDevice's EEPROM, starting at the given **word** address.
+    ///
+    /// **The given start address is in words NOT bytes. To address the EEPROM using a byte address,
+    /// divide the given byte address by two.**
+    ///
+    /// To read individual typed values including fixed size chunks of `[u8; N]`, see
+    /// [`eeprom_read`](SubDevice::eeprom_read).
+    pub async fn eeprom_read_raw(
+        &self,
+        maindevice: &MainDevice<'_>,
+        start_word: u16,
+        buf: &mut [u8],
+    ) -> Result<usize, Error> {
+        let subdevice_ref = SubDeviceRef::new(maindevice, self.configured_address, ());
+
+        let mut reader = subdevice_ref
+            .eeprom()
+            .start_at(start_word, buf.len() as u16);
+
+        reader.read(buf).await
+    }
+
+    /// Read a value from the SubDevice's EEPROM at the given **word** address.
+    ///
+    /// **The given start address is in words NOT bytes. To address the EEPROM using a byte address,
+    /// divide the given byte address by two.**
+    ///
+    /// To read raw bytes, see [`eeprom_read_raw`](SubDevice::eeprom_read_raw).
+    pub async fn eeprom_read<T>(
+        &self,
+        maindevice: &MainDevice<'_>,
+        start_word: u16,
+    ) -> Result<T, Error>
+    where
+        T: EtherCrabWireReadSized,
+    {
+        let subdevice_ref = SubDeviceRef::new(maindevice, self.configured_address, ());
+
+        let mut reader = subdevice_ref
+            .eeprom()
+            .start_at(start_word, T::PACKED_LEN as u16);
+
+        let mut buf = T::buffer();
+
+        reader.read_exact(buf.as_mut()).await?;
+
+        let result = T::unpack_from_slice(buf.as_ref())?;
+
+        Ok(result)
+    }
+
+    /// Write a value to the SubDevice's EEPROM at the given **word** address.
+    ///
+    /// **The given start address is in words NOT bytes. To address the EEPROM using a byte address,
+    /// divide the given byte address by two.**
+    ///
+    /// **Warning:** This method is safe in the Rust sense, but can cause **corruption** to a
+    /// subdevice's EEPROM. Be **very** careful when writing data to a SubDevice EEPROM.
+    pub async fn eeprom_write_dangerously<T>(
+        &self,
+        maindevice: &MainDevice<'_>,
+        start_word: u16,
+        value: T,
+    ) -> Result<(), Error>
+    where
+        T: EtherCrabWireWriteSized,
+    {
+        let subdevice_ref = SubDeviceRef::new(maindevice, self.configured_address, ());
+
+        let mut writer = subdevice_ref
+            .eeprom()
+            .start_at(start_word, T::PACKED_LEN as u16);
+
+        let res = writer.write_all(value.pack().as_ref()).await?;
+
+        Ok(res)
     }
 
     /// Get additional identifying details for the SubDevice.

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -315,11 +315,15 @@ impl SubDevice {
 
     /// Write a value to the SubDevice's EEPROM at the given **word** address.
     ///
+    /// <div class="warning">
+    ///
+    /// **Warning:** This method is safe in the Rust sense, but can cause **EEPROM corruption** if
+    /// mishandled. Be **very** careful when writing data to a SubDevice's EEPROM.
+    ///
+    /// </div>
+    ///
     /// **The given start address is in words NOT bytes. To address the EEPROM using a byte address,
     /// divide the given byte address by two.**
-    ///
-    /// **Warning:** This method is safe in the Rust sense, but can cause **corruption** to a
-    /// subdevice's EEPROM. Be **very** careful when writing data to a SubDevice EEPROM.
     pub async fn eeprom_write_dangerously<T>(
         &self,
         maindevice: &MainDevice<'_>,


### PR DESCRIPTION
Adds read and write methods for a SubDevice's EEPROM. For example, to dump the entire contents:

```rust
let eeprom_len = subdevice
    .eeprom_size(&maindevice)
    .await
    .expect("Could not read EEPROM len");

log::info!("--> Device EEPROM is {} bytes long", eeprom_len);

let mut buf = vec![0u8; eeprom_len];

// Read entire EEPROM into buffer
subdevice.eeprom_read_raw(&maindevice, 0, &mut buf).await?;
```

Also removes some duplicated methods and replaces their "existence" with `Deref` and `DerefMut` impls.