### PR TITLE
Fix 2024 edition warnings

### DIFF
--- a/src/dc.rs
+++ b/src/dc.rs
@@ -29,7 +29,7 @@ async fn latch_dc_times(
     // Latch receive times into all ports of all SubDevices.
     Command::bwr(RegisterAddress::DcTimePort0.into())
         .with_wkc(num_subdevices_with_dc as u16)
-        .send_receive(maindevice, 0u32)
+        .send(maindevice, 0u32)
         .await?;
 
     // Read receive times for all SubDevices and store on SubDevice structs

--- a/src/eeprom/device_provider.rs
+++ b/src/eeprom/device_provider.rs
@@ -60,7 +60,7 @@ impl<'subdevice> EepromDataProvider for DeviceEeprom<'subdevice> {
         start_word: u16,
     ) -> Result<impl core::ops::Deref<Target = [u8]>, Error> {
         Command::fpwr(self.configured_address, RegisterAddress::SiiControl.into())
-            .send_receive(self.maindevice, SiiRequest::read(start_word))
+            .send(self.maindevice, SiiRequest::read(start_word))
             .await?;
 
         let status = self.wait_while_busy().await?;
@@ -93,7 +93,7 @@ impl<'subdevice> EepromDataProvider for DeviceEeprom<'subdevice> {
             // Send control and address registers. A rising edge on the write flag will store whatever
             // is in `SiiAddress` into the EEPROM at the given address.
             Command::fpwr(self.configured_address, RegisterAddress::SiiControl.into())
-                .send_receive(self.maindevice, SiiRequest::write(start_word))
+                .send(self.maindevice, SiiRequest::write(start_word))
                 .await?;
 
             // Wait for error or not busy


### PR DESCRIPTION
This does not upgrade to 2024, just fixes the "this will become an error in the future" warnings popped up currently.