### PR TITLE
Make `DefaultLock` pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ A pure Rust EtherCAT MainDevice supporting std and no_std environments.
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- [#366](https://github.com/ethercrab-rs/ethercrab/pull/366) Publicly expose `DefaultLock` so crate
+  consumers can use it.
+
 ### Changed
 
-- [#315](https://github.com/ethercrab-rs/ethercrab/pull/315) (@Dirreke) Add `io-uring` feature so
+- [#365](https://github.com/ethercrab-rs/ethercrab/pull/365) (@Dirreke) Add `io-uring` feature so
   `io_uring` can be disabled for Linux platforms that don't support it. Example `Cargo.toml`:
 
   ```toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,10 +212,19 @@ const MAINDEVICE_ADDR: EthernetAddress = EthernetAddress([0x10, 0x10, 0x10, 0x10
 /// Starting address for discovered subdevices.
 const BASE_SUBDEVICE_ADDRESS: u16 = 0x1000;
 
+/// The default lock provided by EtherCrab.
+///
+/// This is [`spin::Yield`] when the `std` feature is enabled. For non-`std` environments, it is
+/// [`spin::Spin`].
 #[cfg(feature = "std")]
-type DefaultLock = spin::rwlock::RwLock<(), spin::Yield>;
+pub type DefaultLock = spin::rwlock::RwLock<(), spin::Yield>;
+
+/// The default lock provided by EtherCrab.
+///
+/// This is [`spin::Yield`] when the `std` feature is enabled. For non-`std` environments, it is
+/// [`spin::Spin`].
 #[cfg(not(feature = "std"))]
-type DefaultLock = spin::rwlock::RwLock<(), spin::Spin>;
+pub type DefaultLock = spin::rwlock::RwLock<(), spin::Spin>;
 
 #[allow(unused)]
 fn test_logger() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,15 +214,15 @@ const BASE_SUBDEVICE_ADDRESS: u16 = 0x1000;
 
 /// The default lock provided by EtherCrab.
 ///
-/// This is [`spin::Yield`] when the `std` feature is enabled. For non-`std` environments, it is
-/// [`spin::Spin`].
+/// This is a [`spin::RwLock`] containing [`spin::Yield`] when the `std` feature is enabled. For
+/// non-`std` environments, it is [`spin::Spin`].
 #[cfg(feature = "std")]
 pub type DefaultLock = spin::rwlock::RwLock<(), spin::Yield>;
 
 /// The default lock provided by EtherCrab.
 ///
-/// This is [`spin::Yield`] when the `std` feature is enabled. For non-`std` environments, it is
-/// [`spin::Spin`].
+/// This is a [`spin::RwLock`] containing [`spin::Yield`] when the `std` feature is enabled. For
+/// non-`std` environments, it is [`spin::Spin`].
 #[cfg(not(feature = "std"))]
 pub type DefaultLock = spin::rwlock::RwLock<(), spin::Spin>;
 


### PR DESCRIPTION
So it can be used when e.g. storing a `SubDeviceGroup` in a struct.