### PR TITLE
fix: read the AL status code

### DIFF
--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -1203,7 +1203,7 @@ impl<'maindevice, S> SubDeviceRef<'maindevice, S> {
 
         if response.error {
             let error = self
-                .read(RegisterAddress::AlStatus)
+                .read(RegisterAddress::AlStatusCode)
                 .receive::<AlStatusCode>(self.maindevice)
                 .await?;
 


### PR DESCRIPTION
When the slave device AL status register error bit is 1, the 0x0134 register should be read