### PR TITLE
Derive defmt::Format for PdoType

### DIFF
--- a/src/eeprom/types.rs
+++ b/src/eeprom/types.rs
@@ -258,6 +258,7 @@ pub enum CategoryType {
 }
 
 /// The type of PDO to search for.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone)]
 pub enum PdoType {
     /// SubDevice send, MainDevice receive.


### PR DESCRIPTION
A blank project using embassy and `ethercrab = { version = "0.7.1", default-features = false, features = ["defmt"] }` in Cargo.toml needs this small fix in order to compile.