### PR TITLE
Add first-class PDO discovery and manipulation

### DIFF
--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -1,6 +1,7 @@
 //! SubDevice Information Interface (SII).
 
 use crate::{
+    base_data_types::PrimitiveDataType,
     coe::SdoExpedited,
     sync_manager_channel::{self, Direction, OperationMode},
 };
@@ -566,7 +567,7 @@ pub enum SyncManagerType {
 impl SdoExpedited for SyncManagerType {}
 
 /// Defined in ETG2010 Table 14 – Structure Category TXPDO and RXPDO for each PDO
-#[derive(Debug, Copy, Clone, PartialEq, ethercrab_wire::EtherCrabWireRead)]
+#[derive(Debug, Clone, PartialEq, ethercrab_wire::EtherCrabWireRead)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[wire(bytes = 8)]
 pub struct Pdo {
@@ -583,12 +584,9 @@ pub struct Pdo {
     // pub(crate) name_string_idx: u8,
     // #[wire(bytes = 2)]
     // pub(crate) flags: PdoFlags,
-
-    // NOTE: Field is only used to sum up `bit_len`, so we don't need to read or store it.
-    // Definition is left here in case we need it later.
-    // // NOTE: This field is skipped during parsing from the wire and is populated later.
-    // #[wire(skip)]
-    // pub(crate) entries: heapless::Vec<PdoEntry, 16>,
+    // NOTE: This field is skipped during parsing from the wire and is populated later.
+    #[wire(skip)]
+    pub entries: heapless::Vec<PdoEntry, 16>,
 
     // NOTE: This field is skipped during parsing from the wire and is populated from all the
     // `PdoEntry`s later.
@@ -626,19 +624,19 @@ pub struct Pdo {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[wire(bytes = 8)]
 pub struct PdoEntry {
-    // #[wire(bytes = 2)]
-    // pub(crate) index: u16,
-    // #[wire(bytes = 1)]
-    // pub(crate) sub_index: u8,
-    // #[wire(bytes = 1)]
-    // pub(crate) name_string_idx: u8,
-    // // See page 103 of ETG2000
-    // #[wire(bytes = 1)]
-    // pub(crate) data_type: PrimitiveDataType,
-    #[wire(bytes = 1, pre_skip_bytes = 5, post_skip_bytes = 2)]
+    #[wire(bytes = 2)]
+    pub(crate) index: u16,
+    #[wire(bytes = 1)]
+    pub(crate) sub_index: u8,
+    #[wire(bytes = 1)]
+    pub(crate) name_string_idx: u8,
+    // See page 103 of ETG2000
+    #[wire(bytes = 1)]
+    pub(crate) data_type: PrimitiveDataType,
+    #[wire(bytes = 1)]
     pub(crate) data_length_bits: u8,
-    // #[wire(bytes = 2)]
-    // pub(crate) flags: u16,
+    #[wire(bytes = 2)]
+    pub(crate) flags: u16,
 }
 
 // impl core::fmt::Debug for PdoEntry {

--- a/src/pdi.rs
+++ b/src/pdi.rs
@@ -103,6 +103,9 @@ impl core::fmt::Display for PdiSegment {
 //     }
 // }
 
+/// Type alias for a mapping of PDOs to their ranges in the PDI (relative to the start of SM FMMU)
+pub type PdoMapping = heapless::FnvIndexMap<(u16, u8), Range<usize>, 32>;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/subdevice/configuration.rs
+++ b/src/subdevice/configuration.rs
@@ -1,4 +1,4 @@
-use super::{SubDevice, SubDeviceRef};
+use super::{SubDevice, SubDeviceRef, types::PdoMappings};
 use crate::{
     coe::{SdoExpedited, SubIndex},
     eeprom::types::{
@@ -10,7 +10,7 @@ use crate::{
     fmt,
     pdi::{PdiOffset, PdiSegment},
     register::RegisterAddress,
-    subdevice::types::{Mailbox, MailboxConfig},
+    subdevice::types::{Mailbox, MailboxConfig, PdoMapping},
     subdevice_state::SubDeviceState,
     sync_manager_channel::{Enable, SM_BASE_ADDRESS, SM_TYPE_ADDRESS, Status, SyncManagerChannel},
 };
@@ -138,7 +138,7 @@ where
             has_coe
         );
 
-        let range = if has_coe {
+        let (range, pdos) = if has_coe {
             self.configure_pdos_coe(&sync_managers, &fmmu_usage, direction, &mut global_offset)
                 .await?
         } else {
@@ -152,12 +152,14 @@ where
                     bytes: (range.bytes.start - group_start_address as usize)
                         ..(range.bytes.end - group_start_address as usize),
                 };
+                self.state.config.io.tx_pdos = pdos;
             }
             PdoDirection::MasterWrite => {
                 self.state.config.io.output = PdiSegment {
                     bytes: (range.bytes.start - group_start_address as usize)
                         ..(range.bytes.end - group_start_address as usize),
                 };
+                self.state.config.io.rx_pdos = pdos;
             }
         };
 
@@ -316,7 +318,7 @@ where
         fmmu_usage: &[FmmuUsage],
         direction: PdoDirection,
         global_offset: &mut PdiOffset,
-    ) -> Result<PdiSegment, Error> {
+    ) -> Result<(PdiSegment, PdoMappings), Error> {
         if !self.state.config.mailbox.has_coe {
             fmt::warn!("Invariant: attempting to configure PDOs from COE with no SOE support");
         }
@@ -334,6 +336,7 @@ where
 
         let start_offset = *global_offset;
         // let mut total_bit_len = 0;
+        let mut pdo_mappings = PdoMappings::new();
 
         for (sync_manager_index, (sm_type, sync_manager)) in self
             .state
@@ -415,6 +418,21 @@ where
                         mapping_bit_len,
                     );
 
+                    pdo_mappings
+                        .push(PdoMapping {
+                            index,
+                            sub_index,
+                            bit_len: mapping_bit_len,
+                            bit_offset: sm_bit_len,
+                        })
+                        .map_err(|_| {
+                            fmt::error!(
+                                "Too many PDO entries for PDO, max {}",
+                                pdo_mappings.capacity()
+                            );
+                            Error::Capacity(Item::PdoEntry)
+                        })?;
+
                     sm_bit_len += u16::from(mapping_bit_len);
                 }
             }
@@ -451,10 +469,13 @@ where
             // total_bit_len += sm_bit_len;
         }
 
-        Ok(PdiSegment {
-            // bit_len: total_bit_len.into(),
-            bytes: start_offset.up_to(*global_offset),
-        })
+        Ok((
+            PdiSegment {
+                // bit_len: total_bit_len.into(),
+                bytes: start_offset.up_to(*global_offset),
+            },
+            pdo_mappings,
+        ))
     }
 
     async fn write_fmmu_config(
@@ -515,7 +536,7 @@ where
         sync_managers: &[SyncManager],
         direction: PdoDirection,
         offset: &mut PdiOffset,
-    ) -> Result<PdiSegment, Error> {
+    ) -> Result<(PdiSegment, PdoMappings), Error> {
         let eeprom = self.eeprom();
 
         let pdos = match direction {
@@ -539,6 +560,7 @@ where
 
         let start_offset = *offset;
         // let mut total_bit_len = 0;
+        let mut pdo_mappings = PdoMappings::new();
 
         let (sm_type, _fmmu_type) = direction.filter_terms();
 
@@ -549,11 +571,28 @@ where
         {
             let sync_manager_index = sync_manager_index as u8;
 
-            let bit_len = pdos
+            let mut bit_len = 0u16;
+            for pdo_entry in pdos
                 .iter()
                 .filter(|pdo| pdo.sync_manager == sync_manager_index)
-                .map(|pdo| pdo.bit_len)
-                .sum();
+                .flat_map(|pdo| pdo.entries.iter())
+            {
+                pdo_mappings
+                    .push(PdoMapping {
+                        index: pdo_entry.index,
+                        sub_index: pdo_entry.sub_index,
+                        bit_len: pdo_entry.data_length_bits,
+                        bit_offset: bit_len,
+                    })
+                    .map_err(|_| {
+                        fmt::error!(
+                            "Too many PDO entries for PDO, max {}",
+                            pdo_mappings.capacity()
+                        );
+                        Error::Capacity(Item::PdoEntry)
+                    })?;
+                bit_len += u16::from(pdo_entry.data_length_bits);
+            }
 
             // total_bit_len += bit_len;
 
@@ -587,10 +626,13 @@ where
             .await?;
         }
 
-        Ok(PdiSegment {
-            // bit_len: total_bit_len.into(),
-            bytes: start_offset.up_to(*offset),
-        })
+        Ok((
+            PdiSegment {
+                // bit_len: total_bit_len.into(),
+                bytes: start_offset.up_to(*offset),
+            },
+            pdo_mappings,
+        ))
     }
 }
 

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -397,7 +397,8 @@ impl SubDevice {
         self.dc_support
     }
 
-    pub(crate) fn io_segments(&self) -> &IoRanges {
+    /// Get information about the PDI segments including PDO mappings
+    pub fn io_segments(&self) -> &IoRanges {
         &self.config.io
     }
 

--- a/src/subdevice/pdi.rs
+++ b/src/subdevice/pdi.rs
@@ -234,6 +234,8 @@ mod tests {
                 bytes: 2..4,
                 // bit_len: 16,
             },
+            rx_pdos: Default::default(),
+            tx_pdos: Default::default(),
         };
 
         const LEN: usize = 64;

--- a/src/subdevice/types.rs
+++ b/src/subdevice/types.rs
@@ -1,6 +1,6 @@
 use crate::{
     eeprom::types::{MailboxProtocols, SyncManagerType},
-    pdi::PdiSegment,
+    pdi::{PdiSegment, PdoMapping},
 };
 use core::fmt::{self, Debug};
 
@@ -75,15 +75,6 @@ pub struct Mailbox {
 pub struct IoRanges {
     pub input: PdiSegment,
     pub output: PdiSegment,
-    pub tx_pdos: PdoMappings,
-    pub rx_pdos: PdoMappings,
+    pub tx_pdos: PdoMapping,
+    pub rx_pdos: PdoMapping,
 }
-
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct PdoMapping {
-    pub index: u16,
-    pub sub_index: u8,
-    pub bit_len: u8,
-    pub bit_offset: u16,
-}
-pub type PdoMappings = heapless::Vec<PdoMapping, 64>;

--- a/src/subdevice/types.rs
+++ b/src/subdevice/types.rs
@@ -2,7 +2,10 @@ use crate::{
     eeprom::types::{MailboxProtocols, SyncManagerType},
     pdi::PdiSegment,
 };
-use core::fmt::{self, Debug};
+use core::{
+    fmt::{self, Debug},
+    ops::Range,
+};
 
 /// SubDevice identity information (vendor ID, product ID, etc).
 #[derive(Default, Copy, Clone, PartialEq, ethercrab_wire::EtherCrabWireRead)]
@@ -75,4 +78,15 @@ pub struct Mailbox {
 pub struct IoRanges {
     pub input: PdiSegment,
     pub output: PdiSegment,
+    pub tx_pdos: PdoMappings,
+    pub rx_pdos: PdoMappings,
 }
+
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct PdoMapping {
+    pub index: u16,
+    pub sub_index: u8,
+    pub bit_len: u8,
+    pub bit_offset: u16,
+}
+pub type PdoMappings = heapless::Vec<PdoMapping, 64>;

--- a/src/subdevice/types.rs
+++ b/src/subdevice/types.rs
@@ -2,10 +2,7 @@ use crate::{
     eeprom::types::{MailboxProtocols, SyncManagerType},
     pdi::PdiSegment,
 };
-use core::{
-    fmt::{self, Debug},
-    ops::Range,
-};
+use core::fmt::{self, Debug};
 
 /// SubDevice identity information (vendor ID, product ID, etc).
 #[derive(Default, Copy, Clone, PartialEq, ethercrab_wire::EtherCrabWireRead)]

--- a/src/subdevice_group/mod.rs
+++ b/src/subdevice_group/mod.rs
@@ -803,6 +803,7 @@ where
         let IoRanges {
             input: input_range,
             output: output_range,
+            ..
         } = &io_ranges;
 
         fmt::trace!(


### PR DESCRIPTION
Thanks again for this awesome crate!

When learning ethercrab (and ethercat), it was difficult and unclear to understand exactly how PDOs are managed, how to access them, and specifically the byte mappings to the PDI input/output slices. Not only this, but the ergonomics of dealing with raw byte slices are poor and brittle. 

When digging into the crate, I realized that we already have all the information we need to provide a richer PDO interface, through the sm bit length discovery we conduct during init. 

This PR aims to provide a clean and easy way to interact with PDOs. It does this by:
* collecting discovered PDOs from EEPROM/CoE into a map stored in the state struct
* simplifying `pdi.rs` by delegating `PdiIoRawWriteGuard` to `PdiWriteGuard` (ditto for read) and simplifying ownership
* adding `fn pdo_raw` on `PdiWriteGuard` (and read) which produces a slice based on PDO mappings

I believe this is the first step to richer object dictionary support and flexible device support. My usecase here is connecting to varous Ds402 and having them work out of the box (provided their default configurations provide the required PDO mappings) without needing to know their PDI byte mappings during compile time.

I'd love to hear your thoughts on this design.

The largest challenge I am running into: stack space. Currently, `heapless::FnvIndexMap<(u16, u8), Range<usize>, 32>;` is `904` bytes on a macbook pro. This, multiplied by two, crashes the stack if you have many devices enabled.
* dropping `Range<u16>` reduces to 456 bytes, as our PDI will never be that huge, but then the slice accessors become more messy (acceptable)
* switching to `LinearMap` reduces to 264 bytes, which is better, but has a runtime cost

Implementing both these approaches still overflow the stack in some instances.

Perhaps the correct solution is to move PDI mapping config into static storage along with the PDI itself, though I don't really know how to do this cleanly. Any suggestions?

Todo:

- [ ] Docs
  - [ ] Pdo mapping docstring examples
  - [ ] Use in examples
- [ ] Add `pdo_read<T>` and `pdo_write<T>` non-raw methods to `PdiWriteGuard`
- [ ] Add `all_pdos` which returns a map of all mapped PDOs and their corresponding byte slices?
- [ ] Verify changes to pdi.rs don't violate memory/sync safety
- [ ] Fix large stack usage