### PR TITLE
feat: allow passing group initial state

### DIFF
--- a/src/maindevice.rs
+++ b/src/maindevice.rs
@@ -212,16 +212,12 @@ impl<'sto> MainDevice<'sto> {
     pub async fn init<const MAX_SUBDEVICES: usize, G>(
         &self,
         now: impl Fn() -> u64 + Copy,
+        groups: G,
         mut group_filter: impl for<'g> FnMut(
             &'g G,
             &SubDevice,
         ) -> Result<&'g dyn SubDeviceGroupHandle, Error>,
-    ) -> Result<G, Error>
-    where
-        G: Default,
-    {
-        let groups = G::default();
-
+    ) -> Result<G, Error> {
         // Each SubDevice increments working counter, so we can use it as a total count of
         // SubDevices
         let num_subdevices = self.count_subdevices().await?;
@@ -398,7 +394,7 @@ impl<'sto> MainDevice<'sto> {
         &self,
         now: impl Fn() -> u64 + Copy,
     ) -> Result<SubDeviceGroup<MAX_SUBDEVICES, MAX_PDI, subdevice_group::PreOp>, Error> {
-        self.init::<MAX_SUBDEVICES, _>(now, |group, _subdevice| Ok(group))
+        self.init::<MAX_SUBDEVICES, _>(now, Default::default(), |group, _subdevice| Ok(group))
             .await
     }
 


### PR DESCRIPTION
In my application, I have various subdevices and their related groups loaded at runtime. This means I have an unknown number of groups, for which I have a device ID -> group mapping that is used to sort the subdevices into groups.

This means the best container for my usecase is some dynamic object like `IndexMap<String, SubDeviceGroup<MAX_SUBDEVICES, PDI_LEN>>` or `Vec<(String, SubDeviceGroup<MAX_SUBDEVICES, PDI_LEN>)>`.

The issue with the current ethercrab api is that I want to be able to use `push_back` or `insert` on my container of groups to  initialize a group when the first device in the group is discovered. 

However, the `groups` object passed by `groups_filter` is non-mut, so those mut commands don't work. Making it `&mut` is a non-starter as rust rightfully complains that mutating the group container invalidates any previously yielded group references. 

Instead, the best approach is to pre-allocate the expected number of elements in the group container, then pass it to the init function which will populate the "slots". 

This means removing the magic default() groups container initialization.

As an aside, this feels like less type magic, as it is confusing in the current api where the groups object comes from (implicitly default). Now, we can pass it directly which feels more like the api to `Iterator::fold`. 