### PR TITLE
Use `u16` to bump oversampling upper bound

### DIFF
--- a/examples/el3702-oversampling.rs
+++ b/examples/el3702-oversampling.rs
@@ -47,7 +47,7 @@ struct EL3702 {
 
 impl EL3702 {
     // Make sure this is the same value as the array lengths in the struct definition
-    const OVERSAMPLE_MUL: u8 = 25;
+    const OVERSAMPLE_MUL: u16 = 25;
 }
 
 fn main() -> Result<(), Error> {

--- a/src/subdevice/configuration.rs
+++ b/src/subdevice/configuration.rs
@@ -372,7 +372,7 @@ where
                     .find_map(|(pdo_id, mul)| if *pdo_id == pdo { Some(*mul) } else { None })
                     .unwrap_or(1);
 
-                let pdo_bit_len = pdo_bit_len * u16::from(oversampling);
+                let pdo_bit_len = pdo_bit_len * oversampling;
 
                 fmt::trace!(
                     "----> CoE: {:#06x} oversampling: {}, this PDO bit len {}",
@@ -530,7 +530,7 @@ where
                         })
                         .unwrap_or(1);
 
-                    let len = pdo.bit_len * u16::from(oversampling);
+                    let len = pdo.bit_len * oversampling;
 
                     fmt::trace!(
                         "EEPROM: {:#06x} oversampling: {}, this PDO bit len {}",

--- a/src/subdevice/mod.rs
+++ b/src/subdevice/mod.rs
@@ -86,7 +86,8 @@ pub struct SubDevice {
     /// DC config.
     pub(crate) dc_sync: DcSync,
 
-    pub(crate) oversampling_config: &'static [(u16, u8)],
+    /// Oversampling config, a list of tuples of `(PDO, oversampling multipler)`.
+    pub(crate) oversampling_config: &'static [(u16, u16)],
 }
 
 // Only required for tests, also doesn't make much sense - consumers of EtherCrab should be
@@ -249,7 +250,7 @@ impl SubDevice {
     ///
     /// This is a temporary(ish) solution to configure oversampling until a better one is found to
     /// configure SubDevices from ESI files, etc.
-    pub fn set_oversampling(&mut self, oversampling_config: &'static [(u16, u8)]) {
+    pub fn set_oversampling(&mut self, oversampling_config: &'static [(u16, u16)]) {
         self.oversampling_config = oversampling_config
     }
 

--- a/src/subdevice_group/mod.rs
+++ b/src/subdevice_group/mod.rs
@@ -458,7 +458,7 @@ where
                 .await?;
 
             let flags = if let DcSync::Sync01 { sync1_period } = subdevice.dc_sync() {
-                let sync1_period = u64::from(u32::try_from(sync1_period.as_nanos())?);
+                let sync1_period = u64::try_from(sync1_period.as_nanos())?;
 
                 subdevice
                     .write(RegisterAddress::DcSync1CycleTime)


### PR DESCRIPTION
The current `u8` config item is too restrictive for fast SubDevices, e.g. those sampling at 1KHz.