### PR TITLE
Move criterion to dev-dependencies in ethercrab-wire-derive

### DIFF
--- a/ethercrab-wire-derive/Cargo.toml
+++ b/ethercrab-wire-derive/Cargo.toml
@@ -18,12 +18,12 @@ proc-macro = true
 path = "src/lib.rs"
 
 [dependencies]
-criterion = { version = "0.5.1", default-features = false }
 proc-macro2 = "1.0.73"
 quote = "1.0.34"
 syn = { version = "2.0.44", features = ["full"] }
 
 [dev-dependencies]
+criterion = { version = "0.5.1", default-features = false }
 trybuild = "1.0.86"
 ethercrab-wire = { path = "../ethercrab-wire" }
 syn = { version = "2.0.44", features = ["full", "extra-traits"] }


### PR DESCRIPTION
It's already in dev-dependencies in the main Cargo.toml, but not in ethercrab-wire-derive for some reason.
Trims the dependency tree quite a bit.