### PR TITLE
Fall back to other fields when computing SM type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ An EtherCAT MainDevice written in Rust.
   when reading empty or nearly-empty SubDevice EEPROMs.
 - [#291](https://github.com/ethercrab-rs/ethercrab/pull/291) Allow initialisation to progress
   further for devices with empty EEPROMs by falling back to defaults if config data cannot be found.
+- [#294](https://github.com/ethercrab-rs/ethercrab/pull/294) Compute SM type using fallback data
+  when EEPROM record is incomplete.
 
 ## [0.5.3] - 2025-01-24
 

--- a/src/subdevice/configuration.rs
+++ b/src/subdevice/configuration.rs
@@ -261,7 +261,7 @@ where
             let sync_manager_index = sync_manager_index as u8;
 
             // Mailboxes are configured in INIT state
-            match sync_manager.usage_type {
+            match sync_manager.usage_type() {
                 SyncManagerType::MailboxWrite => {
                     self.write_sm_config(
                         sync_manager_index,
@@ -554,7 +554,7 @@ where
         for (sync_manager_index, sync_manager) in sync_managers
             .iter()
             .enumerate()
-            .filter(|(_idx, sm)| sm.usage_type == sm_type)
+            .filter(|(_idx, sm)| sm.usage_type() == sm_type)
         {
             let sync_manager_index = sync_manager_index as u8;
 


### PR DESCRIPTION
The log in #290 shows `usage_type: Unknown` however the fields in `control.operation_mode` and `control.direction` are populated, so we can use them as a fallback to compute the SM type when the EEPROM data is incomplete.

This is another PR in a few like #291 that handle missing data in the EEPROM. Another reason to support ESI files as they seem to be the preferred way for manufacturers to configure their devices...

Closes #290