### PR TITLE
Read the CoE abort code when there is an SDO abort

### DIFF
--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -742,7 +742,9 @@ where
                 error_register: decoded.error_register,
             }))
         } else if headers.command == CoeCommand::Abort {
-            let code = CoeAbortCode::Incompatible;
+            // ETG 1000.6 §5.6.2.7.1 Table 40
+            response.trim_front(HeadersRaw::PACKED_LEN);
+            let code = CoeAbortCode::unpack_from_slice(&response)?;
 
             fmt::error!(
                 "Mailbox error for SubDevice {:#06x} (supports complete access: {}): {}",


### PR DESCRIPTION
I tested this by attempting to read from 0xffff:0 on a device that doesn't use that address.  It threw "0x06090011: Subindex does not exist" as expected.