### PR TITLE
Implement SDO Info Get Object Description List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ A pure Rust EtherCAT MainDevice supporting std and no_std environments.
 
 - [#310](https://github.com/ethercrab-rs/ethercrab/pull/310) Add support for XDP on Linux systems
   using the `xdp` feature.
+  using the `xdp` feature.z
+- [#305](https://github.com/ethercrab-rs/ethercrab/pull/305) (@fpdotmonkey) Added
+  `SubDevice::sdo_info_object_description_list` and `SubDevice::sdo_info_object_quantities` to get
+  information about a SubDevice's SDOs.
 
 ### Changed
 

--- a/examples/sdo-info.rs
+++ b/examples/sdo-info.rs
@@ -1,0 +1,127 @@
+//! Print SDO Info about the CoE object dictionaries of every device on the bus.
+//!
+//! Run with e.g.
+//!
+//! Linux
+//!
+//! ```bash
+//! cargo build --release --example sdo-info
+//! # avoid sudo with `sudo setcap cap_net_raw=pe /path/to/sdo-info`
+//! RUST_LOG=debug sudo -E ./target/release/sdo-info eth0
+//! ```
+//!
+//! Windows
+//!
+//! ```ps
+//! $env:RUST_LOG="debug" ; cargo run --example ek1100 --release -- '\Device\NPF_{FF0ACEE6-E8CD-48D5-A399-619CD2340465}'
+//! ```
+
+use env_logger::Env;
+use ethercrab::{
+    error::Error, std::ethercat_now, MainDevice, MainDeviceConfig, ObjectDescriptionListQuery,
+    ObjectDescriptionListQueryCounts, PduStorage, Timeouts,
+};
+use std::{sync::Arc, time::Duration};
+
+/// Maximum number of SubDevices that can be stored. This must be a power of 2 greater than 1.
+const MAX_SUBDEVICES: usize = 16;
+/// Maximum PDU data payload size - set this to the max PDI size or higher.
+const MAX_PDU_DATA: usize = PduStorage::element_size(1100);
+/// Maximum number of EtherCAT frames that can be in flight at any one time.
+const MAX_FRAMES: usize = 16;
+/// Maximum total PDI length.
+const PDI_LEN: usize = 64;
+
+static PDU_STORAGE: PduStorage<MAX_FRAMES, MAX_PDU_DATA> = PduStorage::new();
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    let interface = std::env::args()
+        .nth(1)
+        .expect("Provide network interface as first argument.");
+
+    let (tx, rx, pdu_loop) = PDU_STORAGE.try_split().expect("can only split once");
+
+    let maindevice = Arc::new(MainDevice::new(
+        pdu_loop,
+        Timeouts {
+            wait_loop_delay: Duration::from_millis(2),
+            mailbox_response: Duration::from_millis(1000),
+            ..Default::default()
+        },
+        MainDeviceConfig::default(),
+    ));
+
+    #[cfg(target_os = "windows")]
+    std::thread::spawn(move || {
+        ethercrab::std::tx_rx_task_blocking(
+            &interface,
+            tx,
+            rx,
+            ethercrab::std::TxRxTaskConfig { spinloop: false },
+        )
+        .expect("TX/RX task")
+    });
+    #[cfg(not(target_os = "windows"))]
+    tokio::spawn(ethercrab::std::tx_rx_task(&interface, tx, rx).expect("spawn TX/RX task"));
+
+    let group = maindevice
+        .init_single_group::<MAX_SUBDEVICES, PDI_LEN>(ethercat_now)
+        .await
+        .expect("Init");
+
+    for subdevice in group.iter(&maindevice) {
+        println!("{}:", subdevice.name());
+        let object_quantities = subdevice.sdo_info_object_quantities().await?.unwrap_or(
+            ObjectDescriptionListQueryCounts {
+                all: 0,
+                rx_pdo_mappable: 0,
+                tx_pdo_mappable: 0,
+                stored_for_device_replacement: 0,
+                startup_parameters: 0,
+            },
+        );
+        println!(
+            r#"  object-quantities:
+    all: {}
+    rx-pdo-mappable: {}
+    tx-pdo-mappable: {}
+    stored-for-device-replacement: {}
+    startup-parameters: {}"#,
+            object_quantities.all,
+            object_quantities.rx_pdo_mappable,
+            object_quantities.tx_pdo_mappable,
+            object_quantities.stored_for_device_replacement,
+            object_quantities.startup_parameters,
+        );
+
+        let addresses = subdevice
+            .sdo_info_object_description_list(ObjectDescriptionListQuery::All)
+            .await?
+            .unwrap_or_default();
+        println!("  addresses: {}", address_list(addresses));
+    }
+
+    let _group = group.into_init(&maindevice).await.expect("PRE-OP -> INIT");
+
+    log::info!("PRE-OP -> INIT, shutdown complete");
+
+    Ok(())
+}
+
+// the string can be as big as 0x1_0000 addresses * 8 char/address.
+fn address_list(addresses: heapless::Vec<u16, 0x1_0000>) -> heapless::String<0x8_0000> {
+    let mut out = heapless::String::<0x8_0000>::new();
+    if addresses.is_empty() {
+        return out;
+    }
+    out.push('[').expect("longer buffer");
+    for address in addresses[..addresses.len() - 1].iter() {
+        let _ = out.push_str(&format!("{address:#06x}, "));
+    }
+    out.push_str(&format!("{:#06x}]", addresses.last().unwrap()))
+        .expect("longer buffer");
+    out
+}

--- a/examples/sdo-info.rs
+++ b/examples/sdo-info.rs
@@ -115,6 +115,7 @@ async fn main() -> Result<(), Error> {
 fn address_list(addresses: heapless::Vec<u16, 0x1_0000>) -> heapless::String<0x8_0000> {
     let mut out = heapless::String::<0x8_0000>::new();
     if addresses.is_empty() {
+        out.push_str("[]").unwrap();
         return out;
     }
     out.push('[').expect("longer buffer");

--- a/examples/sdo-info.rs
+++ b/examples/sdo-info.rs
@@ -18,8 +18,8 @@
 
 use env_logger::Env;
 use ethercrab::{
-    error::Error, std::ethercat_now, MainDevice, MainDeviceConfig, ObjectDescriptionListQuery,
-    ObjectDescriptionListQueryCounts, PduStorage, Timeouts,
+    MainDevice, MainDeviceConfig, ObjectDescriptionListQuery, ObjectDescriptionListQueryCounts,
+    PduStorage, Timeouts, error::Error, std::ethercat_now,
 };
 use std::{sync::Arc, time::Duration};
 

--- a/src/coe/mod.rs
+++ b/src/coe/mod.rs
@@ -3,6 +3,8 @@ use ethercrab_wire::EtherCrabWireReadSized;
 pub mod abort_code;
 pub mod services;
 
+pub use services::{ObjectDescriptionListQuery, ObjectDescriptionListQueryCounts};
+
 /// Defined in ETG1000.6 Table 29 – CoE elements
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ethercrab_wire::EtherCrabWireReadWrite)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
@@ -76,6 +78,31 @@ pub struct SegmentSdoHeader {
 
     #[wire(bits = 3)]
     command: CoeCommand,
+}
+
+/// Defined in ETG.1000.6 5.6.3.2
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ethercrab_wire::EtherCrabWireReadWrite)]
+#[wire(bytes = 4)]
+pub struct SdoInfoHeader {
+    #[wire(bits = 7)]
+    pub op_code: SdoInfoOpCode,
+    #[wire(bits = 1)]
+    pub incomplete: bool,
+    #[wire(pre_skip = 8, bytes = 2)]
+    pub fragments_left: u16,
+}
+
+/// Defined in ETG.1000.6 5.6.3.2
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ethercrab_wire::EtherCrabWireReadWrite)]
+#[repr(u8)]
+pub enum SdoInfoOpCode {
+    GetObjectDescriptionListRequest = 0x01,
+    GetObjectDescriptionListResponse = 0x02,
+    GetObjectDescriptionRequest = 0x03,
+    GetObjectDescriptionResponse = 0x04,
+    GetEntryDescriptionRequest = 0x05,
+    GetEntryDescriptionResponse = 0x06,
+    SdoInfoErrorRequest = 0x07,
 }
 
 /// Subindex access.

--- a/src/coe/services.rs
+++ b/src/coe/services.rs
@@ -84,7 +84,7 @@ impl Display for SdoSegmented {
 /// Defined in ETG.1000.6 §5.6.3.3.1
 #[derive(Debug, Copy, Clone, PartialEq, ethercrab_wire::EtherCrabWireReadWrite)]
 #[wire(bytes = 14)]
-pub struct GetObjectDescriptionListRequest {
+pub struct ObjectDescriptionListRequest {
     #[wire(bytes = 8)]
     pub mailbox: MailboxHeader,
     #[wire(bytes = 4)]
@@ -96,7 +96,7 @@ pub struct GetObjectDescriptionListRequest {
 /// Defined in ETG.1000.6 §5.6.3.3.2
 #[derive(Debug, Copy, Clone, PartialEq, ethercrab_wire::EtherCrabWireReadWrite)]
 #[wire(bytes = 12)]
-pub struct GetObjectDescriptionListResponse {
+pub struct ObjectDescriptionListResponse {
     #[wire(bytes = 8)]
     pub mailbox: MailboxHeader,
     #[wire(bytes = 4)]
@@ -300,8 +300,8 @@ pub fn upload(counter: u8, index: u16, access: SubIndex) -> SdoNormal {
 pub fn get_object_description_list(
     counter: u8,
     list_type: ObjectDescriptionListQuery,
-) -> GetObjectDescriptionListRequest {
-    GetObjectDescriptionListRequest {
+) -> ObjectDescriptionListRequest {
+    ObjectDescriptionListRequest {
         mailbox: MailboxHeader {
             length: 0x08,
             // address: 0x0000,
@@ -319,8 +319,8 @@ pub fn get_object_description_list(
     }
 }
 
-pub fn get_object_quantities(counter: u8) -> GetObjectDescriptionListRequest {
-    GetObjectDescriptionListRequest {
+pub fn get_object_quantities(counter: u8) -> ObjectDescriptionListRequest {
+    ObjectDescriptionListRequest {
         mailbox: MailboxHeader {
             length: 0x08,
             // address: 0x0000,
@@ -509,8 +509,8 @@ mod tests {
         let raw: [u8; 14] = [
             0x8, 0x0, 0x0, 0x0, 0x0, 0x73, 0x0, 0x80, 0x1, 0x0, 0x0, 0x0, 0x1, 0x0,
         ];
-        let parsed = GetObjectDescriptionListRequest::unpack_from_slice(&raw);
-        let expected = GetObjectDescriptionListRequest {
+        let parsed = ObjectDescriptionListRequest::unpack_from_slice(&raw);
+        let expected = ObjectDescriptionListRequest {
             mailbox: MailboxHeader {
                 length: 8,
                 priority: Priority::Lowest,
@@ -526,10 +526,10 @@ mod tests {
             list_type: ObjectDescriptionListQueryInner::All,
         };
         pretty_assertions::assert_eq!(parsed, Ok(expected));
-        let mut buf = [0u8; GetObjectDescriptionListRequest::PACKED_LEN];
+        let mut buf = [0u8; ObjectDescriptionListRequest::PACKED_LEN];
         pretty_assertions::assert_eq!(
             expected.pack_to_slice(&mut buf),
-            Ok(&raw[..GetObjectDescriptionListRequest::PACKED_LEN])
+            Ok(&raw[..ObjectDescriptionListRequest::PACKED_LEN])
         );
 
         // from Wireshark
@@ -545,8 +545,8 @@ mod tests {
             0x1a, 0x1e, 0x1a, 0x1f, 0x1a, 0x20, 0x1a, 0x21, 0x1a, 0x22, 0x1a, 0x23, 0x1a, 0x24,
             0x1a, 0x25, 0x1a, 0x26, 0x1a, 0x30, 0x1a, 0x31, 0x1a,
         ];
-        let parsed = GetObjectDescriptionListResponse::unpack_from_slice(&raw);
-        let expected = GetObjectDescriptionListResponse {
+        let parsed = ObjectDescriptionListResponse::unpack_from_slice(&raw);
+        let expected = ObjectDescriptionListResponse {
             mailbox: MailboxHeader {
                 length: 122,
                 priority: Priority::Lowest,
@@ -562,17 +562,17 @@ mod tests {
         };
         pretty_assertions::assert_eq!(parsed, Ok(expected));
         let list_type = <ObjectDescriptionListQueryInner>::unpack_from_slice(
-            &raw[GetObjectDescriptionListResponse::PACKED_LEN
-                ..GetObjectDescriptionListResponse::PACKED_LEN + 2],
+            &raw[ObjectDescriptionListResponse::PACKED_LEN
+                ..ObjectDescriptionListResponse::PACKED_LEN + 2],
         );
         pretty_assertions::assert_eq!(list_type, Ok(ObjectDescriptionListQueryInner::All));
-        let mut buf = [0u8; GetObjectDescriptionListResponse::PACKED_LEN];
+        let mut buf = [0u8; ObjectDescriptionListResponse::PACKED_LEN];
         pretty_assertions::assert_eq!(
             expected.pack_to_slice(&mut buf),
-            Ok(&raw[..GetObjectDescriptionListResponse::PACKED_LEN])
+            Ok(&raw[..ObjectDescriptionListResponse::PACKED_LEN])
         );
         // length is actually 57
-        let expected: [u16; (RAW_LEN - GetObjectDescriptionListRequest::PACKED_LEN) / 2] = [
+        let expected: [u16; (RAW_LEN - ObjectDescriptionListRequest::PACKED_LEN) / 2] = [
             0x1000, 0x1008, 0x1009, 0x100a, 0x1018, 0x1601, 0x1602, 0x1603, 0x1621, 0x1622, 0x1623,
             0x1624, 0x1625, 0x1626, 0x1630, 0x1631, 0x1a00, 0x1a01, 0x1a02, 0x1a03, 0x1a04, 0x1a05,
             0x1a06, 0x1a07, 0x1a08, 0x1a09, 0x1a0a, 0x1a0b, 0x1a0c, 0x1a0d, 0x1a0e, 0x1a0f, 0x1a10,
@@ -580,7 +580,7 @@ mod tests {
             0x1a1c, 0x1a1d, 0x1a1e, 0x1a1f, 0x1a20, 0x1a21, 0x1a22, 0x1a23, 0x1a24, 0x1a25, 0x1a26,
             0x1a30, 0x1a31,
         ];
-        let parsed = <_>::unpack_from_slice(&raw[GetObjectDescriptionListRequest::PACKED_LEN..]);
+        let parsed = <_>::unpack_from_slice(&raw[ObjectDescriptionListRequest::PACKED_LEN..]);
         pretty_assertions::assert_eq!(parsed, Ok(expected));
     }
 

--- a/src/coe/services.rs
+++ b/src/coe/services.rs
@@ -103,21 +103,21 @@ pub struct GetObjectDescriptionListResponse {
     pub sdo_info_header: SdoInfoHeader,
 }
 
-/// [`ObjectDescriptionListType`], but with `ObjectQuantities`.
+/// [`ObjectDescriptionListQuery`], but with `ObjectQuantities`.
 #[derive(Debug, Copy, Clone, PartialEq, ethercrab_wire::EtherCrabWireReadWrite)]
 #[repr(u8)]
 pub enum ObjectDescriptionListQueryInner {
-    /// Get number of objects in the 5 different lists
+    /// Get number of objects in the 5 different lists.
     ObjectQuantities = 0x00,
-    /// All objects of the object dictionary
+    /// All objects of the object dictionary.
     All = 0x01,
-    /// Objects which are mappable in an RxPDO
+    /// Objects which are mappable in an RxPDO.
     RxPdoMappable = 0x02,
-    /// Objects which are mappable in a TxPDO
+    /// Objects which are mappable in a TxPDO.
     TxPdoMappable = 0x03,
-    /// Objects which have to be stored for a device replacement
+    /// Objects which have to be stored for a device replacement.
     StoredForDeviceReplacement = 0x04,
-    /// Objects which can be used as startup parameter
+    /// Objects which can be used as startup parameter.
     StartupParameters = 0x05,
 }
 
@@ -133,15 +133,15 @@ pub enum ObjectDescriptionListQueryInner {
 #[repr(u8)]
 pub enum ObjectDescriptionListQuery {
     // ObjectQuantities is invoked through a different API
-    /// All objects of the object dictionary
+    /// All objects of the object dictionary.
     All = 0x01,
-    /// Objects which are mappable in an RxPDO
+    /// Objects which are mappable in an RxPDO.
     RxPdoMappable = 0x02,
-    /// Objects which are mappable in a TxPDO
+    /// Objects which are mappable in a TxPDO.
     TxPdoMappable = 0x03,
-    /// Objects which have to be stored for a device replacement
+    /// Objects which have to be stored for a device replacement.
     StoredForDeviceReplacement = 0x04,
-    /// Objects which can be used as startup parameter
+    /// Objects which can be used as startup parameter.
     StartupParameters = 0x05,
 }
 
@@ -165,18 +165,18 @@ impl From<ObjectDescriptionListQuery> for ObjectDescriptionListQueryInner {
     }
 }
 
-/// How many CoE objects on a subdevice are of each [`ObjectDescriptionListType`].
+/// How many CoE objects on a subdevice are of each [`ObjectDescriptionListQuery`].
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ObjectDescriptionListQueryCounts {
-    /// How many are of type [`ObjectDescriptionListType::All`].
+    /// How many are of type [`ObjectDescriptionListQuery::All`].
     pub all: u16,
-    /// How many are of type [`ObjectDescriptionListType::RxPdoMappable`].
+    /// How many are of type [`ObjectDescriptionListQuery::RxPdoMappable`].
     pub rx_pdo_mappable: u16,
-    /// How many are of type [`ObjectDescriptionListType::TxPdoMappable`].
+    /// How many are of type [`ObjectDescriptionListQuery::TxPdoMappable`].
     pub tx_pdo_mappable: u16,
-    /// How many are of type [`ObjectDescriptionListType::StoredForDeviceReplacement`].
+    /// How many are of type [`ObjectDescriptionListQuery::StoredForDeviceReplacement`].
     pub stored_for_device_replacement: u16,
-    /// How many are of type [`ObjectDescriptionListType::StartupParameters`].
+    /// How many are of type [`ObjectDescriptionListQuery::StartupParameters`].
     pub startup_parameters: u16,
 }
 

--- a/src/coe/services.rs
+++ b/src/coe/services.rs
@@ -166,17 +166,24 @@ impl From<ObjectDescriptionListQuery> for ObjectDescriptionListQueryInner {
 }
 
 /// How many CoE objects on a subdevice are of each [`ObjectDescriptionListQuery`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, ethercrab_wire::EtherCrabWireRead)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[wire(bytes = 10)]
 pub struct ObjectDescriptionListQueryCounts {
     /// How many are of type [`ObjectDescriptionListQuery::All`].
+    #[wire(bytes = 2)]
     pub all: u16,
     /// How many are of type [`ObjectDescriptionListQuery::RxPdoMappable`].
+    #[wire(bytes = 2)]
     pub rx_pdo_mappable: u16,
     /// How many are of type [`ObjectDescriptionListQuery::TxPdoMappable`].
+    #[wire(bytes = 2)]
     pub tx_pdo_mappable: u16,
     /// How many are of type [`ObjectDescriptionListQuery::StoredForDeviceReplacement`].
+    #[wire(bytes = 2)]
     pub stored_for_device_replacement: u16,
     /// How many are of type [`ObjectDescriptionListQuery::StartupParameters`].
+    #[wire(bytes = 2)]
     pub startup_parameters: u16,
 }
 

--- a/src/coe/services.rs
+++ b/src/coe/services.rs
@@ -1,4 +1,4 @@
-use super::{CoeService, InitSdoHeader, SegmentSdoHeader, SubIndex};
+use super::{CoeService, InitSdoHeader, SdoInfoHeader, SdoInfoOpCode, SegmentSdoHeader, SubIndex};
 use crate::mailbox::{MailboxHeader, MailboxType, Priority};
 use core::fmt::Display;
 
@@ -81,7 +81,93 @@ impl Display for SdoSegmented {
     }
 }
 
-/// Must be implemented for any type used to send a CoE service.
+/// Defined in ETG.1000.6 §5.6.3.3.1
+#[derive(Debug, Copy, Clone, PartialEq, ethercrab_wire::EtherCrabWireReadWrite)]
+#[wire(bytes = 14)]
+pub struct GetObjectDescriptionListRequest {
+    #[wire(bytes = 8)]
+    pub mailbox: MailboxHeader,
+    #[wire(bytes = 4)]
+    pub sdo_info_header: SdoInfoHeader,
+    #[wire(bytes = 1, post_skip = 8)]
+    list_type: ObjectDescriptionListQueryInner,
+}
+
+/// [`ObjectDescriptionListType`], but with `ObjectQuantities`.
+#[derive(Debug, Copy, Clone, PartialEq, ethercrab_wire::EtherCrabWireReadWrite)]
+#[repr(u8)]
+enum ObjectDescriptionListQueryInner {
+    /// Get number of objects in the 5 different lists
+    ObjectQuantities = 0x00,
+    /// All objects of the object dictionary
+    All = 0x01,
+    /// Objects which are mappable in an RxPDO
+    RxPdoMappable = 0x02,
+    /// Objects which are mappable in a TxPDO
+    TxPdoMappable = 0x03,
+    /// Objects which have to be stored for a device replacement
+    StoredForDeviceReplacement = 0x04,
+    /// Objects which can be used as startup parameter
+    StartupParameters = 0x05,
+}
+
+/// The subset of indices of the object dictionary which
+/// [`crate::SubDeviceRef::sdo_info_object_description_list`] makes a request for.
+///
+/// Defined in ETG.1000.6 §5.6.3.3.1.
+///
+/// Note that object quantities (value 0 in the standard) can be queried with
+/// [`crate::SubDeviceRef::sdo_info_object_quantities`].
+#[derive(Debug, Copy, Clone, ethercrab_wire::EtherCrabWireReadWrite)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum ObjectDescriptionListQuery {
+    // ObjectQuantities is invoked through a different API
+    /// All objects of the object dictionary
+    All = 0x01,
+    /// Objects which are mappable in an RxPDO
+    RxPdoMappable = 0x02,
+    /// Objects which are mappable in a TxPDO
+    TxPdoMappable = 0x03,
+    /// Objects which have to be stored for a device replacement
+    StoredForDeviceReplacement = 0x04,
+    /// Objects which can be used as startup parameter
+    StartupParameters = 0x05,
+}
+
+/// How many CoE objects on a subdevice are of each [`ObjectDescriptionListType`].
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct ObjectDescriptionListQueryCounts {
+    /// How many are of type [`ObjectDescriptionListType::All`].
+    pub all: u16,
+    /// How many are of type [`ObjectDescriptionListType::RxPdoMappable`].
+    pub rx_pdo_mappable: u16,
+    /// How many are of type [`ObjectDescriptionListType::TxPdoMappable`].
+    pub tx_pdo_mappable: u16,
+    /// How many are of type [`ObjectDescriptionListType::StoredForDeviceReplacement`].
+    pub stored_for_device_replacement: u16,
+    /// How many are of type [`ObjectDescriptionListType::StartupParameters`].
+    pub startup_parameters: u16,
+}
+
+impl core::fmt::Display for ObjectDescriptionListQuery {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                ObjectDescriptionListQuery::All => "All",
+                ObjectDescriptionListQuery::RxPdoMappable => "RxPDO-Mappable",
+                ObjectDescriptionListQuery::TxPdoMappable => "TxPDO-Mappable",
+                ObjectDescriptionListQuery::StoredForDeviceReplacement =>
+                    "Stored for Device Replacement",
+                ObjectDescriptionListQuery::StartupParameters => "Startup Parameters",
+            }
+        )
+    }
+}
+
+/// Must be implemented for any type used to send a CoE SDO Request or Response service.
 pub trait CoeServiceRequest:
     ethercrab_wire::EtherCrabWireReadWrite + ethercrab_wire::EtherCrabWireWriteSized
 {
@@ -178,6 +264,49 @@ pub fn upload(counter: u8, index: u16, access: SubIndex) -> SdoNormal {
             index,
             sub_index: access.sub_index(),
         },
+    }
+}
+
+pub fn get_object_description_list(
+    counter: u8,
+    list_type: ObjectDescriptionListQuery,
+) -> GetObjectDescriptionListRequest {
+    GetObjectDescriptionListRequest {
+        mailbox: MailboxHeader {
+            length: 0x08,
+            // address: 0x0000,
+            priority: Priority::Lowest,
+            mailbox_type: MailboxType::Coe,
+            counter,
+            service: CoeService::SdoInformation,
+        },
+        sdo_info_header: SdoInfoHeader {
+            op_code: SdoInfoOpCode::GetObjectDescriptionListRequest,
+            incomplete: false,
+            fragments_left: 0,
+        },
+        // unwrap is fine since UserObjectDescriptionListType is a
+        // subset of ObjectDescriptionListType
+        list_type: (list_type as u8).try_into().unwrap(),
+    }
+}
+
+pub fn get_object_quantities(counter: u8) -> GetObjectDescriptionListRequest {
+    GetObjectDescriptionListRequest {
+        mailbox: MailboxHeader {
+            length: 0x08,
+            // address: 0x0000,
+            priority: Priority::Lowest,
+            mailbox_type: MailboxType::Coe,
+            counter,
+            service: CoeService::SdoInformation,
+        },
+        sdo_info_header: SdoInfoHeader {
+            op_code: SdoInfoOpCode::GetObjectDescriptionListRequest,
+            incomplete: false,
+            fragments_left: 0,
+        },
+        list_type: ObjectDescriptionListQueryInner::ObjectQuantities,
     }
 }
 
@@ -344,6 +473,83 @@ mod tests {
         );
 
         assert_eq!(&raw[(12 + u32::PACKED_LEN)..][..4], &[69, 75, 49, 57]);
+    }
+
+    #[test]
+    fn get_object_description_list() {
+        // from Wireshark
+        let raw: [u8; 14] = [
+            0x8, 0x0, 0x0, 0x0, 0x0, 0x73, 0x0, 0x80, 0x1, 0x0, 0x0, 0x0, 0x1, 0x0,
+        ];
+        let parsed = GetObjectDescriptionListRequest::unpack_from_slice(&raw);
+        let expected = GetObjectDescriptionListRequest {
+            mailbox: MailboxHeader {
+                length: 8,
+                priority: Priority::Lowest,
+                mailbox_type: MailboxType::Coe,
+                counter: 7,
+                service: CoeService::SdoInformation,
+            },
+            sdo_info_header: SdoInfoHeader {
+                op_code: SdoInfoOpCode::GetObjectDescriptionListRequest,
+                incomplete: false,
+                fragments_left: 0,
+            },
+            list_type: ObjectDescriptionListQueryInner::All,
+        };
+        pretty_assertions::assert_eq!(parsed, Ok(expected));
+        let mut buf = [0u8; GetObjectDescriptionListRequest::PACKED_LEN];
+        pretty_assertions::assert_eq!(
+            expected.pack_to_slice(&mut buf),
+            Ok(&raw[..GetObjectDescriptionListRequest::PACKED_LEN])
+        );
+
+        // from Wireshark
+        const RAW_LEN: usize = 128;
+        let raw: [u8; RAW_LEN] = [
+            0x7a, 0x0, 0x0, 0x0, 0x0, 0x73, 0x0, 0x80, 0x82, 0x0, 0x1, 0x0, 0x1, 0x0, 0x0, 0x10,
+            0x8, 0x10, 0x9, 0x10, 0xa, 0x10, 0x18, 0x10, 0x1, 0x16, 0x2, 0x16, 0x3, 0x16, 0x21,
+            0x16, 0x22, 0x16, 0x23, 0x16, 0x24, 0x16, 0x25, 0x16, 0x26, 0x16, 0x30, 0x16, 0x31,
+            0x16, 0x0, 0x1a, 0x1, 0x1a, 0x2, 0x1a, 0x3, 0x1a, 0x4, 0x1a, 0x5, 0x1a, 0x6, 0x1a, 0x7,
+            0x1a, 0x8, 0x1a, 0x9, 0x1a, 0xa, 0x1a, 0xb, 0x1a, 0xc, 0x1a, 0xd, 0x1a, 0xe, 0x1a, 0xf,
+            0x1a, 0x10, 0x1a, 0x11, 0x1a, 0x12, 0x1a, 0x13, 0x1a, 0x14, 0x1a, 0x15, 0x1a, 0x16,
+            0x1a, 0x17, 0x1a, 0x18, 0x1a, 0x19, 0x1a, 0x1a, 0x1a, 0x1b, 0x1a, 0x1c, 0x1a, 0x1d,
+            0x1a, 0x1e, 0x1a, 0x1f, 0x1a, 0x20, 0x1a, 0x21, 0x1a, 0x22, 0x1a, 0x23, 0x1a, 0x24,
+            0x1a, 0x25, 0x1a, 0x26, 0x1a, 0x30, 0x1a, 0x31, 0x1a,
+        ];
+        let parsed = GetObjectDescriptionListRequest::unpack_from_slice(&raw);
+        let expected = GetObjectDescriptionListRequest {
+            mailbox: MailboxHeader {
+                length: 122,
+                priority: Priority::Lowest,
+                mailbox_type: MailboxType::Coe,
+                counter: 7,
+                service: CoeService::SdoInformation,
+            },
+            sdo_info_header: SdoInfoHeader {
+                op_code: SdoInfoOpCode::GetObjectDescriptionListResponse,
+                incomplete: true,
+                fragments_left: 1,
+            },
+            list_type: ObjectDescriptionListQueryInner::All,
+        };
+        pretty_assertions::assert_eq!(parsed, Ok(expected));
+        let mut buf = [0u8; GetObjectDescriptionListRequest::PACKED_LEN];
+        pretty_assertions::assert_eq!(
+            expected.pack_to_slice(&mut buf),
+            Ok(&raw[..GetObjectDescriptionListRequest::PACKED_LEN])
+        );
+        // length is actually 57
+        let expected: [u16; (RAW_LEN - GetObjectDescriptionListRequest::PACKED_LEN) / 2] = [
+            0x1000, 0x1008, 0x1009, 0x100a, 0x1018, 0x1601, 0x1602, 0x1603, 0x1621, 0x1622, 0x1623,
+            0x1624, 0x1625, 0x1626, 0x1630, 0x1631, 0x1a00, 0x1a01, 0x1a02, 0x1a03, 0x1a04, 0x1a05,
+            0x1a06, 0x1a07, 0x1a08, 0x1a09, 0x1a0a, 0x1a0b, 0x1a0c, 0x1a0d, 0x1a0e, 0x1a0f, 0x1a10,
+            0x1a11, 0x1a12, 0x1a13, 0x1a14, 0x1a15, 0x1a16, 0x1a17, 0x1a18, 0x1a19, 0x1a1a, 0x1a1b,
+            0x1a1c, 0x1a1d, 0x1a1e, 0x1a1f, 0x1a20, 0x1a21, 0x1a22, 0x1a23, 0x1a24, 0x1a25, 0x1a26,
+            0x1a30, 0x1a31,
+        ];
+        let parsed = <_>::unpack_from_slice(&raw[GetObjectDescriptionListRequest::PACKED_LEN..]);
+        pretty_assertions::assert_eq!(parsed, Ok(expected));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -263,8 +263,12 @@ pub enum MailboxError {
         /// The subindex used in the operation.
         sub_index: u8,
     },
-    /// A SubDeviceve has no mailbox but requires one for a given action.
-    NoMailbox,
+    /// A SubDevice has no write (SubDevice IN) mailbox, but requires one
+    /// for a given action.
+    NoReadMailbox,
+    /// A SubDevice has no read (SubDevice OUT) mailbox, but requires one
+    /// for a given action.
+    NoWriteMailbox,
     /// The response to a mailbox action is invalid.
     SdoResponseInvalid {
         /// The address used in the operation.
@@ -298,7 +302,10 @@ impl core::fmt::Display for MailboxError {
                 "{:#06x}:{} returned data is too long",
                 address, sub_index
             ),
-            MailboxError::NoMailbox => f.write_str("device has no mailbox"),
+            MailboxError::NoReadMailbox => f.write_str("device has no read (subdevice in) mailbox"),
+            MailboxError::NoWriteMailbox => {
+                f.write_str("device has no write (subdevice out) mailbox")
+            }
             MailboxError::SdoResponseInvalid { address, sub_index } => write!(
                 f,
                 "{:#06x}:{} invalid response from device",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,10 @@ pub use maindevice::MainDevice;
 pub use maindevice_config::{MainDeviceConfig, RetryBehaviour};
 pub use pdu_loop::{PduLoop, PduRx, PduStorage, PduTx, ReceiveAction, SendableFrame};
 pub use register::{DcSupport, RegisterAddress};
-pub use subdevice::{DcSync, SubDevice, SubDeviceIdentity, SubDevicePdi, SubDeviceRef};
+pub use subdevice::{
+    DcSync, ObjectDescriptionListQuery, ObjectDescriptionListQueryCounts, SubDevice,
+    SubDeviceIdentity, SubDevicePdi, SubDeviceRef,
+};
 pub use subdevice_group::{GroupId, SubDeviceGroup, SubDeviceGroupHandle, TxRxResponse};
 pub use subdevice_state::SubDeviceState;
 pub use timer_factory::Timeouts;

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -790,7 +790,7 @@ where
     // TODO: make this generic w.r.t. SDO Info header type.
     async fn send_sdo_info_service(
         &self,
-        request: coe::services::GetObjectDescriptionListRequest,
+        request: coe::services::ObjectDescriptionListRequest,
     ) -> Result<Option<heapless::Vec<u8, { u16::MAX as usize * 2 }>>, Error> {
         let (read_mailbox, write_mailbox) = match self.coe_mailboxes().await {
             Ok((read, write)) => Ok((read, write)),
@@ -816,7 +816,7 @@ where
         loop {
             let mut response = self.coe_response(&read_mailbox).await?;
             let headers =
-                <coe::services::GetObjectDescriptionListResponse>::unpack_from_slice(&response)?;
+                <coe::services::ObjectDescriptionListResponse>::unpack_from_slice(&response)?;
             if headers.sdo_info_header.op_code
                 == coe::SdoInfoOpCode::GetObjectDescriptionListResponse
             {
@@ -825,7 +825,7 @@ where
                     "CoE Info, {} fragments left",
                     headers.sdo_info_header.fragments_left
                 );
-                response.trim_front(coe::services::GetObjectDescriptionListResponse::PACKED_LEN);
+                response.trim_front(coe::services::ObjectDescriptionListResponse::PACKED_LEN);
                 if !consumed_list_type {
                     response.trim_front(2); // skip over the list type
                     consumed_list_type = true;

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -1168,23 +1168,17 @@ where
             return Ok(None);
         };
 
-        let counts = <[u16; 5]>::unpack_from_slice(&response_payload).map_err(|_| {
-            fmt::error!(
-                "SDO Info Get OD List (type Object Quantities) data {:?} (len {})",
-                response_payload,
-                response_payload.len()
-            );
+        coe::ObjectDescriptionListQueryCounts::unpack_from_slice(&response_payload)
+            .map_err(|_| {
+                fmt::error!(
+                    "SDO Info Get OD List (type Object Quantities) data {:?} (len {})",
+                    response_payload,
+                    response_payload.len()
+                );
 
-            Error::Pdu(PduError::Decode)
-        })?;
-
-        Ok(Some(coe::ObjectDescriptionListQueryCounts {
-            all: counts[0],
-            rx_pdo_mappable: counts[1],
-            tx_pdo_mappable: counts[2],
-            stored_for_device_replacement: counts[3],
-            startup_parameters: counts[4],
-        }))
+                Error::Pdu(PduError::Decode)
+            })
+            .map(Some)
     }
 }
 


### PR DESCRIPTION
To add this endpoint, I added two methods
(`SubDeviceRef::{sdo_info_object_description_list, sdo_info_object_quantities}`) and two types
(`crate::{ObjectDescriptionListType, ObjectDescriptionListTypeCounts}`) to the public interface.  I also made a modest change to the `MailboxError` type.

The application I have in mind for this feature is to list out the object dictionaries of every device on the bus to improve surveying, troubleshoot, and plain ol' hacking.  You can see the beginning of this in `/examples/sdo-info.rs`.  Some devices on the bus won't have the necessary mailboxes to support this kind of probing.  To handle that gracefully, the log messages that were produced at the same site as the `NoMailbox` errors needed to be lofted to where that error was actually problematic.  But to preserve the existing logs, the errors needed to specify whether it was a read or write mailbox that was missing, so I created those errors.

In principal I could have implemented this endpoint with a single method and type, as that's what the standard describes, but I elected to make the list quantity request separate since that would enable a more expressive API for the user with less documentation lookups for which index is which list type.

I plan to expand the `sdo-info` example with more SDO Info protocols in the coming weeks.