### PR TITLE
Backport #288 to 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ An EtherCAT master written in Rust.
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- [#288](https://github.com/ethercrab-rs/ethercrab/pull/288) Prevent overflow and infinite loops
+  when reading empty or nearly-empty SubDevice EEPROMs.
+
 ## [0.5.3] - 2025-01-24
 
 ### Added
@@ -458,8 +463,8 @@ An EtherCAT master written in Rust.
 - Initial release
 
 <!-- next-url -->
-[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.5.3...HEAD
 
+[unreleased]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.5.3...HEAD
 [0.5.3]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.5.2...ethercrab-v0.5.3
 [0.5.2]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.5.1...ethercrab-v0.5.2
 [0.5.1]: https://github.com/ethercrab-rs/ethercrab/compare/ethercrab-v0.5.0...ethercrab-v0.5.1

--- a/src/subdevice/eeprom.rs
+++ b/src/subdevice/eeprom.rs
@@ -40,16 +40,41 @@ where
 
         let mut word_addr = SII_FIRST_CATEGORY_START;
 
+        let mut num_empty_categories = 0u8;
+
         loop {
             let chunk = reader.read_chunk(word_addr).await?;
 
-            word_addr += 2;
+            let Some(incr) = word_addr.checked_add(2) else {
+                fmt::warn!(
+                    "Could not find EEPROM category {:?} or end marker. EEPROM could be empty or corrupt.",
+                    category
+                );
+
+                break Ok(None);
+            };
+
+            word_addr = incr;
 
             let (c1, chunk) = fmt::unwrap_opt!(chunk.split_first_chunk::<2>());
             let (c2, _chunk) = fmt::unwrap_opt!(chunk.split_first_chunk::<2>());
 
             let category_type = CategoryType::from(u16::from_le_bytes(*c1));
             let len_words = u16::from_le_bytes(*c2);
+
+            if len_words == 0 {
+                num_empty_categories += 1;
+            }
+
+            // Heuristic: if every category we search for is empty, it's likely that the EEPROM is
+            // blank and we should stop searching for anything.
+            if num_empty_categories >= 32 {
+                fmt::debug!(
+                    "Did not find any non-empty categories. EEPROM could be empty or corrupt."
+                );
+
+                break Ok(None);
+            }
 
             fmt::trace!(
                 "Found category {:?} at {:#06x} bytes, length {:#04x} ({}) words",

--- a/tests/replay-ek1100-el2828-el2889.rs
+++ b/tests/replay-ek1100-el2828-el2889.rs
@@ -83,6 +83,19 @@ async fn replay_ek1100_el2828_el2889() -> Result<(), Error> {
         .await
         .expect("Fast into OP");
 
+    assert_eq!(
+        slow_outputs.subdevice(&maindevice, 0).unwrap().name(),
+        "EK1100"
+    );
+    assert_eq!(
+        slow_outputs.subdevice(&maindevice, 1).unwrap().name(),
+        "EL2889"
+    );
+    assert_eq!(
+        fast_outputs.subdevice(&maindevice, 0).unwrap().name(),
+        "EL2828"
+    );
+
     let mut slow_cycle_time = tokio::time::interval(Duration::from_millis(10));
     slow_cycle_time.set_missed_tick_behavior(MissedTickBehavior::Skip);
 


### PR DESCRIPTION
#288:

* Handle wrapping add in EEPROM address increment

* Add heuristic to stop searching through a pile of empty categories